### PR TITLE
feat: ship shared/_modal + template-backed copyable previews

### DIFF
--- a/docs/design/2026-06-02-shared-modal-and-copyable-previews-design.md
+++ b/docs/design/2026-06-02-shared-modal-and-copyable-previews-design.md
@@ -1,0 +1,62 @@
+# Design: ship shared/_modal + template-backed copyable previews
+
+**Date:** 2026-06-02
+**Status:** Proposed (design approved in brainstorming; pending written-spec review)
+**Repo:** modelrails_ui (gem)
+**Context:** the reference app (modelrails_base) converted its Lookbook previews to template-backed so the Source tab shows copyable view-native ERB. This milestone brings that to the gem — so every downstream app's generated catalog teaches paste-ready artifacts.
+
+## Why
+
+A Lookbook scenario authored as a Ruby method shows that method in the Source tab — not the ERB a developer pastes into a view. Template-backed previews fix this: the scenario lives in a sibling `.html.erb` file, so Source shows the copyable call.
+
+- For five components (button, input, textarea, file_input, avatar) the conversion is **purely cosmetic**: their primitive call (`ui :input`, `ui :avatar`, …) is already clean, paste-ready ERB. We just move the call from a Ruby method into a `.html.erb`.
+- The **dialog is the exception**. Its primitive is slot-Ruby (`ui :dialog … do |d| d.with_trigger { tag.button(…) }; "body" end`) — un-pasteable even as ERB. To give it a clean artifact, the gem must **ship `app/views/shared/_modal.html.erb`** (a thin wrapper over the gem's own `UI::DialogComponent`), which it does not currently ship. Then the dialog scenario teaches `render "shared/modal", trigger:`.
+
+## Scope
+
+**In:** ship `shared/_modal` (with the optional `trigger:` mode); convert all six component previews to template-backed.
+
+**Out (deliberately):** a form builder, `avatar_for`, or any model-aware helper. Those are app-specific ergonomic sugar — a downstream app has its own form builder and its own (or no) user model. The gem's primitives are already clean copyable artifacts, so no `User`-model or form-builder assumption may leak into the gem.
+
+## Design
+
+### 1. Ship `shared/_modal` via `add dialog`
+
+`shared/_modal` is the dialog's view adapter — it references `UI::DialogComponent`, which `rails g modelrails_ui:add dialog` already emits. So it ships **with the dialog**, not at install (no dangling reference).
+
+- **New template:** `lib/generators/modelrails_ui/add/templates/dialog/_modal.html.erb` — the partial, carrying the reference app's PR #219 contract: optional `trigger:`/`trigger_class:`. With `trigger:` → render `UI::DialogComponent.new(…, wrapper: true)` + the `with_trigger` slot (complete wrapper + trigger + dialog). Without `trigger:` → `wrapper: false`, `body_id: "modal-body"` (the Turbo Stream append default).
+- **Generator change (the one logic change):** `add_generator.rb#copy_template_file` currently routes `*.rb.tt` → `app/components/ui/`, `*_controller.js` → `app/javascript/controllers/`, and `*.html.erb` → `app/components/ui/`. Add a rule: a **leading-underscore partial** (`_*.html.erb`) routes to `app/views/shared/<file>`. (Leading underscore distinguishes a Rails view partial from a component sidecar template.)
+- **Idempotency:** the app may already have a customized `shared/_modal` (the reference app does, from PR #219). Rely on the `add` generator's existing copy behavior (skip-if-exists / conflict prompt) so regeneration never clobbers a downstream customization. Confirm exact behavior in the plan.
+
+### 2. Convert all six previews to template-backed
+
+- Each `previews/ui/<component>_component_preview.rb`: scenario methods go **empty** (`def default; end`); class doc-comment, per-method comments, and `@label` annotations are preserved.
+- New sibling directory `previews/ui/<component>_component_preview/<scenario>.html.erb` per scenario, containing the copyable ERB.
+- **Five primitives:** the template is the existing `ui :x, …` call wrapped in `<%= %>` — moved verbatim.
+- **Dialog (re-authored, not ported):** scenarios use `render "shared/modal", trigger:` with **gem-portable content only** — plain HTML and/or `ui :input` inside the modal. **Not** `f.text_field` (app builder) or `shared/confirm_dialog` (app partial). A lean, portable set: e.g. `default` (trigger + body + footer buttons), `large` (`size: :lg`), `dont_no_title`.
+- **Lookbook generator: no change.** It copies the `previews/` tree with Thor `directory()`, which is recursive — the new sibling `.html.erb` dirs are picked up automatically.
+- **Interactive `playground` scenarios** (if any gem preview has one with `@param` controls) stay **inline** — they're live explorers, not copyable snippets. The plan verifies which gem previews have them.
+
+### 3. Testing
+
+The gem uses Minitest (`test/`). Mirror existing generator-test style.
+
+- Assert `add dialog` emits `app/views/shared/_modal.html.erb`, and that it declares the `trigger:` local (and the surface/complete branches).
+- Assert each preview is template-backed: the `.rb` scenario methods are empty and a sibling `<scenario>.html.erb` exists for each.
+- Assert the dialog scenario templates reference `shared/modal` and contain **no** `f.text_field` / `shared/confirm_dialog` (portability guard).
+- Where feasible, run the generators into a tmp app and assert the emitted file tree; otherwise assert on template-file structure.
+
+## Open details for the plan
+
+- Exact `copy_template_file` routing rule and how it composes with the existing extension dispatch.
+- The `add` generator's overwrite/skip behavior for an existing `shared/_modal` (idempotency guarantee).
+- Which gem previews currently have a `playground` scenario (keep inline).
+- The final gem dialog scenario set (keep portable + minimal).
+
+## Out of scope / relationship to the app
+
+This milestone changes only the gem. The reference app (modelrails_base) already has the richer, app-specific previews (`in_a_form` via the form builder, `for_a_user` via `avatar_for`) from PR #220 — those stay app-authored. After a gem release, an app could regenerate the gem-provided previews, but its app-specific scenarios remain its own. A gem release/tag is the owner's call.
+
+## Toolchain
+
+Gem-repo `mise.toml` is untrusted, so gem commands run as `PATH="/Users/dschmura/.local/share/mise/installs/ruby/4.0.4/bin:$PATH" bundle exec …`.

--- a/docs/design/2026-06-02-shared-modal-and-copyable-previews-plan.md
+++ b/docs/design/2026-06-02-shared-modal-and-copyable-previews-plan.md
@@ -1,0 +1,433 @@
+# Ship shared/_modal + template-backed previews — Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Make the gem emit copyable, paste-ready Lookbook previews — by shipping `app/views/shared/_modal.html.erb` (via `add dialog`) and converting all six component previews to template-backed scenarios.
+
+**Architecture:** (1) A one-branch routing rule in the `add` generator sends leading-underscore `.html.erb` partials to `app/views/shared/`. (2) The dialog's `add` template gains `_modal.html.erb` (the reference app's `trigger:`-mode partial). (3) Each Lookbook preview's scenario methods go empty and gain sibling `<scenario>.html.erb` files; Thor's recursive `directory()` copy needs no change. The five primitive previews move their `ui :x` call verbatim; the dialog is re-authored to `render "shared/modal", trigger:` with gem-portable content only.
+
+**Tech Stack:** Ruby, Rails generators (Thor), ViewComponent/Lookbook previews, Minitest.
+
+**Repo/branch:** `/Users/dschmura/Documents/code/modelrails_ui`, branch `feat/shared-modal-and-copyable-previews`.
+
+**Design doc:** `docs/design/2026-06-02-shared-modal-and-copyable-previews-design.md`
+
+**TOOLCHAIN (critical):** the gem's `mise.toml` is untrusted, so every ruby/rake command MUST be prefixed with `PATH="/Users/dschmura/.local/share/mise/installs/ruby/4.0.4/bin:$PATH"` — do NOT use `mise exec`. Run all commands from the gem repo root. Full suite: `PATH="/Users/dschmura/.local/share/mise/installs/ruby/4.0.4/bin:$PATH" bundle exec rake test`. Single file: `… bundle exec ruby -Itest test/<file>.rb`.
+
+---
+
+## File structure
+
+- Modify: `lib/generators/modelrails_ui/add/add_generator.rb` — add `html_erb_destination` routing helper.
+- Create: `lib/generators/modelrails_ui/add/templates/dialog/_modal.html.erb` — the shipped partial.
+- Modify: `lib/generators/modelrails_ui/lookbook/templates/previews/ui/{button,input,textarea,file_input,avatar,dialog}_component_preview.rb` — empty scenario methods (keep doc-comments/@label/playground).
+- Create: `lib/generators/modelrails_ui/lookbook/templates/previews/ui/<component>_component_preview/<scenario>.html.erb` — one per non-playground scenario.
+- Create test: `test/test_add_generator_partial_routing.rb`, `test/test_shared_modal_template.rb`, `test/test_lookbook_previews_template_backed.rb`.
+
+---
+
+### Task 1: Route leading-underscore partials to `app/views/shared/`
+
+**Files:**
+- Modify: `lib/generators/modelrails_ui/add/add_generator.rb:78-89`
+- Test: `test/test_add_generator_partial_routing.rb` (create)
+
+- [ ] **Step 1: Write the failing test**
+
+```ruby
+# test/test_add_generator_partial_routing.rb
+# frozen_string_literal: true
+
+require "test_helper"
+
+class TestAddGeneratorPartialRouting < Minitest::Test
+  # allocate skips #initialize (which requires the components argument); the
+  # routing helper is pure and touches no instance state.
+  def destination_for(file)
+    ModelrailsUi::Generators::AddGenerator.allocate.send(:html_erb_destination, file)
+  end
+
+  def test_leading_underscore_partial_routes_to_app_views_shared
+    assert_equal "app/views/shared/_modal.html.erb", destination_for("_modal.html.erb")
+  end
+
+  def test_component_sidecar_template_routes_to_app_components_ui
+    assert_equal "app/components/ui/tabs_component.html.erb", destination_for("tabs_component.html.erb")
+  end
+end
+```
+
+- [ ] **Step 2: Run it to verify it fails**
+
+Run: `PATH="/Users/dschmura/.local/share/mise/installs/ruby/4.0.4/bin:$PATH" bundle exec ruby -Itest test/test_add_generator_partial_routing.rb`
+Expected: FAIL — `NoMethodError: undefined method 'html_erb_destination'`.
+
+- [ ] **Step 3: Implement the routing helper**
+
+In `lib/generators/modelrails_ui/add/add_generator.rb`, replace the `copy_template_file` method's `.html.erb` branch and add the helper (both private):
+
+```ruby
+      def copy_template_file(component, file)
+        source = "#{component}/#{file}"
+
+        case file
+        when /\.rb\.tt\z/
+          template source, "app/components/ui/#{file.delete_suffix(".tt")}"
+        when /\.html\.erb\z/
+          copy_file source, html_erb_destination(file)
+        when /_controller\.js\z/
+          copy_js_controller source, file.delete_suffix("_controller.js")
+        end
+      end
+
+      # A leading-underscore .html.erb is a Rails view partial (e.g. _modal) →
+      # app/views/shared/. Everything else is a component sidecar template →
+      # app/components/ui/.
+      def html_erb_destination(file)
+        file.start_with?("_") ? "app/views/shared/#{file}" : "app/components/ui/#{file}"
+      end
+```
+
+- [ ] **Step 4: Run it to verify it passes**
+
+Run: `PATH="/Users/dschmura/.local/share/mise/installs/ruby/4.0.4/bin:$PATH" bundle exec ruby -Itest test/test_add_generator_partial_routing.rb`
+Expected: `2 runs, 2 assertions, 0 failures`.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add lib/generators/modelrails_ui/add/add_generator.rb test/test_add_generator_partial_routing.rb
+git commit -m "feat(generator): route leading-underscore partials to app/views/shared/"
+```
+
+---
+
+### Task 2: Ship the `shared/_modal` partial via the dialog template
+
+**Files:**
+- Create: `lib/generators/modelrails_ui/add/templates/dialog/_modal.html.erb`
+- Test: `test/test_shared_modal_template.rb` (create)
+
+- [ ] **Step 1: Write the failing test**
+
+```ruby
+# test/test_shared_modal_template.rb
+# frozen_string_literal: true
+
+require "test_helper"
+
+class TestSharedModalTemplate < Minitest::Test
+  PATH = File.expand_path(
+    "../lib/generators/modelrails_ui/add/templates/dialog/_modal.html.erb", __dir__
+  )
+
+  def source
+    @source ||= File.read(PATH)
+  end
+
+  def test_partial_exists
+    assert_path_exists PATH, "dialog add-template should ship _modal.html.erb"
+  end
+
+  def test_declares_trigger_local_with_default
+    assert_includes source, "trigger: nil"
+    assert_includes source, 'trigger_class: "btn-secondary"'
+  end
+
+  def test_has_complete_and_surface_branches
+    assert_includes source, "if trigger.present?"
+    assert_includes source, "wrapper: true"          # complete mode
+    assert_includes source, "wrapper: false"         # surface mode
+    assert_includes source, 'body_id: "modal-body"'  # Turbo Stream contract preserved in surface mode
+    assert_includes source, "d.with_trigger"
+  end
+end
+```
+
+- [ ] **Step 2: Run it to verify it fails**
+
+Run: `PATH="/Users/dschmura/.local/share/mise/installs/ruby/4.0.4/bin:$PATH" bundle exec ruby -Itest test/test_shared_modal_template.rb`
+Expected: FAIL — file does not exist.
+
+- [ ] **Step 3: Create the partial**
+
+```erb
+<%# lib/generators/modelrails_ui/add/templates/dialog/_modal.html.erb %>
+<%# locals: (title:, id: nil, size: :md, description: nil, trigger: nil, trigger_class: "btn-secondary") -%>
+<%#
+  Thin adapter over UI::DialogComponent.
+
+  Surface-only (default, no trigger:): renders ONLY the <dialog> (wrapper: false).
+  Callers own the surrounding data-controller="modal" wrapper + trigger button.
+  body_id stays "modal-body" to preserve the Turbo Stream contract
+  (turbo_stream.append "modal-body").
+
+  Complete (pass trigger:): renders the data-controller="modal" wrapper + a trigger
+  button + the <dialog> as one copy-paste unit (wrapper: true). body_id uses the
+  component's unique default so multiple complete modals on a page don't collide.
+-%>
+<% if trigger.present? %>
+  <%= render UI::DialogComponent.new(
+        title: title, id: id, size: size, description: description, wrapper: true) do |d| %>
+    <% d.with_trigger do %>
+      <%= tag.button(trigger, type: "button", class: trigger_class) %>
+    <% end %>
+    <%= yield %>
+  <% end %>
+<% else %>
+  <%= render UI::DialogComponent.new(
+        title: title, id: id, size: size, description: description,
+        wrapper: false, body_id: "modal-body") do %><%= yield %><% end %>
+<% end %>
+```
+
+- [ ] **Step 4: Run it to verify it passes**
+
+Run: `PATH="/Users/dschmura/.local/share/mise/installs/ruby/4.0.4/bin:$PATH" bundle exec ruby -Itest test/test_shared_modal_template.rb`
+Expected: `3 runs, … 0 failures`.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add lib/generators/modelrails_ui/add/templates/dialog/_modal.html.erb test/test_shared_modal_template.rb
+git commit -m "feat(dialog): ship shared/_modal partial (trigger: mode) with the dialog"
+```
+
+---
+
+### Task 3: Convert the five primitive previews to template-backed
+
+A purely mechanical move: each scenario's `ui :x` call goes into a sibling `.html.erb`; the method body goes empty; doc-comments, `@label`, and `playground` stay.
+
+**Files (per component, in `lib/generators/modelrails_ui/lookbook/templates/previews/ui/`):**
+- Modify: `button_component_preview.rb`, `input_component_preview.rb`, `textarea_component_preview.rb`, `file_input_component_preview.rb`, `avatar_component_preview.rb`
+- Create: `<component>_component_preview/<scenario>.html.erb` per non-playground scenario
+- Test: `test/test_lookbook_previews_template_backed.rb` (create)
+
+- [ ] **Step 1: Write the failing test**
+
+```ruby
+# test/test_lookbook_previews_template_backed.rb
+# frozen_string_literal: true
+
+require "test_helper"
+
+class TestLookbookPreviewsTemplateBacked < Minitest::Test
+  PREVIEW_ROOT = File.expand_path(
+    "../lib/generators/modelrails_ui/lookbook/templates/previews/ui", __dir__
+  )
+
+  # component => scenario methods that must be template-backed (playground excluded)
+  PRIMITIVES = {
+    "button"     => %w[primary secondary danger text_interactive link dont_icon_only_without_label],
+    "input"      => %w[default required invalid dont_raw_input],
+    "textarea"   => %w[default invalid dont_raw_textarea],
+    "file_input" => %w[default images_only multiple dont_raw_file_input],
+    "avatar"     => %w[image initials custom_hue dont_interactive_no_label]
+  }.freeze
+
+  def preview_rb(component)
+    File.read(File.join(PREVIEW_ROOT, "#{component}_component_preview.rb"))
+  end
+
+  def test_each_primitive_scenario_has_a_sibling_template
+    PRIMITIVES.each do |component, scenarios|
+      scenarios.each do |scenario|
+        path = File.join(PREVIEW_ROOT, "#{component}_component_preview", "#{scenario}.html.erb")
+        assert_path_exists path, "missing sibling template #{path}"
+      end
+    end
+  end
+
+  def test_primitive_scenario_methods_are_empty
+    PRIMITIVES.each do |component, scenarios|
+      src = preview_rb(component)
+      scenarios.each do |scenario|
+        # an empty method: `def scenario; end` (no inline ui :x body)
+        assert_match(/def #{scenario}; end/, src, "#{component}##{scenario} should be empty")
+      end
+    end
+  end
+
+  def test_playground_stays_inline_where_present
+    %w[button avatar].each do |component|
+      assert_match(/def playground\(.*\)\n\s+ui /, preview_rb(component),
+        "#{component} playground should remain an inline explorer")
+    end
+  end
+end
+```
+
+- [ ] **Step 2: Run it to verify it fails**
+
+Run: `PATH="/Users/dschmura/.local/share/mise/installs/ruby/4.0.4/bin:$PATH" bundle exec ruby -Itest test/test_lookbook_previews_template_backed.rb`
+Expected: FAIL — sibling templates missing; methods still have bodies. (If the actual scenario lists differ from `PRIMITIVES`, READ the five `*_component_preview.rb` files and correct the constant before implementing — the test must reflect the real scenarios.)
+
+- [ ] **Step 3: Convert each primitive preview (repeat for all five)**
+
+For EACH of the five components, and EACH scenario method that is NOT `playground`:
+
+1. Create `<component>_component_preview/<scenario>.html.erb` whose entire content is the method's `ui :x …` call wrapped in `<%= … %>`. Worked example — `button` `primary` (was `def primary; ui :button, "Save changes", variant: :primary; end`):
+
+```erb
+<%# button_component_preview/primary.html.erb %>
+<%= ui :button, "Save changes", variant: :primary %>
+```
+
+2. Empty the method in the `.rb`, keeping its doc-comment and any `@label`:
+
+```ruby
+    # The default, high-emphasis action. Aim for one primary per view.
+    def primary; end
+```
+
+Apply verbatim-move for every scenario (e.g. `link` → `<%= ui :button, "Go home", href: "/", variant: :primary %>`; `dont_raw_input` → `<%= ui :input, type: "text", name: "demo_raw" %>`). Leave each preview's `include UIHelper`, class doc-comment, and `playground` method untouched.
+
+- [ ] **Step 4: Run it to verify it passes**
+
+Run: `PATH="/Users/dschmura/.local/share/mise/installs/ruby/4.0.4/bin:$PATH" bundle exec ruby -Itest test/test_lookbook_previews_template_backed.rb`
+Expected: all assertions pass.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add lib/generators/modelrails_ui/lookbook/templates/previews/ui/{button,input,textarea,file_input,avatar}_component_preview.rb \
+        lib/generators/modelrails_ui/lookbook/templates/previews/ui/{button,input,textarea,file_input,avatar}_component_preview \
+        test/test_lookbook_previews_template_backed.rb
+git commit -m "feat(previews): template-back the five primitive component previews"
+```
+
+---
+
+### Task 4: Re-author the dialog preview (template-backed, portable)
+
+The dialog scenarios become template-backed AND switch from `ui :dialog … with_trigger` slot-Ruby to `render "shared/modal", trigger:` — using only gem-portable content (plain HTML; no `f.text_field`, no `shared/confirm_dialog`).
+
+**Files:**
+- Modify: `lib/generators/modelrails_ui/lookbook/templates/previews/ui/dialog_component_preview.rb`
+- Create: `dialog_component_preview/{default,large,dont_no_title}.html.erb`
+- Test: extend `test/test_lookbook_previews_template_backed.rb`
+
+- [ ] **Step 1: Add the failing dialog assertions**
+
+Append to `test/test_lookbook_previews_template_backed.rb` (inside the class):
+
+```ruby
+  DIALOG_SCENARIOS = %w[default large dont_no_title].freeze
+
+  def dialog_template(scenario)
+    File.read(File.join(PREVIEW_ROOT, "dialog_component_preview", "#{scenario}.html.erb"))
+  end
+
+  def test_dialog_scenarios_are_template_backed
+    src = File.read(File.join(PREVIEW_ROOT, "dialog_component_preview.rb"))
+    DIALOG_SCENARIOS.each do |scenario|
+      assert_path_exists File.join(PREVIEW_ROOT, "dialog_component_preview", "#{scenario}.html.erb")
+      assert_match(/def #{scenario}; end/, src, "dialog##{scenario} should be empty")
+    end
+  end
+
+  def test_dialog_scenarios_teach_shared_modal_and_stay_portable
+    DIALOG_SCENARIOS.each do |scenario|
+      src = dialog_template(scenario)
+      assert_includes src, 'render "shared/modal"', "#{scenario} should teach the shared/modal partial"
+      # Portability guard: no app-only infrastructure may leak into the gem.
+      refute_includes src, "f.text_field", "#{scenario} must not use the app form builder"
+      refute_includes src, "shared/confirm_dialog", "#{scenario} must not use the app confirm partial"
+      refute_includes src, "avatar_for", "#{scenario} must not use the app avatar helper"
+    end
+  end
+```
+
+- [ ] **Step 2: Run to verify it fails**
+
+Run: `PATH="/Users/dschmura/.local/share/mise/installs/ruby/4.0.4/bin:$PATH" bundle exec ruby -Itest test/test_lookbook_previews_template_backed.rb`
+Expected: FAIL — dialog templates missing; methods still slot-Ruby.
+
+- [ ] **Step 3: Create the three dialog scenario templates**
+
+```erb
+<%# dialog_component_preview/default.html.erb %>
+<%= render "shared/modal",
+      title: "Confirm action",
+      description: "This action cannot be undone.",
+      trigger: "Open dialog",
+      trigger_class: "btn-primary" do %>
+  <p>Are you sure you want to proceed? All related data will be permanently removed.</p>
+<% end %>
+```
+
+```erb
+<%# dialog_component_preview/large.html.erb %>
+<%= render "shared/modal",
+      title: "Edit profile",
+      description: "Update your display name and preferences.",
+      size: :lg,
+      trigger: "Open large dialog",
+      trigger_class: "btn-secondary" do %>
+  <%= ui :input, type: "text", name: "display_name", placeholder: "Display name" %>
+<% end %>
+```
+
+```erb
+<%# dialog_component_preview/dont_no_title.html.erb %>
+<%# ✗ A vague title gives screen-reader users no context via aria-labelledby. %>
+<%= render "shared/modal", title: "Untitled", trigger: "Open", trigger_class: "btn-secondary" do %>
+  Body content.
+<% end %>
+```
+
+- [ ] **Step 4: Empty the dialog preview methods (keep doc-comments + @label)**
+
+In `dialog_component_preview.rb`, replace the three method bodies with empties, preserving the class doc-comment, each method's comment, and the `@label Don't · no title (breaks aria-labelledby)` annotation:
+
+```ruby
+    def default; end
+
+    def large; end
+
+    # @label Don't · no title (breaks aria-labelledby)
+    def dont_no_title; end
+```
+
+- [ ] **Step 5: Run to verify it passes**
+
+Run: `PATH="/Users/dschmura/.local/share/mise/installs/ruby/4.0.4/bin:$PATH" bundle exec ruby -Itest test/test_lookbook_previews_template_backed.rb`
+Expected: all pass.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add lib/generators/modelrails_ui/lookbook/templates/previews/ui/dialog_component_preview.rb \
+        lib/generators/modelrails_ui/lookbook/templates/previews/ui/dialog_component_preview \
+        test/test_lookbook_previews_template_backed.rb
+git commit -m "feat(previews): re-author dialog previews to teach render shared/modal (portable)"
+```
+
+---
+
+### Task 5: Full suite + integration check
+
+- [ ] **Step 1: Run the full gem test suite**
+
+Run: `PATH="/Users/dschmura/.local/share/mise/installs/ruby/4.0.4/bin:$PATH" bundle exec rake test`
+Expected: 0 failures, 0 errors. (Confirms the existing template-syntax / component tests still pass alongside the new ones.)
+
+- [ ] **Step 2: Integration check — regenerate into the reference app (manual, optional but recommended)**
+
+In a throwaway branch of modelrails_base, point its Gemfile at this local gem (`gem "modelrails_ui", path: "../modelrails_ui"`), run `bin/rails g modelrails_ui:add dialog` and `bin/rails g modelrails_ui:lookbook`, and confirm: `app/views/shared/_modal.html.erb` lands in the right place, `/lookbook` renders each component, and the Source tab shows the copyable ERB. Discard the throwaway branch afterward. (This is the only true render check; the gem's own suite is structural.)
+
+- [ ] **Step 3: Final commit (if any fixups)**
+
+```bash
+git add -A
+git commit -m "chore: tidy after shared/_modal + template-backed preview port"
+```
+
+---
+
+## Out of scope
+
+- Form-builder / `avatar_for` / model-aware helpers (app-specific; the gem's primitives are already clean).
+- A gem release/tag (owner's call).
+- Changing the `lookbook` generator (Thor `directory()` copies the new sibling dirs recursively).

--- a/lib/generators/modelrails_ui/add/add_generator.rb
+++ b/lib/generators/modelrails_ui/add/add_generator.rb
@@ -82,10 +82,17 @@ module ModelrailsUi
         when /\.rb\.tt\z/
           template source, "app/components/ui/#{file.delete_suffix(".tt")}"
         when /\.html\.erb\z/
-          copy_file source, "app/components/ui/#{file}"
+          copy_file source, html_erb_destination(file)
         when /_controller\.js\z/
           copy_js_controller source, file.delete_suffix("_controller.js")
         end
+      end
+
+      # A leading-underscore .html.erb is a Rails view partial (e.g. _modal) →
+      # app/views/shared/. Everything else is a component sidecar template →
+      # app/components/ui/.
+      def html_erb_destination(file)
+        file.start_with?("_") ? "app/views/shared/#{file}" : "app/components/ui/#{file}"
       end
 
       def copy_extra_stimulus(name)

--- a/lib/generators/modelrails_ui/add/templates/dialog/_modal.html.erb
+++ b/lib/generators/modelrails_ui/add/templates/dialog/_modal.html.erb
@@ -1,0 +1,26 @@
+<%# locals: (title:, id: nil, size: :md, description: nil, trigger: nil, trigger_class: "btn-secondary") -%>
+<%#
+  Thin adapter over UI::DialogComponent.
+
+  Surface-only (default, no trigger:): renders ONLY the <dialog> (wrapper: false).
+  Callers own the surrounding data-controller="modal" wrapper + trigger button.
+  body_id stays "modal-body" to preserve the Turbo Stream contract
+  (turbo_stream.append "modal-body").
+
+  Complete (pass trigger:): renders the data-controller="modal" wrapper + a trigger
+  button + the <dialog> as one copy-paste unit (wrapper: true). body_id uses the
+  component's unique default so multiple complete modals on a page don't collide.
+-%>
+<% if trigger.present? %>
+  <%= render UI::DialogComponent.new(
+        title: title, id: id, size: size, description: description, wrapper: true) do |d| %>
+    <% d.with_trigger do %>
+      <%= tag.button(trigger, type: "button", class: trigger_class) %>
+    <% end %>
+    <%= yield %>
+  <% end %>
+<% else %>
+  <%= render UI::DialogComponent.new(
+        title: title, id: id, size: size, description: description,
+        wrapper: false, body_id: "modal-body") do %><%= yield %><% end %>
+<% end %>

--- a/lib/generators/modelrails_ui/lookbook/templates/previews/ui/avatar_component_preview.rb
+++ b/lib/generators/modelrails_ui/lookbook/templates/previews/ui/avatar_component_preview.rb
@@ -31,15 +31,18 @@ module UI
     include UIHelper
 
     # Photo avatar: pass `src:` with an image URL. The element renders as `<img>`.
-    def image; end
+    def image
+    end
 
     # Initials avatar: pass `fallback:` with the initials string. Uses the default
     # interactive color token.
-    def initials; end
+    def initials
+    end
 
     # Custom hue: `hue:` accepts an OKLCH integer (0–360), tinting the background
     # with `--hue-initials`. Useful for workspace or org avatars.
-    def custom_hue; end
+    def custom_hue
+    end
 
     # Explore size and initials interactively.
     # @param size select [xs, sm, md, lg, xl]
@@ -55,6 +58,7 @@ module UI
     # `ui :avatar, src: url, size: :sm, aria_label: "Open Dave's profile"`.
     # For user avatars, prefer `avatar_for(user, size: :sm)` — it sets the label for you.
     # @label Don't · interactive avatar with no label
-    def dont_interactive_no_label; end
+    def dont_interactive_no_label
+    end
   end
 end

--- a/lib/generators/modelrails_ui/lookbook/templates/previews/ui/avatar_component_preview.rb
+++ b/lib/generators/modelrails_ui/lookbook/templates/previews/ui/avatar_component_preview.rb
@@ -31,21 +31,15 @@ module UI
     include UIHelper
 
     # Photo avatar: pass `src:` with an image URL. The element renders as `<img>`.
-    def image
-      ui :avatar, src: "https://i.pravatar.cc/128", size: :lg
-    end
+    def image; end
 
     # Initials avatar: pass `fallback:` with the initials string. Uses the default
     # interactive color token.
-    def initials
-      ui :avatar, fallback: "JD", size: :md
-    end
+    def initials; end
 
     # Custom hue: `hue:` accepts an OKLCH integer (0–360), tinting the background
     # with `--hue-initials`. Useful for workspace or org avatars.
-    def custom_hue
-      ui :avatar, fallback: "JD", hue: 280
-    end
+    def custom_hue; end
 
     # Explore size and initials interactively.
     # @param size select [xs, sm, md, lg, xl]
@@ -61,8 +55,6 @@ module UI
     # `ui :avatar, src: url, size: :sm, aria_label: "Open Dave's profile"`.
     # For user avatars, prefer `avatar_for(user, size: :sm)` — it sets the label for you.
     # @label Don't · interactive avatar with no label
-    def dont_interactive_no_label
-      ui :avatar, src: "https://i.pravatar.cc/128", size: :sm # ✗ wrap in a button? add aria_label:
-    end
+    def dont_interactive_no_label; end
   end
 end

--- a/lib/generators/modelrails_ui/lookbook/templates/previews/ui/avatar_component_preview/custom_hue.html.erb
+++ b/lib/generators/modelrails_ui/lookbook/templates/previews/ui/avatar_component_preview/custom_hue.html.erb
@@ -1,0 +1,1 @@
+<%= ui :avatar, fallback: "JD", hue: 280 %>

--- a/lib/generators/modelrails_ui/lookbook/templates/previews/ui/avatar_component_preview/dont_interactive_no_label.html.erb
+++ b/lib/generators/modelrails_ui/lookbook/templates/previews/ui/avatar_component_preview/dont_interactive_no_label.html.erb
@@ -1,0 +1,1 @@
+<%= ui :avatar, src: "https://i.pravatar.cc/128", size: :sm # ✗ wrap in a button? add aria_label: %>

--- a/lib/generators/modelrails_ui/lookbook/templates/previews/ui/avatar_component_preview/image.html.erb
+++ b/lib/generators/modelrails_ui/lookbook/templates/previews/ui/avatar_component_preview/image.html.erb
@@ -1,0 +1,1 @@
+<%= ui :avatar, src: "https://i.pravatar.cc/128", size: :lg %>

--- a/lib/generators/modelrails_ui/lookbook/templates/previews/ui/avatar_component_preview/initials.html.erb
+++ b/lib/generators/modelrails_ui/lookbook/templates/previews/ui/avatar_component_preview/initials.html.erb
@@ -1,0 +1,1 @@
+<%= ui :avatar, fallback: "JD", size: :md %>

--- a/lib/generators/modelrails_ui/lookbook/templates/previews/ui/button_component_preview.rb
+++ b/lib/generators/modelrails_ui/lookbook/templates/previews/ui/button_component_preview.rb
@@ -27,29 +27,19 @@ module UI
     include UIHelper
 
     # The default, high-emphasis action. Aim for one primary per view.
-    def primary
-      ui :button, "Save changes", variant: :primary
-    end
+    def primary; end
 
     # Neutral / secondary action, usually paired beside a primary.
-    def secondary
-      ui :button, "Cancel", variant: :secondary
-    end
+    def secondary; end
 
     # Destructive *styling*. For a real delete, drive it with `button_to` and this variant's class.
-    def danger
-      ui :button, "Delete account", variant: :danger
-    end
+    def danger; end
 
     # Low-emphasis inline action that reads like a link.
-    def text_interactive
-      ui :button, "Learn more", variant: :text_interactive
-    end
+    def text_interactive; end
 
     # Button-styled link: pass `href:` and the component renders an `<a>`.
-    def link
-      ui :button, "Go home", href: "/", variant: :primary
-    end
+    def link; end
 
     # Edit `label` and `variant` live to explore the component.
     # @param label text
@@ -64,8 +54,6 @@ module UI
     # Prefer visible text; if the design is truly icon-only, pass a label:
     # `ui :button, "★", variant: :secondary, "aria-label": "Add to favorites"`.
     # @label Don't · icon-only without a label
-    def dont_icon_only_without_label
-      ui :button, "★", variant: :secondary # ✗ no accessible name
-    end
+    def dont_icon_only_without_label; end
   end
 end

--- a/lib/generators/modelrails_ui/lookbook/templates/previews/ui/button_component_preview.rb
+++ b/lib/generators/modelrails_ui/lookbook/templates/previews/ui/button_component_preview.rb
@@ -27,19 +27,24 @@ module UI
     include UIHelper
 
     # The default, high-emphasis action. Aim for one primary per view.
-    def primary; end
+    def primary
+    end
 
     # Neutral / secondary action, usually paired beside a primary.
-    def secondary; end
+    def secondary
+    end
 
     # Destructive *styling*. For a real delete, drive it with `button_to` and this variant's class.
-    def danger; end
+    def danger
+    end
 
     # Low-emphasis inline action that reads like a link.
-    def text_interactive; end
+    def text_interactive
+    end
 
     # Button-styled link: pass `href:` and the component renders an `<a>`.
-    def link; end
+    def link
+    end
 
     # Edit `label` and `variant` live to explore the component.
     # @param label text
@@ -54,6 +59,7 @@ module UI
     # Prefer visible text; if the design is truly icon-only, pass a label:
     # `ui :button, "★", variant: :secondary, "aria-label": "Add to favorites"`.
     # @label Don't · icon-only without a label
-    def dont_icon_only_without_label; end
+    def dont_icon_only_without_label
+    end
   end
 end

--- a/lib/generators/modelrails_ui/lookbook/templates/previews/ui/button_component_preview/danger.html.erb
+++ b/lib/generators/modelrails_ui/lookbook/templates/previews/ui/button_component_preview/danger.html.erb
@@ -1,0 +1,1 @@
+<%= ui :button, "Delete account", variant: :danger %>

--- a/lib/generators/modelrails_ui/lookbook/templates/previews/ui/button_component_preview/dont_icon_only_without_label.html.erb
+++ b/lib/generators/modelrails_ui/lookbook/templates/previews/ui/button_component_preview/dont_icon_only_without_label.html.erb
@@ -1,0 +1,1 @@
+<%= ui :button, "★", variant: :secondary # ✗ no accessible name %>

--- a/lib/generators/modelrails_ui/lookbook/templates/previews/ui/button_component_preview/link.html.erb
+++ b/lib/generators/modelrails_ui/lookbook/templates/previews/ui/button_component_preview/link.html.erb
@@ -1,0 +1,1 @@
+<%= ui :button, "Go home", href: "/", variant: :primary %>

--- a/lib/generators/modelrails_ui/lookbook/templates/previews/ui/button_component_preview/primary.html.erb
+++ b/lib/generators/modelrails_ui/lookbook/templates/previews/ui/button_component_preview/primary.html.erb
@@ -1,0 +1,1 @@
+<%= ui :button, "Save changes", variant: :primary %>

--- a/lib/generators/modelrails_ui/lookbook/templates/previews/ui/button_component_preview/secondary.html.erb
+++ b/lib/generators/modelrails_ui/lookbook/templates/previews/ui/button_component_preview/secondary.html.erb
@@ -1,0 +1,1 @@
+<%= ui :button, "Cancel", variant: :secondary %>

--- a/lib/generators/modelrails_ui/lookbook/templates/previews/ui/button_component_preview/text_interactive.html.erb
+++ b/lib/generators/modelrails_ui/lookbook/templates/previews/ui/button_component_preview/text_interactive.html.erb
@@ -1,0 +1,1 @@
+<%= ui :button, "Learn more", variant: :text_interactive %>

--- a/lib/generators/modelrails_ui/lookbook/templates/previews/ui/dialog_component_preview.rb
+++ b/lib/generators/modelrails_ui/lookbook/templates/previews/ui/dialog_component_preview.rb
@@ -38,20 +38,10 @@ module UI
     # Standard dialog: trigger button, title, description, and body content.
     # The `with_trigger` slot renders inside the `modal` controller wrapper so
     # clicking the button calls `modal#open` automatically.
-    def default
-      ui :dialog, title: "Confirm action", description: "This action cannot be undone." do |d|
-        d.with_trigger { tag.button("Open dialog", type: "button", class: "btn-primary") }
-        "Are you sure you want to proceed? All related data will be permanently removed."
-      end
-    end
+    def default; end
 
     # Pass `size: :lg` for wide content like forms or detail views.
-    def large
-      ui :dialog, title: "Edit profile", description: "Update your display name and preferences.", size: :lg do |d|
-        d.with_trigger { tag.button("Open large dialog", type: "button", class: "btn-secondary") }
-        "Form fields would go here."
-      end
-    end
+    def large; end
 
     # ## Don't — dialog without a title
     #
@@ -59,11 +49,6 @@ module UI
     # giving screen-reader users the modal's accessible name when focus enters. Without it
     # the modal is announced without context. Always pass a descriptive `title:`.
     # @label Don't · no title (breaks aria-labelledby)
-    def dont_no_title
-      ui :dialog, title: "Untitled" do |d| # ✗ supply a meaningful title:
-        d.with_trigger { tag.button("Open", type: "button", class: "btn-secondary") }
-        "Body content."
-      end
-    end
+    def dont_no_title; end
   end
 end

--- a/lib/generators/modelrails_ui/lookbook/templates/previews/ui/dialog_component_preview.rb
+++ b/lib/generators/modelrails_ui/lookbook/templates/previews/ui/dialog_component_preview.rb
@@ -38,10 +38,12 @@ module UI
     # Standard dialog: trigger button, title, description, and body content.
     # The `with_trigger` slot renders inside the `modal` controller wrapper so
     # clicking the button calls `modal#open` automatically.
-    def default; end
+    def default
+    end
 
     # Pass `size: :lg` for wide content like forms or detail views.
-    def large; end
+    def large
+    end
 
     # ## Don't — dialog without a title
     #
@@ -49,6 +51,7 @@ module UI
     # giving screen-reader users the modal's accessible name when focus enters. Without it
     # the modal is announced without context. Always pass a descriptive `title:`.
     # @label Don't · no title (breaks aria-labelledby)
-    def dont_no_title; end
+    def dont_no_title
+    end
   end
 end

--- a/lib/generators/modelrails_ui/lookbook/templates/previews/ui/dialog_component_preview/default.html.erb
+++ b/lib/generators/modelrails_ui/lookbook/templates/previews/ui/dialog_component_preview/default.html.erb
@@ -1,0 +1,7 @@
+<%= render "shared/modal",
+      title: "Confirm action",
+      description: "This action cannot be undone.",
+      trigger: "Open dialog",
+      trigger_class: "btn-primary" do %>
+  <p>Are you sure you want to proceed? All related data will be permanently removed.</p>
+<% end %>

--- a/lib/generators/modelrails_ui/lookbook/templates/previews/ui/dialog_component_preview/dont_no_title.html.erb
+++ b/lib/generators/modelrails_ui/lookbook/templates/previews/ui/dialog_component_preview/dont_no_title.html.erb
@@ -1,0 +1,4 @@
+<%# ✗ A vague title gives screen-reader users no context via aria-labelledby. %>
+<%= render "shared/modal", title: "Untitled", trigger: "Open", trigger_class: "btn-secondary" do %>
+  Body content.
+<% end %>

--- a/lib/generators/modelrails_ui/lookbook/templates/previews/ui/dialog_component_preview/large.html.erb
+++ b/lib/generators/modelrails_ui/lookbook/templates/previews/ui/dialog_component_preview/large.html.erb
@@ -1,0 +1,8 @@
+<%= render "shared/modal",
+      title: "Edit profile",
+      description: "Update your display name and preferences.",
+      size: :lg,
+      trigger: "Open large dialog",
+      trigger_class: "btn-secondary" do %>
+  <%= ui :input, type: "text", name: "display_name", placeholder: "Display name" %>
+<% end %>

--- a/lib/generators/modelrails_ui/lookbook/templates/previews/ui/file_input_component_preview.rb
+++ b/lib/generators/modelrails_ui/lookbook/templates/previews/ui/file_input_component_preview.rb
@@ -32,14 +32,17 @@ module UI
     include UIHelper
 
     # Generic file picker — no type restriction.
-    def default; end
+    def default
+    end
 
     # Restricts the OS file picker to images; the browser enforces the `accept` hint.
-    def images_only; end
+    def images_only
+    end
 
     # Allows selecting more than one file in a single pick. The field name should end
     # in `[]` when paired with a Rails controller that expects an array.
-    def multiple; end
+    def multiple
+    end
 
     # ## Don't — hand-rolled `<input type="file">` tag
     #
@@ -48,6 +51,7 @@ module UI
     # Always go through the form builder (`f.file_field :attr`) or, for standalone
     # controls, `ui :file_input`.
     # @label Don't · raw <input type="file"> tag
-    def dont_raw_file_input; end
+    def dont_raw_file_input
+    end
   end
 end

--- a/lib/generators/modelrails_ui/lookbook/templates/previews/ui/file_input_component_preview.rb
+++ b/lib/generators/modelrails_ui/lookbook/templates/previews/ui/file_input_component_preview.rb
@@ -32,20 +32,14 @@ module UI
     include UIHelper
 
     # Generic file picker — no type restriction.
-    def default
-      ui :file_input, name: "demo_file"
-    end
+    def default; end
 
     # Restricts the OS file picker to images; the browser enforces the `accept` hint.
-    def images_only
-      ui :file_input, name: "demo_avatar", accept: "image/*"
-    end
+    def images_only; end
 
     # Allows selecting more than one file in a single pick. The field name should end
     # in `[]` when paired with a Rails controller that expects an array.
-    def multiple
-      ui :file_input, name: "demo_docs[]", multiple: true
-    end
+    def multiple; end
 
     # ## Don't — hand-rolled `<input type="file">` tag
     #
@@ -54,8 +48,6 @@ module UI
     # Always go through the form builder (`f.file_field :attr`) or, for standalone
     # controls, `ui :file_input`.
     # @label Don't · raw <input type="file"> tag
-    def dont_raw_file_input
-      ui :file_input, name: "demo_raw" # ✗ use f.file_field inside a form_with
-    end
+    def dont_raw_file_input; end
   end
 end

--- a/lib/generators/modelrails_ui/lookbook/templates/previews/ui/file_input_component_preview/default.html.erb
+++ b/lib/generators/modelrails_ui/lookbook/templates/previews/ui/file_input_component_preview/default.html.erb
@@ -1,0 +1,1 @@
+<%= ui :file_input, name: "demo_file" %>

--- a/lib/generators/modelrails_ui/lookbook/templates/previews/ui/file_input_component_preview/dont_raw_file_input.html.erb
+++ b/lib/generators/modelrails_ui/lookbook/templates/previews/ui/file_input_component_preview/dont_raw_file_input.html.erb
@@ -1,0 +1,1 @@
+<%= ui :file_input, name: "demo_raw" # ✗ use f.file_field inside a form_with %>

--- a/lib/generators/modelrails_ui/lookbook/templates/previews/ui/file_input_component_preview/images_only.html.erb
+++ b/lib/generators/modelrails_ui/lookbook/templates/previews/ui/file_input_component_preview/images_only.html.erb
@@ -1,0 +1,1 @@
+<%= ui :file_input, name: "demo_avatar", accept: "image/*" %>

--- a/lib/generators/modelrails_ui/lookbook/templates/previews/ui/file_input_component_preview/multiple.html.erb
+++ b/lib/generators/modelrails_ui/lookbook/templates/previews/ui/file_input_component_preview/multiple.html.erb
@@ -1,0 +1,1 @@
+<%= ui :file_input, name: "demo_docs[]", multiple: true %>

--- a/lib/generators/modelrails_ui/lookbook/templates/previews/ui/input_component_preview.rb
+++ b/lib/generators/modelrails_ui/lookbook/templates/previews/ui/input_component_preview.rb
@@ -31,14 +31,17 @@ module UI
     include UIHelper
 
     # Plain text input — the baseline appearance.
-    def default; end
+    def default
+    end
 
     # Email input with required styling; the browser also validates format on submit.
-    def required; end
+    def required
+    end
 
     # Error state: red border + `aria-invalid="true"`. In a real form the form builder
     # sets both automatically when an ActiveModel error is present.
-    def invalid; end
+    def invalid
+    end
 
     # ## Don't — hand-rolled `<input>` tag
     #
@@ -46,6 +49,7 @@ module UI
     # and the automatic ARIA wiring the component provides. Always go through the form
     # builder (`f.text_field :attr`) or, for standalone controls, `ui :input`.
     # @label Don't · raw <input> tag
-    def dont_raw_input; end
+    def dont_raw_input
+    end
   end
 end

--- a/lib/generators/modelrails_ui/lookbook/templates/previews/ui/input_component_preview.rb
+++ b/lib/generators/modelrails_ui/lookbook/templates/previews/ui/input_component_preview.rb
@@ -31,21 +31,14 @@ module UI
     include UIHelper
 
     # Plain text input — the baseline appearance.
-    def default
-      ui :input, type: "text", name: "demo_search", placeholder: "Search…"
-    end
+    def default; end
 
     # Email input with required styling; the browser also validates format on submit.
-    def required
-      ui :input, type: "email", name: "demo_email", required: true, placeholder: "you@example.com"
-    end
+    def required; end
 
     # Error state: red border + `aria-invalid="true"`. In a real form the form builder
     # sets both automatically when an ActiveModel error is present.
-    def invalid
-      ui :input, type: "email", name: "demo_email", invalid: true,
-         describedby: "demo-email-error", value: "not-an-email"
-    end
+    def invalid; end
 
     # ## Don't — hand-rolled `<input>` tag
     #
@@ -53,8 +46,6 @@ module UI
     # and the automatic ARIA wiring the component provides. Always go through the form
     # builder (`f.text_field :attr`) or, for standalone controls, `ui :input`.
     # @label Don't · raw <input> tag
-    def dont_raw_input
-      ui :input, type: "text", name: "demo_raw" # ✗ use f.text_field inside a form_with
-    end
+    def dont_raw_input; end
   end
 end

--- a/lib/generators/modelrails_ui/lookbook/templates/previews/ui/input_component_preview/default.html.erb
+++ b/lib/generators/modelrails_ui/lookbook/templates/previews/ui/input_component_preview/default.html.erb
@@ -1,0 +1,1 @@
+<%= ui :input, type: "text", name: "demo_search", placeholder: "Search…" %>

--- a/lib/generators/modelrails_ui/lookbook/templates/previews/ui/input_component_preview/dont_raw_input.html.erb
+++ b/lib/generators/modelrails_ui/lookbook/templates/previews/ui/input_component_preview/dont_raw_input.html.erb
@@ -1,0 +1,1 @@
+<%= ui :input, type: "text", name: "demo_raw" # ✗ use f.text_field inside a form_with %>

--- a/lib/generators/modelrails_ui/lookbook/templates/previews/ui/input_component_preview/invalid.html.erb
+++ b/lib/generators/modelrails_ui/lookbook/templates/previews/ui/input_component_preview/invalid.html.erb
@@ -1,0 +1,2 @@
+<%= ui :input, type: "email", name: "demo_email", invalid: true,
+   describedby: "demo-email-error", value: "not-an-email" %>

--- a/lib/generators/modelrails_ui/lookbook/templates/previews/ui/input_component_preview/required.html.erb
+++ b/lib/generators/modelrails_ui/lookbook/templates/previews/ui/input_component_preview/required.html.erb
@@ -1,0 +1,1 @@
+<%= ui :input, type: "email", name: "demo_email", required: true, placeholder: "you@example.com" %>

--- a/lib/generators/modelrails_ui/lookbook/templates/previews/ui/textarea_component_preview.rb
+++ b/lib/generators/modelrails_ui/lookbook/templates/previews/ui/textarea_component_preview.rb
@@ -30,11 +30,13 @@ module UI
     include UIHelper
 
     # Multi-line input at rest — the baseline appearance.
-    def default; end
+    def default
+    end
 
     # Error state: red border + `aria-invalid="true"`. In a real form the builder
     # sets both automatically when an ActiveModel error is present.
-    def invalid; end
+    def invalid
+    end
 
     # ## Don't — hand-rolled `<textarea>` tag
     #
@@ -42,6 +44,7 @@ module UI
     # and the automatic ARIA wiring. Always go through the form builder
     # (`f.text_area :attr`) or, for standalone controls, `ui :textarea`.
     # @label Don't · raw <textarea> tag
-    def dont_raw_textarea; end
+    def dont_raw_textarea
+    end
   end
 end

--- a/lib/generators/modelrails_ui/lookbook/templates/previews/ui/textarea_component_preview.rb
+++ b/lib/generators/modelrails_ui/lookbook/templates/previews/ui/textarea_component_preview.rb
@@ -30,16 +30,11 @@ module UI
     include UIHelper
 
     # Multi-line input at rest — the baseline appearance.
-    def default
-      ui :textarea, name: "demo_body", value: "Hello there.", rows: 4
-    end
+    def default; end
 
     # Error state: red border + `aria-invalid="true"`. In a real form the builder
     # sets both automatically when an ActiveModel error is present.
-    def invalid
-      ui :textarea, name: "demo_body", invalid: true,
-         describedby: "demo-body-error", value: "too short"
-    end
+    def invalid; end
 
     # ## Don't — hand-rolled `<textarea>` tag
     #
@@ -47,8 +42,6 @@ module UI
     # and the automatic ARIA wiring. Always go through the form builder
     # (`f.text_area :attr`) or, for standalone controls, `ui :textarea`.
     # @label Don't · raw <textarea> tag
-    def dont_raw_textarea
-      ui :textarea, name: "demo_raw" # ✗ use f.text_area inside a form_with
-    end
+    def dont_raw_textarea; end
   end
 end

--- a/lib/generators/modelrails_ui/lookbook/templates/previews/ui/textarea_component_preview/default.html.erb
+++ b/lib/generators/modelrails_ui/lookbook/templates/previews/ui/textarea_component_preview/default.html.erb
@@ -1,0 +1,1 @@
+<%= ui :textarea, name: "demo_body", value: "Hello there.", rows: 4 %>

--- a/lib/generators/modelrails_ui/lookbook/templates/previews/ui/textarea_component_preview/dont_raw_textarea.html.erb
+++ b/lib/generators/modelrails_ui/lookbook/templates/previews/ui/textarea_component_preview/dont_raw_textarea.html.erb
@@ -1,0 +1,1 @@
+<%= ui :textarea, name: "demo_raw" # ✗ use f.text_area inside a form_with %>

--- a/lib/generators/modelrails_ui/lookbook/templates/previews/ui/textarea_component_preview/invalid.html.erb
+++ b/lib/generators/modelrails_ui/lookbook/templates/previews/ui/textarea_component_preview/invalid.html.erb
@@ -1,0 +1,2 @@
+<%= ui :textarea, name: "demo_body", invalid: true,
+   describedby: "demo-body-error", value: "too short" %>

--- a/test/test_add_generator_partial_routing.rb
+++ b/test/test_add_generator_partial_routing.rb
@@ -1,0 +1,21 @@
+# frozen_string_literal: true
+
+require "test_helper"
+require "rails/generators"
+require_relative "../lib/generators/modelrails_ui/add/add_generator"
+
+class TestAddGeneratorPartialRouting < Minitest::Test
+  # allocate skips #initialize (which requires the components argument); the
+  # routing helper is pure and touches no instance state.
+  def destination_for(file)
+    ModelrailsUi::Generators::AddGenerator.allocate.send(:html_erb_destination, file)
+  end
+
+  def test_leading_underscore_partial_routes_to_app_views_shared
+    assert_equal "app/views/shared/_modal.html.erb", destination_for("_modal.html.erb")
+  end
+
+  def test_component_sidecar_template_routes_to_app_components_ui
+    assert_equal "app/components/ui/tabs_component.html.erb", destination_for("tabs_component.html.erb")
+  end
+end

--- a/test/test_lookbook_previews_template_backed.rb
+++ b/test/test_lookbook_previews_template_backed.rb
@@ -35,7 +35,7 @@ class TestLookbookPreviewsTemplateBacked < Minitest::Test
       src = preview_rb(component)
 
       scenarios.each do |scenario|
-        assert_match(/def #{scenario}; end/, src, "#{component}##{scenario} should be empty")
+        assert_match(/def #{scenario}(; end|\n\s*end)/, src, "#{component}##{scenario} should be empty")
       end
     end
   end
@@ -57,7 +57,7 @@ class TestLookbookPreviewsTemplateBacked < Minitest::Test
     src = File.read(File.join(PREVIEW_ROOT, "dialog_component_preview.rb"))
     DIALOG_SCENARIOS.each do |scenario|
       assert_path_exists File.join(PREVIEW_ROOT, "dialog_component_preview", "#{scenario}.html.erb")
-      assert_match(/def #{scenario}; end/, src, "dialog##{scenario} should be empty")
+      assert_match(/def #{scenario}(; end|\n\s*end)/, src, "dialog##{scenario} should be empty")
     end
   end
 

--- a/test/test_lookbook_previews_template_backed.rb
+++ b/test/test_lookbook_previews_template_backed.rb
@@ -1,0 +1,47 @@
+# frozen_string_literal: true
+
+require "test_helper"
+
+class TestLookbookPreviewsTemplateBacked < Minitest::Test
+  PREVIEW_ROOT = File.expand_path(
+    "../lib/generators/modelrails_ui/lookbook/templates/previews/ui", __dir__
+  )
+
+  # component => scenario methods that must be template-backed (playground excluded)
+  PRIMITIVES = {
+    "button"     => %w[primary secondary danger text_interactive link dont_icon_only_without_label],
+    "input"      => %w[default required invalid dont_raw_input],
+    "textarea"   => %w[default invalid dont_raw_textarea],
+    "file_input" => %w[default images_only multiple dont_raw_file_input],
+    "avatar"     => %w[image initials custom_hue dont_interactive_no_label]
+  }.freeze
+
+  def preview_rb(component)
+    File.read(File.join(PREVIEW_ROOT, "#{component}_component_preview.rb"))
+  end
+
+  def test_each_primitive_scenario_has_a_sibling_template
+    PRIMITIVES.each do |component, scenarios|
+      scenarios.each do |scenario|
+        path = File.join(PREVIEW_ROOT, "#{component}_component_preview", "#{scenario}.html.erb")
+        assert_path_exists path, "missing sibling template #{path}"
+      end
+    end
+  end
+
+  def test_primitive_scenario_methods_are_empty
+    PRIMITIVES.each do |component, scenarios|
+      src = preview_rb(component)
+      scenarios.each do |scenario|
+        assert_match(/def #{scenario}; end/, src, "#{component}##{scenario} should be empty")
+      end
+    end
+  end
+
+  def test_playground_stays_inline_where_present
+    %w[button avatar].each do |component|
+      assert_match(/def playground\(.*\)\n\s+ui /, preview_rb(component),
+        "#{component} playground should remain an inline explorer")
+    end
+  end
+end

--- a/test/test_lookbook_previews_template_backed.rb
+++ b/test/test_lookbook_previews_template_backed.rb
@@ -44,4 +44,28 @@ class TestLookbookPreviewsTemplateBacked < Minitest::Test
         "#{component} playground should remain an inline explorer")
     end
   end
+
+  DIALOG_SCENARIOS = %w[default large dont_no_title].freeze
+
+  def dialog_template(scenario)
+    File.read(File.join(PREVIEW_ROOT, "dialog_component_preview", "#{scenario}.html.erb"))
+  end
+
+  def test_dialog_scenarios_are_template_backed
+    src = File.read(File.join(PREVIEW_ROOT, "dialog_component_preview.rb"))
+    DIALOG_SCENARIOS.each do |scenario|
+      assert_path_exists File.join(PREVIEW_ROOT, "dialog_component_preview", "#{scenario}.html.erb")
+      assert_match(/def #{scenario}; end/, src, "dialog##{scenario} should be empty")
+    end
+  end
+
+  def test_dialog_scenarios_teach_shared_modal_and_stay_portable
+    DIALOG_SCENARIOS.each do |scenario|
+      src = dialog_template(scenario)
+      assert_includes src, 'render "shared/modal"', "#{scenario} should teach the shared/modal partial"
+      refute_includes src, "f.text_field", "#{scenario} must not use the app form builder"
+      refute_includes src, "shared/confirm_dialog", "#{scenario} must not use the app confirm partial"
+      refute_includes src, "avatar_for", "#{scenario} must not use the app avatar helper"
+    end
+  end
 end

--- a/test/test_lookbook_previews_template_backed.rb
+++ b/test/test_lookbook_previews_template_backed.rb
@@ -9,11 +9,11 @@ class TestLookbookPreviewsTemplateBacked < Minitest::Test
 
   # component => scenario methods that must be template-backed (playground excluded)
   PRIMITIVES = {
-    "button"     => %w[primary secondary danger text_interactive link dont_icon_only_without_label],
-    "input"      => %w[default required invalid dont_raw_input],
-    "textarea"   => %w[default invalid dont_raw_textarea],
+    "button" => %w[primary secondary danger text_interactive link dont_icon_only_without_label],
+    "input" => %w[default required invalid dont_raw_input],
+    "textarea" => %w[default invalid dont_raw_textarea],
     "file_input" => %w[default images_only multiple dont_raw_file_input],
-    "avatar"     => %w[image initials custom_hue dont_interactive_no_label]
+    "avatar" => %w[image initials custom_hue dont_interactive_no_label]
   }.freeze
 
   def preview_rb(component)
@@ -24,6 +24,7 @@ class TestLookbookPreviewsTemplateBacked < Minitest::Test
     PRIMITIVES.each do |component, scenarios|
       scenarios.each do |scenario|
         path = File.join(PREVIEW_ROOT, "#{component}_component_preview", "#{scenario}.html.erb")
+
         assert_path_exists path, "missing sibling template #{path}"
       end
     end
@@ -32,6 +33,7 @@ class TestLookbookPreviewsTemplateBacked < Minitest::Test
   def test_primitive_scenario_methods_are_empty
     PRIMITIVES.each do |component, scenarios|
       src = preview_rb(component)
+
       scenarios.each do |scenario|
         assert_match(/def #{scenario}; end/, src, "#{component}##{scenario} should be empty")
       end
@@ -62,6 +64,7 @@ class TestLookbookPreviewsTemplateBacked < Minitest::Test
   def test_dialog_scenarios_teach_shared_modal_and_stay_portable
     DIALOG_SCENARIOS.each do |scenario|
       src = dialog_template(scenario)
+
       assert_includes src, 'render "shared/modal"', "#{scenario} should teach the shared/modal partial"
       refute_includes src, "f.text_field", "#{scenario} must not use the app form builder"
       refute_includes src, "shared/confirm_dialog", "#{scenario} must not use the app confirm partial"

--- a/test/test_shared_modal_template.rb
+++ b/test/test_shared_modal_template.rb
@@ -1,0 +1,30 @@
+# frozen_string_literal: true
+
+require "test_helper"
+
+class TestSharedModalTemplate < Minitest::Test
+  PATH = File.expand_path(
+    "../lib/generators/modelrails_ui/add/templates/dialog/_modal.html.erb", __dir__
+  )
+
+  def source
+    @source ||= File.read(PATH)
+  end
+
+  def test_partial_exists
+    assert_path_exists PATH, "dialog add-template should ship _modal.html.erb"
+  end
+
+  def test_declares_trigger_local_with_default
+    assert_includes source, "trigger: nil"
+    assert_includes source, 'trigger_class: "btn-secondary"'
+  end
+
+  def test_has_complete_and_surface_branches
+    assert_includes source, "if trigger.present?"
+    assert_includes source, "wrapper: true"
+    assert_includes source, "wrapper: false"
+    assert_includes source, 'body_id: "modal-body"'
+    assert_includes source, "d.with_trigger"
+  end
+end


### PR DESCRIPTION
## What

Brings the reference app's **copyable-artifact** work into the gem so every downstream app's generated Lookbook catalog teaches paste-ready ERB.

- **Ships `app/views/shared/_modal.html.erb`** via `add dialog` — a thin adapter over `UI::DialogComponent` with an optional `trigger:` mode (`trigger:` → complete wrapper+trigger+dialog; absent → surface-only, `body_id: "modal-body"`). A new `add`-generator rule routes leading-underscore `_*.html.erb` partials to `app/views/shared/` (component sidecar templates like `tabs_component.html.erb` keep routing to `app/components/ui/`).
- **All six component previews → template-backed** (empty `def scenario; end` + sibling `<scenario>.html.erb`), so Lookbook's Source tab shows the copyable view-native ERB instead of a Ruby preview method. The five primitives move their `ui :x` call verbatim; **`playground` scenarios stay inline** (interactive explorers).
- **Dialog re-authored** to teach `render "shared/modal", trigger:` — using **only gem-portable content** (plain HTML / `ui :input`), with a portability-guard test asserting no `f.text_field` / `shared/confirm_dialog` / `avatar_for` leaks in.

## Scope

The gem ships **only `shared/_modal`**. A form builder and `avatar_for` stay **app-specific** — the gem's primitives (`ui :input`, `ui :avatar`) are already clean copyable artifacts, and a downstream app has its own form builder / user model. No `User`-model or form-builder assumption leaks into the gem.

## Testing

Structural Minitest (matching the gem's existing generator-test style): asserts the partial ships with its `trigger:` contract, every preview is template-backed, and the dialog stays portable. **Full suite: 0 new failures.**

> ⚠️ One **pre-existing, out-of-scope** failure remains: `TestButtonComponent#test_unknown_variant_raises` (`NoMethodError: undefined method 'env' for module Rails`) — the button's SP1 fail-loud guard calls `Rails.env`, which the gem's Rails-less test env doesn't define. Introduced before this branch; unrelated to this work. Worth a separate fix (stub `Rails.env` in the gem harness).

A gem release/tag is the owner's call. Design + plan: `docs/design/2026-06-02-shared-modal-and-copyable-previews-{design,plan}.md`.