### PR TITLE
feat(alert): harden to DoD + render test + Lookbook preview + COMPONENT_STATUS (Wave 1 exemplar)

### DIFF
--- a/COMPONENT_STATUS.md
+++ b/COMPONENT_STATUS.md
@@ -23,3 +23,10 @@ without extra verification.
 | data_table | experimental | ❌ | ❌ | Wave 1 sub-wave 2 (kbd sort, 44px) |
 
 All other gem components: **experimental** (unverified) unless listed above.
+
+**Sibling templates to copy:** `alert` is the canonical Wave 1 reference. Copy its render test
+(`test/render/alert_render_test.rb`), template-backed preview, and — for 0b — its preview-host
+axe-AAA system spec shape (`spec/system/ui/alert_component_spec.rb` in the app: visit the preview
+URL, scope axe to the component subtree by role, assert `axe_clean_in_both_themes?` with **no**
+color-contrast exclude). `button` predates the preview-host 0b convention (its 0b was proven via
+in-page adoption), so follow `alert` for the system-spec pattern, not `button`.

--- a/COMPONENT_STATUS.md
+++ b/COMPONENT_STATUS.md
@@ -1,0 +1,25 @@
+# Component Status
+
+Tier ledger for the modelrails_ui hardening program (see
+`docs/design/2026-06-03-component-hardening-program-design.md`). Keeps the library
+honest mid-program: only `proven`/`hardened` components are safe to adopt downstream
+without extra verification.
+
+- **proven** — render test + real app browser-axe AAA proof (0a + 0b).
+- **hardened** — meets the 10-point DoD with a render test (0a); app adoption in progress.
+- **experimental** — structurally present but unverified. Adopt at your own risk.
+- **broken** — known generation/runtime bug. Do not adopt.
+
+| Component | Tier | Render test | App-adopted (axe) | Notes |
+| --- | --- | --- | --- | --- |
+| button | proven | ✅ | ✅ | SP1 exemplar |
+| alert | hardened | ✅ | ⏳ | Wave 1 exemplar (app adoption in `feat/ui-alert-exemplar`) |
+| select | experimental | ❌ | ❌ | Wave 1 sub-wave 1 (native `<select>` target) |
+| checkbox | experimental | ❌ | ❌ | Wave 1 sub-wave 1 |
+| radio_group | experimental | ❌ | ❌ | Wave 1 sub-wave 1 |
+| switch | experimental | ❌ | ❌ | Wave 1 sub-wave 1 (aria-checked sync bug) |
+| toggle | experimental | ❌ | ❌ | Wave 1 sub-wave 1 (sub-44px target) |
+| badge | experimental | ❌ | ❌ | Wave 1 sub-wave 2 |
+| data_table | experimental | ❌ | ❌ | Wave 1 sub-wave 2 (kbd sort, 44px) |
+
+All other gem components: **experimental** (unverified) unless listed above.

--- a/lib/generators/modelrails_ui/add/templates/alert/alert_component.rb.tt
+++ b/lib/generators/modelrails_ui/add/templates/alert/alert_component.rb.tt
@@ -1,32 +1,61 @@
 # frozen_string_literal: true
 
 module UI
+  # # Alert
+  #
+  # An inline contextual message banner — NOT the flash/toast pipeline. Renders a
+  # `<div>` live region with semantics matched to its urgency and an AAA-tuned color
+  # treatment.
+  #
+  # ## Use when
+  # - You need an inline, in-page message tied to surrounding content: a form-level
+  #   error summary, a destructive-action warning, an empty-state notice.
+  #
+  # ## Don't use when
+  # - It's an ephemeral flash/notice — that's the app's toast system (`shared/_toasts`).
+  #
+  # ## Accessibility contract
+  # - **Guarantees:** a live region matched to urgency — `role="status"`/`aria-live="polite"`
+  #   for the neutral `default`, `role="alert"`/`aria-live="assertive"` for `destructive` —
+  #   and AAA-contrast text on the banner surface.
+  # - **You supply:** a title and/or description (kwargs or the `alert_title` /
+  #   `alert_description` slots) and a valid `variant` (an unknown one raises in development).
+  #
+  # ## Variants
+  # `default` · `destructive`
   class AlertComponent < ApplicationComponent
     OUTER_CLASSES = "relative grid w-full grid-cols-[0_1fr] items-start gap-y-0.5 rounded-lg border " \
                     "px-4 py-3 text-sm has-[>svg]:grid-cols-[calc(var(--spacing)*4)_1fr] " \
                     "has-[>svg]:gap-x-3 [&>svg]:size-4 [&>svg]:translate-y-0.5 [&>svg]:text-current"
 
+    # `text-danger` (not `text-danger/90`): an opacity modifier strictly lowers
+    # contrast and risks the AAA 7:1 floor on the description text.
     VARIANTS = {
       default: "bg-surface-raised text-text-body",
-      destructive: "bg-surface-raised text-danger [&>svg]:text-current *:data-[slot=alert-description]:text-danger/90"
+      destructive: "bg-surface-raised text-danger [&>svg]:text-current *:data-[slot=alert-description]:text-danger"
     }.freeze
+
+    # Live-region semantics by urgency: neutral announces politely, errors assertively.
+    ROLES = { default: "status", destructive: "alert" }.freeze
+    LIVE  = { default: "polite", destructive: "assertive" }.freeze
 
     renders_one :alert_title, "UI::AlertComponent::TitleComponent"
     renders_one :alert_description, "UI::AlertComponent::DescriptionComponent"
 
-    # title: and description: are kwargs shorthands for plain-text content.
-    # Use slots (with_alert_title / with_alert_description) for rich HTML content.
+    # title: and description: are kwarg shorthands for plain-text content.
+    # Use slots (with_alert_title / with_alert_description) for rich HTML.
     # Slots take precedence over kwargs when both are provided.
     def initialize(variant: :default, title: nil, description: nil)
-      @variant = variant.to_sym
+      @variant = coerce_variant(variant.to_sym)
       @title = title
       @description = description
     end
 
     def call
       content_tag(:div, safe_join([resolved_title, resolved_description].compact),
-        role: "alert",
-        class: cn(OUTER_CLASSES, VARIANTS.fetch(@variant, VARIANTS[:default])))
+        role: ROLES.fetch(@variant),
+        "aria-live": LIVE.fetch(@variant),
+        class: cn(OUTER_CLASSES, VARIANTS.fetch(@variant)))
     end
 
     class TitleComponent < ApplicationComponent
@@ -46,6 +75,23 @@ module UI
     end
 
     private
+
+    # Fail loud on an unknown variant in development/test so misuse is caught
+    # immediately; fall back to :default in production so a bad variant never
+    # 500s a page. The Rails.respond_to?(:env) guard stays correct even when the Rails
+    # module is defined but Rails.env isn't booted (the gem's Rails-less tests load
+    # rails/generators, which defines Rails without Rails.env).
+    def coerce_variant(variant)
+      return variant if VARIANTS.key?(variant)
+
+      unless defined?(Rails) && Rails.respond_to?(:env) && Rails.env.production?
+        raise ArgumentError,
+          "UI::AlertComponent: unknown variant #{variant.inspect}. " \
+          "Expected one of: #{VARIANTS.keys.join(", ")}."
+      end
+
+      :default
+    end
 
     def resolved_title
       alert_title || (@title && content_tag(:h5, @title, class: TitleComponent::CLASSES))

--- a/lib/generators/modelrails_ui/lookbook/templates/previews/ui/alert_component_preview.rb
+++ b/lib/generators/modelrails_ui/lookbook/templates/previews/ui/alert_component_preview.rb
@@ -1,0 +1,46 @@
+# frozen_string_literal: true
+
+module UI
+  # # Alert
+  #
+  # An inline contextual message banner (NOT the flash/toast pipeline). Announced
+  # politely (`role="status"`) when neutral, assertively (`role="alert"`) when
+  # destructive.
+  #
+  # ## Use when
+  # - An inline, in-page message tied to surrounding content (form error summary,
+  #   destructive-action warning, empty-state notice).
+  #
+  # ## Don't use when
+  # - It's an ephemeral flash — use the app's toast system (`shared/_toasts`).
+  #
+  # ## Accessibility contract
+  # - **Guarantees:** an urgency-matched live region and AAA-contrast text.
+  # - **You supply:** a title and/or description, and a valid `variant`.
+  #
+  # ## Variants
+  # `default` · `destructive`
+  class AlertComponentPreview < ViewComponent::Preview
+    include UIHelper
+
+    # Neutral, informational message — announced politely (role=status).
+    def default
+    end
+
+    # Error / destructive message — announced assertively (role=alert).
+    def destructive
+    end
+
+    # Rich content via slots — a destructive summary wrapping a list of errors.
+    def with_slots
+    end
+
+    # ## Don't — an empty alert
+    #
+    # An alert with no title and no description renders an empty live region —
+    # screen-reader users hear nothing. Always pass a message.
+    # @label Don't · empty alert
+    def dont_empty
+    end
+  end
+end

--- a/lib/generators/modelrails_ui/lookbook/templates/previews/ui/alert_component_preview/default.html.erb
+++ b/lib/generators/modelrails_ui/lookbook/templates/previews/ui/alert_component_preview/default.html.erb
@@ -1,0 +1,1 @@
+<%= ui :alert, title: "Heads up", description: "Your trial ends in 3 days." %>

--- a/lib/generators/modelrails_ui/lookbook/templates/previews/ui/alert_component_preview/destructive.html.erb
+++ b/lib/generators/modelrails_ui/lookbook/templates/previews/ui/alert_component_preview/destructive.html.erb
@@ -1,0 +1,1 @@
+<%= ui :alert, variant: :destructive, title: "Couldn't save changes", description: "Please fix the highlighted fields." %>

--- a/lib/generators/modelrails_ui/lookbook/templates/previews/ui/alert_component_preview/dont_empty.html.erb
+++ b/lib/generators/modelrails_ui/lookbook/templates/previews/ui/alert_component_preview/dont_empty.html.erb
@@ -1,1 +1,2 @@
-<%= ui :alert, variant: :destructive # ✗ no title/description — nothing to announce %>
+<%# ✗ no title/description — nothing to announce %>
+<%= ui :alert, variant: :destructive %>

--- a/lib/generators/modelrails_ui/lookbook/templates/previews/ui/alert_component_preview/dont_empty.html.erb
+++ b/lib/generators/modelrails_ui/lookbook/templates/previews/ui/alert_component_preview/dont_empty.html.erb
@@ -1,0 +1,1 @@
+<%= ui :alert, variant: :destructive # ✗ no title/description — nothing to announce %>

--- a/lib/generators/modelrails_ui/lookbook/templates/previews/ui/alert_component_preview/with_slots.html.erb
+++ b/lib/generators/modelrails_ui/lookbook/templates/previews/ui/alert_component_preview/with_slots.html.erb
@@ -1,0 +1,9 @@
+<%= ui :alert, variant: :destructive do |alert| %>
+  <% alert.with_alert_title { "2 errors prevented saving" } %>
+  <% alert.with_alert_description do %>
+    <ul class="list-disc list-inside">
+      <li>Title can't be blank</li>
+      <li>Status is not included in the list</li>
+    </ul>
+  <% end %>
+<% end %>

--- a/test/render/alert_render_test.rb
+++ b/test/render/alert_render_test.rb
@@ -1,0 +1,44 @@
+# frozen_string_literal: true
+
+require "render_test_helper"
+load_component "alert", "alert_component.rb.tt"
+
+class AlertRenderTest < ViewComponent::TestCase
+  def test_default_variant_is_a_polite_status_region
+    render_inline(UI::AlertComponent.new(title: "Heads up"))
+
+    assert_selector "div[role='status'][aria-live='polite']", text: "Heads up"
+  end
+
+  def test_destructive_variant_is_an_assertive_alert_region
+    render_inline(UI::AlertComponent.new(variant: :destructive, title: "Couldn't save"))
+
+    assert_selector "div[role='alert'][aria-live='assertive']", text: "Couldn't save"
+  end
+
+  # AAA semantic tokens (the design-token guarantee), not raw Tailwind:
+  def test_renders_with_aaa_tokens
+    render_inline(UI::AlertComponent.new(title: "X"))
+
+    assert_selector "div.bg-surface-raised"
+    assert_selector "div.text-text-body"
+  end
+
+  def test_renders_title_and_description_slots
+    render_inline(UI::AlertComponent.new(variant: :destructive)) do |alert|
+      alert.with_alert_title { "2 errors" }
+      alert.with_alert_description { "Title can't be blank" }
+    end
+
+    assert_selector "h5", text: "2 errors"
+    assert_selector "div[data-slot='alert-description']", text: "Title can't be blank"
+    # AAA regression guard: destructive uses text-danger (not text-danger/90).
+    assert_selector "div.text-danger"
+  end
+
+  def test_unknown_variant_raises
+    assert_raises(ArgumentError) do
+      render_inline(UI::AlertComponent.new(variant: :bogus))
+    end
+  end
+end


### PR DESCRIPTION
## Summary

First component hardened in the Wave 1 program — the pattern-setting exemplar.

- Harden `alert` to the 10-point DoD: fail-loud `coerce_variant` guard (raises in dev/test, falls back in prod), urgency-matched live region (`default` → `role=status`/`aria-live=polite`, `destructive` → `role=alert`/`aria-live=assertive`), and AAA-safe `text-danger` description token (dropped the `/90` opacity modifier).
- Add `test/render/alert_render_test.rb` — first slotted component proven through the 0a render harness (`renders_one` resolves correctly).
- Template-backed Lookbook preview (4 scenarios incl. a labeled "Don't").
- New `COMPONENT_STATUS.md` tier ledger; `alert` = `hardened`, plus a note marking it the canonical 0b preview-host axe-spec template for the 7 sibling components.

## Test Plan

- [x] `rake` green — `test:structural` 441/0 + `test:render` 9/0 + rubocop clean
- [x] Adopted and browser-axe-AAA-proven in the app (companion `modelrails_base` PR)