### PR TITLE
fix: repair gem CI — ButtonComponent Rails.env guard + rubocop autocorrect

### DIFF
--- a/lib/generators/modelrails_ui/add/templates/button/button_component.rb.tt
+++ b/lib/generators/modelrails_ui/add/templates/button/button_component.rb.tt
@@ -52,11 +52,13 @@ module UI
 
     # Fail loud on an unknown variant in development/test so misuse is caught
     # immediately; fall back to :primary in production so a bad variant never
-    # 500s a page. `defined?(Rails)` keeps this correct in the gem's Rails-less tests.
+    # 500s a page. The Rails.respond_to?(:env) guard stays correct even when the Rails
+    # module is defined but Rails.env isn't booted (the gem's Rails-less tests load
+    # rails/generators, which defines Rails without Rails.env).
     def coerce_variant(variant)
       return variant if VARIANTS.key?(variant)
 
-      unless defined?(Rails) && Rails.env.production?
+      unless defined?(Rails) && Rails.respond_to?(:env) && Rails.env.production?
         raise ArgumentError,
           "UI::ButtonComponent: unknown variant #{variant.inspect}. " \
           "Expected one of: #{VARIANTS.keys.join(", ")}."

--- a/lib/generators/modelrails_ui/lookbook/templates/previews/ui/input_component_preview.rb
+++ b/lib/generators/modelrails_ui/lookbook/templates/previews/ui/input_component_preview.rb
@@ -44,7 +44,7 @@ module UI
     # sets both automatically when an ActiveModel error is present.
     def invalid
       ui :input, type: "email", name: "demo_email", invalid: true,
-         describedby: "demo-email-error", value: "not-an-email"
+        describedby: "demo-email-error", value: "not-an-email"
     end
 
     # ## Don't — hand-rolled `<input>` tag

--- a/lib/generators/modelrails_ui/lookbook/templates/previews/ui/textarea_component_preview.rb
+++ b/lib/generators/modelrails_ui/lookbook/templates/previews/ui/textarea_component_preview.rb
@@ -38,7 +38,7 @@ module UI
     # sets both automatically when an ActiveModel error is present.
     def invalid
       ui :textarea, name: "demo_body", invalid: true,
-         describedby: "demo-body-error", value: "too short"
+        describedby: "demo-body-error", value: "too short"
     end
 
     # ## Don't — hand-rolled `<textarea>` tag

--- a/test/test_aaa_contrast.rb
+++ b/test/test_aaa_contrast.rb
@@ -15,11 +15,11 @@ class TestAaaContrast < Minitest::Test
   AAA = 7.0
 
   # Tailwind v4 default palette OKLCH [L (0..1), C, H] for the shades the tokens use.
-  WHITE     = [1.0,   0.0,   0.0].freeze
-  BLACK     = [0.0,   0.0,   0.0].freeze
-  SKY_300   = [0.828, 0.111, 230.318].freeze # dark-mode interactive (primary-300)
-  SKY_800   = [0.443, 0.110, 240.790].freeze # light-mode interactive (primary-800)
-  SLATE_50  = [0.984, 0.003, 247.858].freeze # light surface (neutral-50)
+  WHITE = [1.0, 0.0, 0.0].freeze
+  BLACK = [0.0, 0.0, 0.0].freeze
+  SKY_300 = [0.828, 0.111, 230.318].freeze # dark-mode interactive (primary-300)
+  SKY_800 = [0.443, 0.110, 240.790].freeze # light-mode interactive (primary-800)
+  SLATE_50 = [0.984, 0.003, 247.858].freeze # light surface (neutral-50)
   SLATE_100 = [0.968, 0.007, 247.896].freeze # dark text-heading (neutral-100)
   SLATE_300 = [0.869, 0.022, 252.894].freeze # dark text-body (neutral-300)
   SLATE_700 = [0.372, 0.044, 257.287].freeze # light text-body/muted (neutral-700)
@@ -33,8 +33,8 @@ class TestAaaContrast < Minitest::Test
     l_ = (l + 0.3963377774 * a + 0.2158037573 * b)**3
     m_ = (l - 0.1055613458 * a - 0.0638541728 * b)**3
     s_ = (l - 0.0894841775 * a - 1.2914855480 * b)**3
-    r  = 4.0767416621 * l_ - 3.3077115913 * m_ + 0.2309699292 * s_
-    g  = -1.2684380046 * l_ + 2.6097574011 * m_ - 0.3413193965 * s_
+    r = 4.0767416621 * l_ - 3.3077115913 * m_ + 0.2309699292 * s_
+    g = -1.2684380046 * l_ + 2.6097574011 * m_ - 0.3413193965 * s_
     bl = -0.0041960863 * l_ - 0.7034186147 * m_ + 1.7076147010 * s_
     rr, gg, bb = [r, g, bl].map { |x| x.clamp(0.0, 1.0) }
     0.2126 * rr + 0.7152 * gg + 0.0722 * bb
@@ -50,6 +50,7 @@ class TestAaaContrast < Minitest::Test
 
   def assert_aaa(fg, bg, label)
     ratio = contrast(fg, bg)
+
     assert_operator ratio, :>=, AAA, "#{label}: #{ratio.round(2)}:1 is below AAA (#{AAA}:1)"
   end
 
@@ -60,11 +61,11 @@ class TestAaaContrast < Minitest::Test
   end
 
   def test_light_mode_text_pairs_meet_aaa
-    assert_aaa SLATE_900, WHITE,    "light: text-heading on surface-raised"
+    assert_aaa SLATE_900, WHITE, "light: text-heading on surface-raised"
     assert_aaa SLATE_900, SLATE_50, "light: text-heading on surface"
-    assert_aaa SLATE_700, WHITE,    "light: text-body on surface-raised"
+    assert_aaa SLATE_700, WHITE, "light: text-body on surface-raised"
     assert_aaa SLATE_700, SLATE_50, "light: text-body on surface"
-    assert_aaa WHITE,     SKY_800,  "light: text-on-interactive on interactive"
+    assert_aaa WHITE, SKY_800, "light: text-on-interactive on interactive"
   end
 
   def test_dark_mode_text_pairs_meet_aaa
@@ -72,6 +73,6 @@ class TestAaaContrast < Minitest::Test
     assert_aaa SLATE_100, SLATE_800, "dark: text-heading on surface-raised"
     assert_aaa SLATE_300, SLATE_900, "dark: text-body on surface"
     assert_aaa SLATE_300, SLATE_800, "dark: text-body on surface-raised"
-    assert_aaa SLATE_900, SKY_300,   "dark: text-on-interactive on interactive"
+    assert_aaa SLATE_900, SKY_300, "dark: text-on-interactive on interactive"
   end
 end


### PR DESCRIPTION
## Problem

`TestButtonComponent#test_unknown_variant_raises` fails on **every** CI matrix job (Ruby 3.2/3.3/3.4/4.0 + Appraisal rails-7.2/8.1) — the gem's CI is red on `modelrails/harden`:

```
[ArgumentError] exception expected, not <NoMethodError>
Message: <"undefined method 'env' for module Rails">
```

## Root cause

`UI::ButtonComponent#coerce_variant` guarded its prod-fallback with `defined?(Rails) && Rails.env.production?`. But the gem's test harness loads `rails/generators`, which **defines the `Rails` module without booting `Rails.env`** (that comes from a full app/railtie boot — which none of the CI jobs do, including the real-Rails appraisals). So `defined?(Rails)` is true, then `Rails.env` raises `NoMethodError` — instead of the `ArgumentError` the dev/test fail-loud path is supposed to raise.

## Fix

One line: add a `Rails.respond_to?(:env)` guard.

```ruby
unless defined?(Rails) && Rails.respond_to?(:env) && Rails.env.production?
```

When `Rails.env` is unavailable, the guard is false → it raises `ArgumentError` (the correct dev/test behavior). Behavior in a real booted app is unchanged. Fixes the `.tt` template, so every downstream-generated button gets the robust guard.

## Verification

Full gem suite: **431 runs, 1180 assertions, 0 failures**. This turns the gem CI green (and unblocks #1 once rebased/re-run).