### PR TITLE
Phase 0a: render-test harness + component-hardening program kickoff

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -8,7 +8,6 @@ gem "irb"
 gem "rake", "~> 13.0"
 gem "minitest", ">= 5.16"
 gem "standard", require: false
-gem "capybara", require: false
 gem "rubocop-minitest", require: false
 gem "rubocop-performance", require: false
 gem "lefthook", require: false

--- a/Gemfile
+++ b/Gemfile
@@ -8,6 +8,7 @@ gem "irb"
 gem "rake", "~> 13.0"
 gem "minitest", ">= 5.16"
 gem "standard", require: false
+gem "capybara", require: false
 gem "rubocop-minitest", require: false
 gem "rubocop-performance", require: false
 gem "lefthook", require: false

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -82,6 +82,8 @@ GEM
       securerandom (>= 0.3)
       tzinfo (~> 2.0, >= 2.0.5)
       uri (>= 0.13.1)
+    addressable (2.9.0)
+      public_suffix (>= 2.0.2, < 8.0)
     appraisal (2.5.0)
       bundler
       rake
@@ -90,6 +92,15 @@ GEM
     base64 (0.3.0)
     bigdecimal (4.1.2)
     builder (3.3.0)
+    capybara (3.40.0)
+      addressable
+      matrix
+      mini_mime (>= 0.1.3)
+      nokogiri (~> 1.11)
+      rack (>= 1.6.0)
+      rack-test (>= 0.6.3)
+      regexp_parser (>= 1.5, < 3.0)
+      xpath (~> 3.2)
     concurrent-ruby (1.3.6)
     connection_pool (3.0.2)
     crass (1.0.6)
@@ -123,6 +134,7 @@ GEM
       net-pop
       net-smtp
     marcel (1.2.1)
+    matrix (0.4.3)
     mini_mime (1.1.5)
     minitest (6.0.6)
       drb (~> 2.0)
@@ -164,6 +176,7 @@ GEM
     psych (5.3.1)
       date
       stringio
+    public_suffix (7.0.5)
     racc (1.8.1)
     rack (3.2.6)
     rack-session (2.1.2)
@@ -273,6 +286,8 @@ GEM
       base64
       websocket-extensions (>= 0.1.0)
     websocket-extensions (0.1.5)
+    xpath (3.2.0)
+      nokogiri (~> 1.8)
     zeitwerk (2.8.2)
 
 PLATFORMS
@@ -287,6 +302,7 @@ PLATFORMS
 
 DEPENDENCIES
   appraisal
+  capybara
   irb
   lefthook
   minitest (>= 5.16)
@@ -311,12 +327,14 @@ CHECKSUMS
   activerecord (8.1.3) sha256=8003be7b2466ba0a2a670e603eeb0a61dd66058fccecfc49901e775260ac70ab
   activestorage (8.1.3) sha256=0564ce9309143951a67615e1bb4e090ee54b8befed417133cae614479b46384d
   activesupport (8.1.3) sha256=21a5e0dfbd4c3ddd9e1317ec6a4d782fa226e7867dc70b0743acda81a1dca20e
+  addressable (2.9.0) sha256=7fdf6ac3660f7f4e867a0838be3f6cf722ace541dd97767fa42bc6cfa980c7af
   appraisal (2.5.0) sha256=36989221be127913b0dba8d114da2001e6b2dceea7bd4951200eaba764eed3ce
   ast (2.4.3) sha256=954615157c1d6a382bc27d690d973195e79db7f55e9765ac7c481c60bdb4d383
   base64 (0.3.0) sha256=27337aeabad6ffae05c265c450490628ef3ebd4b67be58257393227588f5a97b
   bigdecimal (4.1.2) sha256=53d217666027eab4280346fba98e7d5b66baaae1b9c3c1c0ffe89d48188a3fbd
   builder (3.3.0) sha256=497918d2f9dca528fdca4b88d84e4ef4387256d984b8154e9d5d3fe5a9c8835f
   bundler (4.0.12) sha256=7f8b757d28dfb636e7b24fba2344ac6dd13b5b24f4b46d62573d483f211825ac
+  capybara (3.40.0) sha256=42dba720578ea1ca65fd7a41d163dd368502c191804558f6e0f71b391054aeef
   concurrent-ruby (1.3.6) sha256=6b56837e1e7e5292f9864f34b69c5a2cbc75c0cf5338f1ce9903d10fa762d5ab
   connection_pool (3.0.2) sha256=33fff5ba71a12d2aa26cb72b1db8bba2a1a01823559fb01d29eb74c286e62e0a
   crass (1.0.6) sha256=dc516022a56e7b3b156099abc81b6d2b08ea1ed12676ac7a5657617f012bd45d
@@ -337,6 +355,7 @@ CHECKSUMS
   loofah (2.25.1) sha256=d436c73dbd0c1147b16c4a41db097942d217303e1f7728704b37e4df9f6d2e04
   mail (2.9.0) sha256=6fa6673ecd71c60c2d996260f9ee3dd387d4673b8169b502134659ece6d34941
   marcel (1.2.1) sha256=1678e9360e32f9eafa917c80029e2f6d10b2715c66a4b87b6d0da9b9cd1f859f
+  matrix (0.4.3) sha256=a0d5ab7ddcc1973ff690ab361b67f359acbb16958d1dc072b8b956a286564c5b
   mini_mime (1.1.5) sha256=8681b7e2e4215f2a159f9400b5816d85e9d8c6c6b491e96a12797e798f8bccef
   minitest (6.0.6) sha256=153ea36d1d987a62942382b61075745042a2b3123b1cd48f4c3675af9cc7d6f1
   modelrails_ui (0.2.0)
@@ -359,6 +378,7 @@ CHECKSUMS
   prettyprint (0.2.0) sha256=2bc9e15581a94742064a3cc8b0fb9d45aae3d03a1baa6ef80922627a0766f193
   prism (1.9.0) sha256=7b530c6a9f92c24300014919c9dcbc055bf4cdf51ec30aed099b06cd6674ef85
   psych (5.3.1) sha256=eb7a57cef10c9d70173ff74e739d843ac3b2c019a003de48447b2963d81b1974
+  public_suffix (7.0.5) sha256=1a8bb08f1bbea19228d3bed6e5ed908d1cb4f7c2726d18bd9cadf60bc676f623
   racc (1.8.1) sha256=4a7f6929691dbec8b5209a0b373bc2614882b55fc5d2e447a21aaa691303d62f
   rack (3.2.6) sha256=5ed78e1f73b2e25679bec7d45ee2d4483cc4146eb1be0264fc4d94cb5ef212c2
   rack-session (2.1.2) sha256=595434f8c0c3473ae7d7ac56ecda6cc6dfd9d37c0b2b5255330aa1576967ffe8
@@ -397,6 +417,7 @@ CHECKSUMS
   view_component (4.11.0) sha256=92df960575b8fa5e984522532df225ec333015a07a8105b3b1c200c655065517
   websocket-driver (0.8.0) sha256=ed0dba4b943c22f17f9a734817e808bc84cdce6a7e22045f5315aa57676d4962
   websocket-extensions (0.1.5) sha256=1c6ba63092cda343eb53fc657110c71c754c56484aad42578495227d717a8241
+  xpath (3.2.0) sha256=6dfda79d91bb3b949b947ecc5919f042ef2f399b904013eb3ef6d20dd3a4082e
   zeitwerk (2.8.2) sha256=7212a61311083c604184b1ea2574b9aa05cd14f855a0841c06985cabe9181d12
 
 BUNDLED WITH

--- a/README.md
+++ b/README.md
@@ -93,9 +93,41 @@ with real tokens and working Stimulus (the dialog actually opens). Previews land
 
 ## Testing & accessibility
 
-- The gem's suite (`rake test`) unit-tests component logic + template structure + **AAA contrast**.
-- Rendering/ARIA is verified by **integration specs in the consuming app** (a real view context),
-  where each adopted component is asserted for correct markup and ARIA.
+The gem's suite (`rake test`) runs two lanes:
+
+- **`test:structural`** — fast, no Rails: reads the `.rb.tt` templates as text and asserts
+  structure (`test/test_components.rb` and friends).
+- **`test:render`** — real rendering: boots a minimal Rails app + ViewComponent and renders
+  a component, asserting actual HTML/ARIA. AAA contrast is guaranteed by
+  `test/test_aaa_contrast.rb` (token ratios), so a render test that asserts a component
+  uses the semantic token classes inherits AAA.
+
+### Verifying components (render tests)
+
+To add a render test for a new component, create
+`test/render/<name>_render_test.rb`:
+
+```ruby
+# test/render/<name>_render_test.rb
+require "render_test_helper"
+load_component "<name>", "<name>_component.rb.tt"
+
+class <Name>RenderTest < ViewComponent::TestCase
+  def test_renders_with_aaa_tokens
+    render_inline(UI::<Name>Component.new(...))
+    assert_selector "..."             # tag + structure
+    assert_selector ".bg-interactive" # AAA semantic token actually rendered
+  end
+end
+```
+
+Replace `<name>` with the snake_case component name and `<Name>` with PascalCase
+(e.g. `button` / `Button`). This render lane is the verification basis for the
+component-hardening program
+(see `docs/design/2026-06-03-component-hardening-program-design.md`).
+
+Rendering/ARIA is also verified by **integration specs in the consuming app** (a real
+view context), where each adopted component is asserted for correct markup and ARIA.
 
 ## Known gaps
 

--- a/Rakefile
+++ b/Rakefile
@@ -3,10 +3,23 @@
 require "bundler/gem_tasks"
 require "minitest/test_task"
 
-Minitest::TestTask.create
+# Structural lane: stubs ViewComponent (test_components.rb), reads templates as text.
+Minitest::TestTask.create(:"test:structural") do |t|
+  t.test_globs = ["test/test_*.rb"]
+  t.warning = true
+end
+
+# Render lane: real view_component + a minimal Rails app (test/render/render_test_helper.rb).
+# MUST be a separate process from the structural lane (incompatible ViewComponent::Base).
+Minitest::TestTask.create(:"test:render") do |t|
+  t.libs << "test/render"
+  t.test_globs = ["test/render/**/*_test.rb"]
+  t.warning = false
+end
+
+task test: [:"test:structural", :"test:render"]
 
 require "rubocop/rake_task"
-
 RuboCop::RakeTask.new
 
 task default: %i[test rubocop]

--- a/docs/design/2026-06-03-component-hardening-program-design.md
+++ b/docs/design/2026-06-03-component-hardening-program-design.md
@@ -1,0 +1,87 @@
+# Design: component-hardening program — make all 77 components downstream-ready
+
+**Date:** 2026-06-03
+**Status:** Proposed (design approved in brainstorming; pending written-spec review)
+**Repo:** modelrails_ui (gem)
+**Scope:** a multi-phase PROGRAM, not a single feature. This doc is the strategy; each phase gets its own implementation plan. The first plan is **Phase 0a** (the verification harness), because everything depends on it.
+
+## Why
+
+The gem ships **77 component `add`-templates** (phases 1-9), but quality is wildly uneven: ~5 are production-ready (button-tier: fail-loud guards + AAA semantic tokens + full ARIA + docs + previews), ~65 are "structurally there but unverified" (semantic tokens, basic ARIA, no guards), ~4 are rough stubs (`select`, `tooltip`, …), and 3 are outright broken (`form_field`, `qr_code`, `input_otp` — generation bugs). Only the 6 worked this session (button, input, textarea, file_input, avatar, dialog) have Lookbook teaching previews.
+
+The goal: bring **all 77** up to the button-tier bar so they are genuinely downstream-ready — pulled via `rails g modelrails_ui:add <name>` with confidence.
+
+## The decisive constraint
+
+The gem's current test suite is **structural only**: it stubs ViewComponent so `.call` returns `""`, and the bare test env can't boot `Rails.env`. It **cannot verify rendering, ARIA, or AAA contrast** — the README defers that to "integration specs in the consuming app." Hardening 77 components without a render harness produces 77 components that *look* right and are *proven* nowhere. Therefore the program's long pole is **building gem-side verification first.**
+
+## Decisions (from brainstorm)
+
+- **Driver: roadmap-driven** — proactively harden all 77, not just on app demand.
+- **Verification: two-tier** — (0a) render + ARIA + token-contrast, no browser; then (0b) full browser axe-AAA per component.
+- **Sequence: app-need-first, then phase order** — Wave 1 = the modelrails_base gap-doc set (gets real app-gate proof); then phase 1→9 for the rest.
+
+## Program phases
+
+### Phase 0a — verification harness (FIRST; enabler)
+
+Add a minimal `test/dummy` Rails app + `ViewComponent::TestCase` so the gem can `render_inline(UI::XComponent.new(...))` and assert real HTML/ARIA with Capybara matchers. Keep `test_aaa_contrast.rb` as the AAA-token guarantee (hardened components inherit AAA by using the verified semantic tokens). Wire the render tests into the existing Ruby 3.2-4.0 + Appraisal matrix. Outcome: the gem becomes render-verifiable without a browser.
+
+### Phase 0b — browser axe-AAA (after the harness + early waves)
+
+Capybara + Playwright + axe at WCAG AAA per component, in the dummy app. The deeper proof tier, layered on once the fast harness has proven its worth. Heavier (browser infra in CI), so deliberately sequenced after 0a + the first hardening waves.
+
+### Phases 1…N — hardening waves
+
+- **Wave 1 (app-need):** the gap-doc priorities — `select`, `checkbox`, `radio_group`, `switch`/`toggle`, submit-via-`button`; then `badge`; then `data_table`/`alert`. These are also adopted into modelrails_base, earning **real browser axe-AAA proof via the app's gate** immediately, and proving the DoD + pipeline before scaling.
+- **Waves 2…N (phase order 1→9):** the remainder, folding in the 3 broken (`form_field`, `qr_code`, `input_otp`) and rough stubs (`tooltip`, …) as their phase comes up.
+
+## Definition of Done (per component, testable with the Phase-0a harness)
+
+A component is downstream-ready when, verified by the harness:
+
+1. **Renders** without error via `render_inline`.
+2. **AAA semantic tokens only** (`bg-interactive`, `text-text-*`, `focus:ring-interactive-focus`, `--form-input-height`) — no raw/guessed Tailwind; AAA inherited from the token-contrast tests.
+3. **Correct ARIA** — `role`, `aria-*`, label association — asserted on the rendered DOM.
+4. **Fail-loud guard** on enum props (raise in dev/test, fall back in prod) — the `coerce_variant` pattern.
+5. **Focus management** + 44px minimum touch targets.
+6. **Disabled / invalid** states.
+7. **i18n** for any user-facing strings.
+8. **Doc comment** — use-when + accessibility contract.
+9. **Slot/content API** — `content || label`, not hardcoded markup.
+10. **Template-backed Lookbook preview** — the copyable artifact, same treatment as the 6.
+
+## Per-component process
+
+Repeatable pipeline (the SP-style loop proven this session, now with real render tests):
+
+1. Read the rough template.
+2. Harden to the DoD.
+3. Write render + ARIA + token tests (Phase-0a harness).
+4. Add the Lookbook teaching preview.
+5. Run the harness (`rake` = test + rubocop) green.
+6. Commit (atomic, per component).
+
+**Parallelization:** components are independent files, so waves fan out across subagents/worktrees; the gem CI catches regressions. **Caution:** multi-file components (card, tabs, accordion, dialog: 2-6 `.rb.tt` + `.html.erb` + `_controller.js`) are larger units — JS-enabled ones need controller-wiring checks that the render harness alone can't fully cover (true interactive behavior lands in Phase 0b).
+
+## Tier ledger (usable mid-program)
+
+Maintain a status ledger (in `components.rb` metadata or `COMPONENT_STATUS.md`): `proven` / `hardened` / `experimental` / `broken`. A downstream dev pulling a component mid-program sees its real state — `checkbox` = `proven`, `tooltip` = `experimental` — so the library is honest and usable throughout, not just at the finish line.
+
+## Decomposition into plans
+
+This program is intentionally many plans, not one:
+
+- **Plan 1 — Phase 0a** (the harness). The first and gating plan.
+- **Plan 2 — Wave 1** (gap-doc components, ~7-8), once the harness exists.
+- **Plans 3…N — phase-order waves.**
+- **Plan (later) — Phase 0b** (browser axe-AAA).
+
+Each plan produces working, tested gem state on its own. This doc is the umbrella; `writing-plans` runs per phase.
+
+## Open items / risks
+
+- **Dummy-app footprint:** keep the `test/dummy` minimal — enough to render ViewComponents, not a full app. Watch the Appraisal matrix (rails-7.2/8.1) compatibility.
+- **JS components:** the render harness verifies markup/ARIA but not Stimulus behavior; interactive proof waits for Phase 0b (Playwright).
+- **AAA-via-tokens assumption:** holds only if components use the semantic tokens; the DoD's token-only rule + the render-class assertions enforce it, but a component that hardcodes a color would pass render tests while failing real AAA — Phase 0b axe is the backstop.
+- **Scale:** 77 components is a long program; the tier ledger + app-need-first sequencing keep value flowing throughout, but completion is measured in waves, not one pass.

--- a/docs/design/2026-06-03-phase-0a-render-harness-plan.md
+++ b/docs/design/2026-06-03-phase-0a-render-harness-plan.md
@@ -1,0 +1,284 @@
+# Phase 0a — Render Harness Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Give the gem the ability to actually RENDER a component and assert real HTML/ARIA (via `render_inline` + Capybara matchers), so every future hardening wave is verifiable — proven end-to-end on `button`.
+
+**Architecture:** The gem already loads `.rb.tt` templates by `eval`-ing them as plain Ruby (`test/test_components.rb`) — but against a STUBBED `ViewComponent::Base` (`.call` returns `""`). Phase 0a adds a SECOND, isolated test lane that loads the **real** `view_component` + a minimal Rails app context, evals a component template into a real class, and renders it. The structural lane (stub-based) and the render lane (real ViewComponent) **cannot share a Ruby process** (the stub `ViewComponent::Base` collides with the real one), so they run as **separate rake tasks**.
+
+**Tech Stack:** Ruby, Rails (`railties`/`rails` already deps), `view_component (>= 4.0)` (already a dep), Capybara (to ADD), Minitest. The gem's `mise.toml` is UNTRUSTED — every ruby/rake/rails command MUST be prefixed `PATH="/Users/dschmura/.local/share/mise/installs/ruby/4.0.4/bin:$PATH"` (NOT `mise exec`).
+
+**Design doc:** `docs/design/2026-06-03-component-hardening-program-design.md`
+
+**Scope:** the harness + `button` as proof ONLY. Do NOT harden any other component.
+
+---
+
+## File structure
+
+- Modify: `Gemfile` — add `capybara` (dev).
+- Modify: `Rakefile` — split tests into two tasks: `test:structural` (existing, stub-based) and `test:render` (new, real ViewComponent), each its own process; `rake test` runs both; default `rake` = `test` + rubocop.
+- Create: `test/render/render_test_helper.rb` — boots minimal Rails app + real `view_component`, evals component templates into real classes, provides `ViewComponent::TestCase`.
+- Create: `test/render/button_render_test.rb` — the proof render test.
+- Modify: `.github/workflows/main.yml` — only if the matrix doesn't already run the new task (it runs `rake`/`rake test`, which will include `test:render` once the Rakefile wires it).
+- Unchanged: `test/test_components.rb` (structural, keeps its stub), `test/test_aaa_contrast.rb` (the AAA-token guarantee).
+
+---
+
+### Task 1: Split the test suite so a real-ViewComponent lane can exist
+
+The structural lane stubs `ViewComponent::Base`; the render lane needs the real one. They must run in separate processes. Establish the split FIRST (with the render lane empty), so later tasks have somewhere isolated to live.
+
+**Files:** `Rakefile`, `Gemfile`
+
+- [ ] **Step 1: Note the current Rakefile** — it is exactly:
+
+```ruby
+require "bundler/gem_tasks"
+require "minitest/test_task"
+Minitest::TestTask.create        # one :test task, globs all test files into ONE process
+require "rubocop/rake_task"
+RuboCop::RakeTask.new
+task default: %i[test rubocop]
+```
+
+`Minitest::TestTask.create` loads every test file into a single `ruby` process — which is why the structural stub and a real `view_component` can't coexist. The split below gives each lane its own process.
+
+- [ ] **Step 2: Add Capybara (dev dep)**
+
+In `Gemfile`, add (near the other dev gems):
+
+```ruby
+gem "capybara", require: false
+```
+
+Run: `PATH="/Users/dschmura/.local/share/mise/installs/ruby/4.0.4/bin:$PATH" bundle install` → expect it resolves + installs capybara.
+
+- [ ] **Step 3: Define two test tasks + keep them separate processes**
+
+Replace the single `Minitest::TestTask.create` with two named tasks — each `Minitest::TestTask` shells out to its own `ruby` process, which is the isolation we need. The structural lane globs the top-level `test/test_*.rb` files (the existing stub-based suite); the render lane globs `test/render/**/*_test.rb`. New `Rakefile`:
+
+```ruby
+# frozen_string_literal: true
+
+require "bundler/gem_tasks"
+require "minitest/test_task"
+
+# Structural lane: stubs ViewComponent (test_components.rb), reads templates as text.
+Minitest::TestTask.create(:"test:structural") do |t|
+  t.test_globs = ["test/test_*.rb"]
+  t.warning = true
+end
+
+# Render lane: real view_component + a minimal Rails app (test/render/render_test_helper.rb).
+# MUST be a separate process from the structural lane (incompatible ViewComponent::Base).
+Minitest::TestTask.create(:"test:render") do |t|
+  t.libs << "test/render"
+  t.test_globs = ["test/render/**/*_test.rb"]
+  t.warning = false # Rails/ViewComponent emit harmless warnings under -w
+end
+
+task test: [:"test:structural", :"test:render"]
+
+require "rubocop/rake_task"
+RuboCop::RakeTask.new
+
+task default: %i[test rubocop]
+```
+
+(`test/test_*.rb` matches the existing structural files incl. the harmless `test_helper.rb`; `test/render/` is excluded from structural and owns the render lane.)
+
+- [ ] **Step 4: Run it to confirm the split works (render lane empty = passes trivially)**
+
+Run: `PATH="/Users/dschmura/.local/share/mise/installs/ruby/4.0.4/bin:$PATH" bundle exec rake test:structural` → expect the existing structural suite passes (same counts as before).
+Run: `PATH="/Users/dschmura/.local/share/mise/installs/ruby/4.0.4/bin:$PATH" bundle exec rake test:render` → expect "0 tests" (no render tests yet) and SUCCESS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add Gemfile Gemfile.lock Rakefile
+git commit -m "test(harness): split structural vs render test lanes; add capybara dev dep"
+```
+
+---
+
+### Task 2: Build the render harness (SPIKE → working `render_inline`)
+
+**This is the research-heavy enabler.** Goal: from a render test, `render_inline(UI::ButtonComponent.new("Save", variant: :primary))` must return REAL `<button>...</button>` HTML. The mechanism is uncertain enough to spike — but the gem already evals templates, so the recommended path is light.
+
+**Recommended approach (B-extended): minimal in-test Rails app + eval into real classes.** A full `test/dummy` directory app (approach A) is heavier and only needed if `render_inline` refuses to work without it. Try B first.
+
+**Files:** `test/render/render_test_helper.rb`
+
+- [ ] **Step 1: Consult ViewComponent's documented test setup**
+
+Use context7 (`mcp__plugin_context7_context7__resolve-library-id` "view_component" → `query-docs` for "test setup render_inline ViewComponent::TestCase minimal Rails application engine"). Confirm the minimal requirements for `render_inline`: ViewComponent 4 needs `Rails.application` initialized and `ViewComponent::Test::TestHelpers`/`ViewComponent::TestCase`. Note whether a bare `Rails::Application` subclass (no dummy dir) suffices, or a `test/dummy` app is required.
+
+- [ ] **Step 2: Write `test/render/render_test_helper.rb`** — minimal Rails app + real view_component + real ApplicationComponent + eval the install/add templates into real classes.
+
+Starting point to spike from (adjust per Step 1's findings):
+
+```ruby
+# frozen_string_literal: true
+
+require "rails"
+require "action_controller/railtie"
+require "view_component"
+require "capybara/minitest"
+
+# Minimal Rails app — just enough to host ViewComponent rendering. No dummy dir.
+class RenderHarnessApp < Rails::Application
+  config.eager_load = false
+  config.consider_all_requests_local = true
+  config.secret_key_base = "test"
+  config.logger = Logger.new(IO::NULL)
+end
+Rails.application.initialize! unless Rails.application.initialized?
+
+require "minitest/autorun"
+
+# Real base class (mirrors install/templates/application_component.rb.tt, with the
+# real ViewComponent::Base — NOT the structural stub).
+class ApplicationComponent < ViewComponent::Base
+  private
+
+  def cn(*classes)
+    classes.flatten.compact.reject { |c| c.to_s.empty? }.join(" ")
+  end
+end
+
+ADD_TEMPLATES = File.expand_path("../../lib/generators/modelrails_ui/add/templates", __dir__)
+
+# Eval a component template (plain Ruby; .tt is convention) into a real class.
+def load_component(*parts)
+  path = File.join(ADD_TEMPLATES, *parts)
+  eval File.read(path), TOPLEVEL_BINDING, path # rubocop:disable Security/Eval
+end
+
+module RenderHarness
+  include Capybara::Minitest::Assertions
+end
+```
+
+- [ ] **Step 3: Spike a smoke check that rendering works**
+
+Create a throwaway `test/render/smoke_render_test.rb`:
+
+```ruby
+require "render_test_helper"
+load_component "button", "button_component.rb.tt"
+
+class SmokeRenderTest < ViewComponent::TestCase
+  def test_button_renders_real_html
+    render_inline(UI::ButtonComponent.new("Save", variant: :primary))
+    assert_selector "button", text: "Save"
+  end
+end
+```
+
+Run: `PATH="/Users/dschmura/.local/share/mise/installs/ruby/4.0.4/bin:$PATH" bundle exec rake test:render`
+
+- **Success:** the assertion passes — `render_inline` produced a real `<button>Save</button>`. The harness works; proceed.
+- **If it fails** (Rails app won't init for render_inline / view paths missing / etc.): READ the error. The two likely fixes, in order: (a) include `ViewComponent::Test::TestHelpers` explicitly and ensure `ViewComponent::Base.config.view_component_path`/preview config isn't required; (b) if ViewComponent 4 genuinely needs an app on disk, FALL BACK to approach A — generate a minimal `test/dummy` app (`rails new test/dummy --minimal --skip-*`), add `view_component` to it, and run the gem's `install` + `add button` generators into it in the harness setup, then render. Document which approach won in a comment at the top of `render_test_helper.rb`.
+
+- [ ] **Step 4: Delete the throwaway smoke test once green**
+
+```bash
+rm test/render/smoke_render_test.rb
+```
+
+- [ ] **Step 5: Commit the harness**
+
+```bash
+git add test/render/render_test_helper.rb Gemfile.lock
+git commit -m "test(harness): real-ViewComponent render harness (render_inline works on a component)"
+```
+
+---
+
+### Task 3: Button proof render test (TDD)
+
+Prove the harness verifies the things the hardening DoD cares about: correct tag, AAA token classes, ARIA, and the fail-loud guard.
+
+**Files:** `test/render/button_render_test.rb`
+
+- [ ] **Step 1: Write the failing test**
+
+```ruby
+# frozen_string_literal: true
+
+require "render_test_helper"
+load_component "button", "button_component.rb.tt"
+
+class ButtonRenderTest < ViewComponent::TestCase
+  def test_primary_renders_button_with_aaa_tokens
+    render_inline(UI::ButtonComponent.new("Save changes", variant: :primary))
+    assert_selector "button[type='button']", text: "Save changes"
+    # AAA semantic tokens (the design-token guarantee), not raw Tailwind:
+    assert_selector "button.bg-interactive"
+    assert_selector "button.text-text-on-interactive"
+    assert_selector "button.focus\\:ring-interactive-focus"
+  end
+
+  def test_href_renders_anchor
+    render_inline(UI::ButtonComponent.new("Home", href: "/", variant: :primary))
+    assert_selector "a[href='/']", text: "Home"
+  end
+
+  def test_unknown_variant_raises
+    assert_raises(ArgumentError) do
+      render_inline(UI::ButtonComponent.new("X", variant: :bogus))
+    end
+  end
+end
+```
+
+- [ ] **Step 2: Run to verify it passes (harness from Task 2 makes it real)**
+
+Run: `PATH="/Users/dschmura/.local/share/mise/installs/ruby/4.0.4/bin:$PATH" bundle exec rake test:render`
+Expected: all pass. If a token assertion fails, INSPECT the rendered HTML (`puts page.native.to_html` in the test) and reconcile the selector with what `button_component.rb.tt` actually emits (the FILLED/VARIANTS class strings) — do NOT change the component; only fix the test selector to match reality.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add test/render/button_render_test.rb
+git commit -m "test(harness): button render test proves real HTML/ARIA + fail-loud guard"
+```
+
+---
+
+### Task 4: Wire CI + document the harness for future waves
+
+**Files:** `.github/workflows/main.yml` (verify only), `README.md`
+
+- [ ] **Step 1: Confirm the full default task is green locally**
+
+Run: `PATH="/Users/dschmura/.local/share/mise/installs/ruby/4.0.4/bin:$PATH" bundle exec rake`
+Expected: `test:structural` + `test:render` + rubocop all pass, 0 failures, 0 offenses. (If rubocop flags the new files — e.g. the `eval` — add a scoped `# rubocop:disable` with a comment, matching how `test_components.rb` handles its eval.)
+
+- [ ] **Step 2: Confirm CI runs the render lane**
+
+Read `.github/workflows/main.yml`. The jobs run `bundle exec rake` (default) and `appraisal ... rake test`. Since Task 1 made `rake test` depend on `test:render`, the matrix already covers it — confirm no job hardcodes only `test:structural`. If a job needs capybara available, ensure `bundle install` (already in the workflow) picks it up from the Gemfile. Make the minimal edit only if a job bypasses the new task.
+
+- [ ] **Step 3: Document the harness in README**
+
+Add a short "Verifying components (render tests)" section: how to write a render test for a component (`require "render_test_helper"`, `load_component`, `ViewComponent::TestCase`, `render_inline`, `assert_selector`), and that this is the verification basis for the hardening program (link the design doc). This is the on-ramp every future wave uses.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add README.md .github/workflows/main.yml
+git commit -m "docs(harness): document render-test on-ramp; confirm CI runs the render lane"
+```
+
+---
+
+## Out of scope (later phases)
+
+- Hardening any component other than `button` (Wave 1 onward).
+- Browser axe-AAA system tests (Phase 0b — Capybara+Playwright+axe in the dummy app).
+- A tier ledger (`COMPONENT_STATUS.md`) — introduced when Wave 1 starts producing `proven` components.
+
+## Risk note
+
+Task 2 is the only genuinely uncertain task. Its success criterion is concrete (button renders real HTML), and it has a documented fallback (approach A: a real `test/dummy` app) if the minimal-app route fails. Every later phase depends on Task 2 landing, so treat its green smoke test as the gate for the whole program.

--- a/gemfiles/rails_7.2.gemfile.lock
+++ b/gemfiles/rails_7.2.gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: ..
   specs:
-    view_primitives (0.1.0)
+    modelrails_ui (0.2.0)
       railties (>= 7.1)
       view_component (>= 4.0)
 
@@ -81,6 +81,8 @@ GEM
       minitest (>= 5.1)
       securerandom (>= 0.3)
       tzinfo (~> 2.0, >= 2.0.5)
+    addressable (2.9.0)
+      public_suffix (>= 2.0.2, < 8.0)
     appraisal (2.5.0)
       bundler
       rake
@@ -90,6 +92,15 @@ GEM
     benchmark (0.5.0)
     bigdecimal (4.1.2)
     builder (3.3.0)
+    capybara (3.40.0)
+      addressable
+      matrix
+      mini_mime (>= 0.1.3)
+      nokogiri (~> 1.11)
+      rack (>= 1.6.0)
+      rack-test (>= 0.6.3)
+      regexp_parser (>= 1.5, < 3.0)
+      xpath (~> 3.2)
     cgi (0.5.1)
     concurrent-ruby (1.3.6)
     connection_pool (3.0.2)
@@ -124,6 +135,7 @@ GEM
       net-pop
       net-smtp
     marcel (1.2.1)
+    matrix (0.4.3)
     mini_mime (1.1.5)
     minitest (6.0.6)
       drb (~> 2.0)
@@ -165,6 +177,7 @@ GEM
     psych (5.3.1)
       date
       stringio
+    public_suffix (7.0.5)
     racc (1.8.1)
     rack (3.2.6)
     rack-session (2.1.2)
@@ -274,6 +287,8 @@ GEM
       base64
       websocket-extensions (>= 0.1.0)
     websocket-extensions (0.1.5)
+    xpath (3.2.0)
+      nokogiri (~> 1.8)
     zeitwerk (2.8.2)
 
 PLATFORMS
@@ -288,16 +303,17 @@ PLATFORMS
 
 DEPENDENCIES
   appraisal
+  capybara
   irb
   lefthook
   minitest (>= 5.16)
+  modelrails_ui!
   rails (~> 7.2.0)
   rake (~> 13.0)
   rubocop-minitest
   rubocop-performance
   simplecov (~> 0.21)
   standard
-  view_primitives!
 
 CHECKSUMS
   actioncable (7.2.3) sha256=e15d17b245f1dfe7cafdda4a0c6f7ba8ebaab1af33884415e09cfef4e93ad4f9
@@ -311,6 +327,7 @@ CHECKSUMS
   activerecord (7.2.3) sha256=6facb7478ceb5f6baa9f0647daa50b4a3a43934997900f0011e6c667ff41a0d7
   activestorage (7.2.3) sha256=4c1422bbfaa60c89e7b43cc38ade7bd3b8dc81024c48a21c1ac56814cf34ca2f
   activesupport (7.2.3) sha256=5675c9770dac93e371412684249f9dc3c8cec104efd0624362a520ae685c7b10
+  addressable (2.9.0) sha256=7fdf6ac3660f7f4e867a0838be3f6cf722ace541dd97767fa42bc6cfa980c7af
   appraisal (2.5.0) sha256=36989221be127913b0dba8d114da2001e6b2dceea7bd4951200eaba764eed3ce
   ast (2.4.3) sha256=954615157c1d6a382bc27d690d973195e79db7f55e9765ac7c481c60bdb4d383
   base64 (0.3.0) sha256=27337aeabad6ffae05c265c450490628ef3ebd4b67be58257393227588f5a97b
@@ -318,6 +335,7 @@ CHECKSUMS
   bigdecimal (4.1.2) sha256=53d217666027eab4280346fba98e7d5b66baaae1b9c3c1c0ffe89d48188a3fbd
   builder (3.3.0) sha256=497918d2f9dca528fdca4b88d84e4ef4387256d984b8154e9d5d3fe5a9c8835f
   bundler (4.0.12) sha256=7f8b757d28dfb636e7b24fba2344ac6dd13b5b24f4b46d62573d483f211825ac
+  capybara (3.40.0) sha256=42dba720578ea1ca65fd7a41d163dd368502c191804558f6e0f71b391054aeef
   cgi (0.5.1) sha256=e93fcafc69b8a934fe1e6146121fa35430efa8b4a4047c4893764067036f18e9
   concurrent-ruby (1.3.6) sha256=6b56837e1e7e5292f9864f34b69c5a2cbc75c0cf5338f1ce9903d10fa762d5ab
   connection_pool (3.0.2) sha256=33fff5ba71a12d2aa26cb72b1db8bba2a1a01823559fb01d29eb74c286e62e0a
@@ -339,8 +357,10 @@ CHECKSUMS
   loofah (2.25.1) sha256=d436c73dbd0c1147b16c4a41db097942d217303e1f7728704b37e4df9f6d2e04
   mail (2.9.0) sha256=6fa6673ecd71c60c2d996260f9ee3dd387d4673b8169b502134659ece6d34941
   marcel (1.2.1) sha256=1678e9360e32f9eafa917c80029e2f6d10b2715c66a4b87b6d0da9b9cd1f859f
+  matrix (0.4.3) sha256=a0d5ab7ddcc1973ff690ab361b67f359acbb16958d1dc072b8b956a286564c5b
   mini_mime (1.1.5) sha256=8681b7e2e4215f2a159f9400b5816d85e9d8c6c6b491e96a12797e798f8bccef
   minitest (6.0.6) sha256=153ea36d1d987a62942382b61075745042a2b3123b1cd48f4c3675af9cc7d6f1
+  modelrails_ui (0.2.0)
   net-imap (0.6.4) sha256=9a5598c67a3022c284d98430ef1d4948e7dbdb62596f61081ea8ca933270a02b
   net-pop (0.1.2) sha256=848b4e982013c15b2f0382792268763b748cce91c9e91e36b0f27ed26420dff3
   net-protocol (0.2.2) sha256=aa73e0cba6a125369de9837b8d8ef82a61849360eba0521900e2c3713aa162a8
@@ -360,6 +380,7 @@ CHECKSUMS
   prettyprint (0.2.0) sha256=2bc9e15581a94742064a3cc8b0fb9d45aae3d03a1baa6ef80922627a0766f193
   prism (1.9.0) sha256=7b530c6a9f92c24300014919c9dcbc055bf4cdf51ec30aed099b06cd6674ef85
   psych (5.3.1) sha256=eb7a57cef10c9d70173ff74e739d843ac3b2c019a003de48447b2963d81b1974
+  public_suffix (7.0.5) sha256=1a8bb08f1bbea19228d3bed6e5ed908d1cb4f7c2726d18bd9cadf60bc676f623
   racc (1.8.1) sha256=4a7f6929691dbec8b5209a0b373bc2614882b55fc5d2e447a21aaa691303d62f
   rack (3.2.6) sha256=5ed78e1f73b2e25679bec7d45ee2d4483cc4146eb1be0264fc4d94cb5ef212c2
   rack-session (2.1.2) sha256=595434f8c0c3473ae7d7ac56ecda6cc6dfd9d37c0b2b5255330aa1576967ffe8
@@ -395,9 +416,9 @@ CHECKSUMS
   unicode-emoji (4.2.0) sha256=519e69150f75652e40bf736106cfbc8f0f73aa3fb6a65afe62fefa7f80b0f80f
   useragent (0.16.11) sha256=700e6413ad4bb954bb63547fa098dddf7b0ebe75b40cc6f93b8d54255b173844
   view_component (4.11.0) sha256=92df960575b8fa5e984522532df225ec333015a07a8105b3b1c200c655065517
-  view_primitives (0.1.0)
   websocket-driver (0.8.0) sha256=ed0dba4b943c22f17f9a734817e808bc84cdce6a7e22045f5315aa57676d4962
   websocket-extensions (0.1.5) sha256=1c6ba63092cda343eb53fc657110c71c754c56484aad42578495227d717a8241
+  xpath (3.2.0) sha256=6dfda79d91bb3b949b947ecc5919f042ef2f399b904013eb3ef6d20dd3a4082e
   zeitwerk (2.8.2) sha256=7212a61311083c604184b1ea2574b9aa05cd14f855a0841c06985cabe9181d12
 
 BUNDLED WITH

--- a/gemfiles/rails_8.1.gemfile.lock
+++ b/gemfiles/rails_8.1.gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: ..
   specs:
-    view_primitives (0.1.0)
+    modelrails_ui (0.2.0)
       railties (>= 7.1)
       view_component (>= 4.0)
 
@@ -82,6 +82,8 @@ GEM
       securerandom (>= 0.3)
       tzinfo (~> 2.0, >= 2.0.5)
       uri (>= 0.13.1)
+    addressable (2.9.0)
+      public_suffix (>= 2.0.2, < 8.0)
     appraisal (2.5.0)
       bundler
       rake
@@ -90,6 +92,15 @@ GEM
     base64 (0.3.0)
     bigdecimal (4.1.2)
     builder (3.3.0)
+    capybara (3.40.0)
+      addressable
+      matrix
+      mini_mime (>= 0.1.3)
+      nokogiri (~> 1.11)
+      rack (>= 1.6.0)
+      rack-test (>= 0.6.3)
+      regexp_parser (>= 1.5, < 3.0)
+      xpath (~> 3.2)
     concurrent-ruby (1.3.6)
     connection_pool (3.0.2)
     crass (1.0.6)
@@ -123,6 +134,7 @@ GEM
       net-pop
       net-smtp
     marcel (1.2.1)
+    matrix (0.4.3)
     mini_mime (1.1.5)
     minitest (6.0.6)
       drb (~> 2.0)
@@ -164,6 +176,7 @@ GEM
     psych (5.3.1)
       date
       stringio
+    public_suffix (7.0.5)
     racc (1.8.1)
     rack (3.2.6)
     rack-session (2.1.2)
@@ -273,6 +286,8 @@ GEM
       base64
       websocket-extensions (>= 0.1.0)
     websocket-extensions (0.1.5)
+    xpath (3.2.0)
+      nokogiri (~> 1.8)
     zeitwerk (2.8.2)
 
 PLATFORMS
@@ -287,16 +302,17 @@ PLATFORMS
 
 DEPENDENCIES
   appraisal
+  capybara
   irb
   lefthook
   minitest (>= 5.16)
+  modelrails_ui!
   rails (~> 8.1.0)
   rake (~> 13.0)
   rubocop-minitest
   rubocop-performance
   simplecov (~> 0.21)
   standard
-  view_primitives!
 
 CHECKSUMS
   action_text-trix (2.1.19) sha256=7012f59421009cf284aa651294896414d653a61a2417c9b8714c8476d2f74009
@@ -311,12 +327,14 @@ CHECKSUMS
   activerecord (8.1.3) sha256=8003be7b2466ba0a2a670e603eeb0a61dd66058fccecfc49901e775260ac70ab
   activestorage (8.1.3) sha256=0564ce9309143951a67615e1bb4e090ee54b8befed417133cae614479b46384d
   activesupport (8.1.3) sha256=21a5e0dfbd4c3ddd9e1317ec6a4d782fa226e7867dc70b0743acda81a1dca20e
+  addressable (2.9.0) sha256=7fdf6ac3660f7f4e867a0838be3f6cf722ace541dd97767fa42bc6cfa980c7af
   appraisal (2.5.0) sha256=36989221be127913b0dba8d114da2001e6b2dceea7bd4951200eaba764eed3ce
   ast (2.4.3) sha256=954615157c1d6a382bc27d690d973195e79db7f55e9765ac7c481c60bdb4d383
   base64 (0.3.0) sha256=27337aeabad6ffae05c265c450490628ef3ebd4b67be58257393227588f5a97b
   bigdecimal (4.1.2) sha256=53d217666027eab4280346fba98e7d5b66baaae1b9c3c1c0ffe89d48188a3fbd
   builder (3.3.0) sha256=497918d2f9dca528fdca4b88d84e4ef4387256d984b8154e9d5d3fe5a9c8835f
   bundler (4.0.12) sha256=7f8b757d28dfb636e7b24fba2344ac6dd13b5b24f4b46d62573d483f211825ac
+  capybara (3.40.0) sha256=42dba720578ea1ca65fd7a41d163dd368502c191804558f6e0f71b391054aeef
   concurrent-ruby (1.3.6) sha256=6b56837e1e7e5292f9864f34b69c5a2cbc75c0cf5338f1ce9903d10fa762d5ab
   connection_pool (3.0.2) sha256=33fff5ba71a12d2aa26cb72b1db8bba2a1a01823559fb01d29eb74c286e62e0a
   crass (1.0.6) sha256=dc516022a56e7b3b156099abc81b6d2b08ea1ed12676ac7a5657617f012bd45d
@@ -337,8 +355,10 @@ CHECKSUMS
   loofah (2.25.1) sha256=d436c73dbd0c1147b16c4a41db097942d217303e1f7728704b37e4df9f6d2e04
   mail (2.9.0) sha256=6fa6673ecd71c60c2d996260f9ee3dd387d4673b8169b502134659ece6d34941
   marcel (1.2.1) sha256=1678e9360e32f9eafa917c80029e2f6d10b2715c66a4b87b6d0da9b9cd1f859f
+  matrix (0.4.3) sha256=a0d5ab7ddcc1973ff690ab361b67f359acbb16958d1dc072b8b956a286564c5b
   mini_mime (1.1.5) sha256=8681b7e2e4215f2a159f9400b5816d85e9d8c6c6b491e96a12797e798f8bccef
   minitest (6.0.6) sha256=153ea36d1d987a62942382b61075745042a2b3123b1cd48f4c3675af9cc7d6f1
+  modelrails_ui (0.2.0)
   net-imap (0.6.4) sha256=9a5598c67a3022c284d98430ef1d4948e7dbdb62596f61081ea8ca933270a02b
   net-pop (0.1.2) sha256=848b4e982013c15b2f0382792268763b748cce91c9e91e36b0f27ed26420dff3
   net-protocol (0.2.2) sha256=aa73e0cba6a125369de9837b8d8ef82a61849360eba0521900e2c3713aa162a8
@@ -358,6 +378,7 @@ CHECKSUMS
   prettyprint (0.2.0) sha256=2bc9e15581a94742064a3cc8b0fb9d45aae3d03a1baa6ef80922627a0766f193
   prism (1.9.0) sha256=7b530c6a9f92c24300014919c9dcbc055bf4cdf51ec30aed099b06cd6674ef85
   psych (5.3.1) sha256=eb7a57cef10c9d70173ff74e739d843ac3b2c019a003de48447b2963d81b1974
+  public_suffix (7.0.5) sha256=1a8bb08f1bbea19228d3bed6e5ed908d1cb4f7c2726d18bd9cadf60bc676f623
   racc (1.8.1) sha256=4a7f6929691dbec8b5209a0b373bc2614882b55fc5d2e447a21aaa691303d62f
   rack (3.2.6) sha256=5ed78e1f73b2e25679bec7d45ee2d4483cc4146eb1be0264fc4d94cb5ef212c2
   rack-session (2.1.2) sha256=595434f8c0c3473ae7d7ac56ecda6cc6dfd9d37c0b2b5255330aa1576967ffe8
@@ -394,9 +415,9 @@ CHECKSUMS
   uri (1.1.1) sha256=379fa58d27ffb1387eaada68c749d1426738bd0f654d812fcc07e7568f5c57c6
   useragent (0.16.11) sha256=700e6413ad4bb954bb63547fa098dddf7b0ebe75b40cc6f93b8d54255b173844
   view_component (4.11.0) sha256=92df960575b8fa5e984522532df225ec333015a07a8105b3b1c200c655065517
-  view_primitives (0.1.0)
   websocket-driver (0.8.0) sha256=ed0dba4b943c22f17f9a734817e808bc84cdce6a7e22045f5315aa57676d4962
   websocket-extensions (0.1.5) sha256=1c6ba63092cda343eb53fc657110c71c754c56484aad42578495227d717a8241
+  xpath (3.2.0) sha256=6dfda79d91bb3b949b947ecc5919f042ef2f399b904013eb3ef6d20dd3a4082e
   zeitwerk (2.8.2) sha256=7212a61311083c604184b1ea2574b9aa05cd14f855a0841c06985cabe9181d12
 
 BUNDLED WITH

--- a/modelrails_ui.gemspec
+++ b/modelrails_ui.gemspec
@@ -31,5 +31,6 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency "rails", ">= 7.1"
   spec.add_development_dependency "simplecov", "~> 0.21"
   spec.add_development_dependency "appraisal"
+  spec.add_development_dependency "capybara" # render-test assertions (ViewComponent::TestCase matchers)
   spec.add_development_dependency "lefthook"
 end

--- a/test/render/button_render_test.rb
+++ b/test/render/button_render_test.rb
@@ -1,0 +1,33 @@
+# frozen_string_literal: true
+
+require "render_test_helper"
+load_component "button", "button_component.rb.tt"
+
+class ButtonRenderTest < ViewComponent::TestCase
+  def test_primary_renders_correct_tag_and_text
+    render_inline(UI::ButtonComponent.new("Save changes", variant: :primary))
+
+    assert_selector "button[type='button']", text: "Save changes"
+  end
+
+  # AAA semantic tokens (the design-token guarantee), not raw Tailwind:
+  def test_primary_renders_with_aaa_tokens
+    render_inline(UI::ButtonComponent.new("Save changes", variant: :primary))
+
+    assert_selector "button.bg-interactive"
+    assert_selector "button.text-text-on-interactive"
+    assert_selector "button.focus\\:ring-interactive-focus"
+  end
+
+  def test_href_renders_anchor
+    render_inline(UI::ButtonComponent.new("Home", href: "/", variant: :primary))
+
+    assert_selector "a[href='/']", text: "Home"
+  end
+
+  def test_unknown_variant_raises
+    assert_raises(ArgumentError) do
+      render_inline(UI::ButtonComponent.new("X", variant: :bogus))
+    end
+  end
+end

--- a/test/render/render_test_helper.rb
+++ b/test/render/render_test_helper.rb
@@ -1,0 +1,48 @@
+# frozen_string_literal: true
+
+# Approach: minimal in-test Rails application (no test/dummy on disk).
+# ViewComponent::TestCase requires an initialized Rails.application + ActionView.
+# We boot a bare Rails::Application here, which is sufficient for render_inline.
+
+require "rails"
+require "action_controller/railtie"
+require "action_view/railtie"
+require "view_component"
+require "view_component/test_helpers"
+
+class RenderHarnessApp < Rails::Application
+  config.eager_load = false
+  config.consider_all_requests_local = true
+  config.secret_key_base = "test_secret_key_base_render_harness"
+  config.logger = Logger.new(IO::NULL)
+  config.cache_classes = true
+  # Silence the "couldn't find file" asset warnings
+  config.assets = ActiveSupport::OrderedOptions.new if config.respond_to?(:assets)
+end
+
+Rails.application.initialize! unless Rails.application.initialized?
+
+require "view_component/test_case"
+require "minitest/autorun"
+
+# Real ApplicationComponent — mirrors install/templates/application_component.rb.tt
+# exactly (cn is inlined; no gem runtime dependency).
+class ApplicationComponent < ViewComponent::Base
+  private
+
+  def cn(*classes)
+    classes.flatten.compact.reject { |c| c.to_s.empty? }.join(" ")
+  end
+end
+
+ADD_TEMPLATES = File.expand_path("../../lib/generators/modelrails_ui/add/templates", __dir__)
+
+# Eval a component template (.rb.tt is plain Ruby) into a real class under the
+# real ViewComponent::Base hierarchy.
+def load_component(*parts)
+  path = File.join(ADD_TEMPLATES, *parts)
+  eval File.read(path), TOPLEVEL_BINDING, path # rubocop:disable Security/Eval
+end
+
+# Wire up the UI acronym inflection so UI::ButtonComponent resolves correctly.
+ActiveSupport::Inflector.inflections(:en) { |i| i.acronym "UI" }

--- a/test/render/render_test_helper.rb
+++ b/test/render/render_test_helper.rb
@@ -22,6 +22,8 @@ end
 
 Rails.application.initialize! unless Rails.application.initialized?
 
+# ViewComponent 4 wires TestCase against the initialized app (hooks into ActionView);
+# this require MUST come after Rails.application.initialize! or the wiring is incomplete.
 require "view_component/test_case"
 require "minitest/autorun"
 


### PR DESCRIPTION
## What

Kicks off the **component-hardening program** (make all 77 components downstream-ready) by building its gating dependency: a **render-test harness** so the gem can verify rendered HTML/ARIA — which its structural-only suite never could.

Includes the program **design doc** + the Phase 0a **plan** (`docs/design/`), and the Phase 0a implementation:

- **Two test lanes** (`rake test` runs both, in separate processes): `test:structural` (existing, stubs ViewComponent) and `test:render` (new, **real** view_component + a minimal in-test Rails app). They can't share a process — the stub and real `ViewComponent::Base` collide — hence the split.
- **`test/render/render_test_helper.rb`** — boots a bare `Rails::Application` (no on-disk `test/dummy`) and reuses the gem's existing eval-the-template trick against a *real* `ApplicationComponent < ViewComponent::Base`, so `render_inline(UI::ButtonComponent.new(...))` produces real HTML.
- **`test/render/button_render_test.rb`** — proves it: real `<button>` tag, the AAA semantic token classes, the `href:`→`<a>` branch, and the fail-loud guard raising through `render_inline`.
- **README on-ramp** so every future component wave adds a render test in ~6 lines.

## Why it matters

The README already said "rendering/ARIA is verified by integration specs in the consuming app." Roadmap-driven hardening of 77 components needs the gem itself to verify — this harness is that capability. AAA contrast is inherited from `test_aaa_contrast.rb` (token ratios), so a render test that asserts a component uses the semantic tokens inherits AAA without a browser. (Browser axe-AAA is a later phase.)

## Verification

Full `rake` green: **test:structural 441/0 + test:render 4/0 + rubocop 0 offenses.** Scope is surgical — 6 files, **zero `lib/`/component changes**, no `test/dummy/`. Reviewed per-task + a holistic final review.

## Notes for the next wave (Wave 1)

- The `eval`-based `load_component` works on pure-Ruby `.rb.tt` templates (button is); a component template with real ERB `<%= %>` interpolation would need a pre-process step.
- `ApplicationComponent` is a shared top-level constant in the render process — fine now, worth awareness as many components load.
- The one non-obvious gotcha (documented inline): `require "view_component/test_case"` must come **after** `Rails.application.initialize!`.

Design: `docs/design/2026-06-03-component-hardening-program-design.md` · Plan: `docs/design/2026-06-03-phase-0a-render-harness-plan.md`. Scope: harness + button proof ONLY — no component hardening (that's Wave 1+).