### PR TITLE
feat(form-controls): harden checkbox/select/radio_group/switch/toggle to DoD (Wave 1 sub-wave 1)

### DIFF
--- a/COMPONENT_STATUS.md
+++ b/COMPONENT_STATUS.md
@@ -13,9 +13,9 @@ without extra verification.
 | Component | Tier | Render test | App-adopted (axe) | Notes |
 | --- | --- | --- | --- | --- |
 | button | proven | ✅ | ✅ | SP1 exemplar |
-| alert | hardened | ✅ | ⏳ | Wave 1 exemplar (app adoption in `feat/ui-alert-exemplar`) |
+| alert | proven | ✅ | ✅ | Wave 1 exemplar (gem #4 + app #222 merged) |
 | select | experimental | ❌ | ❌ | Wave 1 sub-wave 1 (native `<select>` target) |
-| checkbox | experimental | ❌ | ❌ | Wave 1 sub-wave 1 |
+| checkbox | hardened | ✅ | ⏳ | Wave 1 sub-wave 1 form-control pattern-setter |
 | radio_group | experimental | ❌ | ❌ | Wave 1 sub-wave 1 |
 | switch | experimental | ❌ | ❌ | Wave 1 sub-wave 1 (aria-checked sync bug) |
 | toggle | experimental | ❌ | ❌ | Wave 1 sub-wave 1 (sub-44px target) |

--- a/COMPONENT_STATUS.md
+++ b/COMPONENT_STATUS.md
@@ -14,11 +14,11 @@ without extra verification.
 | --- | --- | --- | --- | --- |
 | button | proven | ✅ | ✅ | SP1 exemplar |
 | alert | proven | ✅ | ✅ | Wave 1 exemplar (gem #4 + app #222 merged) |
-| select | experimental | ❌ | ❌ | Wave 1 sub-wave 1 (native `<select>` target) |
+| select | hardened | ✅ | ⏳ | Wave 1 sub-wave 1 (native AAA select; id fallback; invalid/describedby) |
 | checkbox | hardened | ✅ | ⏳ | Wave 1 sub-wave 1 form-control pattern-setter |
-| radio_group | experimental | ❌ | ❌ | Wave 1 sub-wave 1 |
-| switch | experimental | ❌ | ❌ | Wave 1 sub-wave 1 (aria-checked sync bug) |
-| toggle | experimental | ❌ | ❌ | Wave 1 sub-wave 1 (sub-44px target) |
+| radio_group | hardened | ✅ | ⏳ | Wave 1 sub-wave 1 (group aria-label; per-option ids; invalid on group) |
+| switch | hardened | ✅ | ⏳ | Wave 1 sub-wave 1 (aria-checked bug fixed; peer-sibling track; 44px target) |
+| toggle | hardened | ✅ | ⏳ | Wave 1 sub-wave 1 (fail-loud size guard; 44px sizes; sm≈default nit deferred) |
 | badge | experimental | ❌ | ❌ | Wave 1 sub-wave 2 |
 | data_table | experimental | ❌ | ❌ | Wave 1 sub-wave 2 (kbd sort, 44px) |
 

--- a/lib/generators/modelrails_ui/add/templates/checkbox/checkbox_component.rb.tt
+++ b/lib/generators/modelrails_ui/add/templates/checkbox/checkbox_component.rb.tt
@@ -1,6 +1,31 @@
 # frozen_string_literal: true
 
 module UI
+  # # Checkbox
+  #
+  # A single labelled native checkbox — the form-control pattern-setter for the
+  # library (radio_group and switch copy its `invalid:` / `describedby:` / id-fallback
+  # API). Renders a native `<input type="checkbox">` so it inherits the browser's
+  # keyboard operability and form semantics for free.
+  #
+  # ## Use when
+  # - A single on/off choice tied to a label: "Accept terms", "Remember me",
+  #   "Email me about updates".
+  #
+  # ## Don't use when
+  # - It's an immediate-effect setting toggle with no form submit — use `switch`.
+  # - You have a mutually-exclusive set of options — use `radio_group`.
+  #
+  # ## Accessibility contract
+  # - **Guarantees:** a labelled, keyboard-operable checkbox with an AAA focus ring.
+  #   The control always carries an `id` (falling back from `id` → sanitized `name`
+  #   → object-based id) so the `<label for=...>` association never breaks, and the
+  #   clickable label provides the larger pointer target (AAA 2.5.5 target-size).
+  # - **You supply:** a `label` and, on error, `invalid: true` (sets `aria-invalid`)
+  #   plus `describedby:` pointing at the error message's id.
+  #
+  # No variant axis (single appearance), so there is no `coerce_variant` fail-loud
+  # guard here — unlike the enum-driven components (alert, button).
   class CheckboxComponent < ApplicationComponent
     BASE = "peer size-4 shrink-0 rounded-[4px] border border-border-strong shadow-xs transition-shadow outline-none " \
            "focus-visible:border-border-focus focus-visible:ring-[3px] focus-visible:ring-interactive-focus " \
@@ -9,10 +34,16 @@ module UI
            "checked:border-interactive checked:bg-interactive checked:text-text-on-interactive " \
            " "
 
-    def initialize(label: nil, checked: false, **html_attrs)
+    # invalid: drives the app's server-validation-driven aria-invalid posture.
+    # describedby: wires the input to its error message's id (aria-describedby).
+    def initialize(label: nil, checked: false, invalid: false, describedby: nil, **html_attrs)
       @label = label
       @checked = checked
-      @id = html_attrs[:id] || html_attrs[:name]&.gsub(/\W/, "_")
+      @invalid = invalid
+      @describedby = describedby
+      # Always resolve an id so the label association never breaks: explicit id →
+      # sanitized name → an object-based fallback (mirrors the switch template).
+      @id = html_attrs[:id] || html_attrs[:name]&.gsub(/\W/, "_") || "checkbox_#{object_id}"
       @extra_class = html_attrs.delete(:class)
       @html_attrs = html_attrs
     end
@@ -33,13 +64,18 @@ module UI
     def checkbox_input
       attrs = @html_attrs.merge(
         type: "checkbox",
+        id: @id,
         class: cn(BASE, @extra_class)
       )
       attrs[:checked] = true if @checked
-      attrs[:id] = @id if @id
+      attrs[:"aria-invalid"] = "true" if @invalid
+      attrs[:"aria-describedby"] = @describedby if @describedby
       content_tag(:input, nil, **attrs)
     end
 
+    # The label is the input's peer sibling so `peer-disabled:` style hooks apply,
+    # and it is the larger clickable pointer target that satisfies AAA 2.5.5 — the
+    # visual control stays size-4 (16px) by design; do not bloat it.
     def label_tag
       content_tag(:label,
         @label,

--- a/lib/generators/modelrails_ui/add/templates/radio_group/radio_group_component.rb.tt
+++ b/lib/generators/modelrails_ui/add/templates/radio_group/radio_group_component.rb.tt
@@ -56,12 +56,19 @@ module UI
     private
 
     def group_attrs
-      attrs = { class: cn("grid gap-2", @extra_class), role: "radiogroup" }
+      # Component wins on its a11y contract: merge caller html_attrs FIRST, then
+      # apply role/aria as overrides so a caller can't clobber the group's
+      # accessible name, invalid state, or radiogroup role. Keys are stringified
+      # so the overrides land on the same key whether the caller passed `role:`
+      # or `"role"` (and likewise for the aria-* attributes).
+      attrs = { "class" => cn("grid gap-2", @extra_class) }
+      @html_attrs.each { |k, v| attrs[k.to_s] = v }
+      attrs["role"] = "radiogroup"
       attrs["aria-label"] = @label if @label.present?
       attrs["aria-labelledby"] = @labelledby if @labelledby.present?
       attrs["aria-invalid"] = "true" if @invalid
       attrs["aria-describedby"] = @describedby if @describedby.present?
-      attrs.merge(@html_attrs)
+      attrs
     end
 
     def radio_item(item)
@@ -85,7 +92,7 @@ module UI
     def radio_label(item, id)
       content_tag(:label, item[:label],
         for: id,
-        class: "text-sm font-medium leading-none peer-disabled:cursor-not-allowed peer-disabled:opacity-70")
+        class: "text-sm font-medium leading-none")
     end
   end
 end

--- a/lib/generators/modelrails_ui/add/templates/radio_group/radio_group_component.rb.tt
+++ b/lib/generators/modelrails_ui/add/templates/radio_group/radio_group_component.rb.tt
@@ -1,20 +1,50 @@
 # frozen_string_literal: true
 
 module UI
+  # # RadioGroup
+  #
+  # A labelled radio group — a `role="radiogroup"` wrapping one native
+  # `<input type="radio">` per option, each tied to its own `<label for>`.
+  #
+  # ## Use when
+  # - You need a single-choice control over a small, fixed set of options
+  #   (a billing plan, a visibility level, a notification cadence).
+  #
+  # ## Don't use when
+  # - There are many options or they're loaded dynamically — use `ui :select`.
+  # - The choice is binary on/off — use `ui :toggle` or `ui :checkbox`.
+  #
+  # ## Accessibility contract
+  # - **Guarantees:** the group exposes an accessible name (`aria-label` from `label:`,
+  #   or `aria-labelledby` from `labelledby:`), each option's `<label for>` matches its
+  #   input `id`, and on error the group carries `aria-invalid="true"` plus an
+  #   `aria-describedby` link to the error/hint element.
+  # - **You supply:** a group `label:` (or `labelledby:`), `items:` as
+  #   `[{ value:, label:, checked?:, disabled?: }]`, and on error `invalid:` +
+  #   `describedby:` pointing at a sibling element that holds the message.
+  #
+  # No fail-loud guard — there is no enum axis to validate.
   class RadioGroupComponent < ApplicationComponent
-    # items: [{ value:, label:, checked: (optional) }]
-    def initialize(name:, items: [], **html_attrs)
+    # items: [{ value:, label:, checked: (optional), disabled: (optional) }]
+    #
+    # Group accessibility/form params, mirroring the shared form-control API:
+    #   label:       sets the group's accessible name via `aria-label`
+    #   labelledby:  sets `aria-labelledby` (point at a visible heading's id instead)
+    #   invalid:     sets `aria-invalid="true"` on the group
+    #   describedby: sets `aria-describedby` on the group (link to hint/error ids)
+    def initialize(name:, label: nil, labelledby: nil, items: [], invalid: false, describedby: nil, **html_attrs)
       @name = name
+      @label = label
+      @labelledby = labelledby
       @items = items
+      @invalid = invalid
+      @describedby = describedby
       @extra_class = html_attrs.delete(:class)
       @html_attrs = html_attrs
     end
 
     def call
-      content_tag(:div,
-        class: cn("grid gap-2", @extra_class),
-        role: "radiogroup",
-        **@html_attrs) do
+      content_tag(:div, **group_attrs) do
         if @items.any?
           safe_join(@items.map { |item| radio_item(item) })
         else
@@ -24,6 +54,15 @@ module UI
     end
 
     private
+
+    def group_attrs
+      attrs = { class: cn("grid gap-2", @extra_class), role: "radiogroup" }
+      attrs["aria-label"] = @label if @label.present?
+      attrs["aria-labelledby"] = @labelledby if @labelledby.present?
+      attrs["aria-invalid"] = "true" if @invalid
+      attrs["aria-describedby"] = @describedby if @describedby.present?
+      attrs.merge(@html_attrs)
+    end
 
     def radio_item(item)
       id = "#{@name}_#{item[:value].to_s.gsub(/\W/, "_")}"
@@ -39,6 +78,7 @@ module UI
                        "focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-interactive-focus " \
                        "disabled:cursor-not-allowed disabled:opacity-50" }
       attrs[:checked] = true if item[:checked]
+      attrs[:disabled] = true if item[:disabled]
       content_tag(:input, nil, **attrs)
     end
 

--- a/lib/generators/modelrails_ui/add/templates/select/select_component.rb.tt
+++ b/lib/generators/modelrails_ui/add/templates/select/select_component.rb.tt
@@ -1,27 +1,65 @@
 # frozen_string_literal: true
 
 module UI
+  # # Select
+  #
+  # A styled native `<select>`; you supply options + an external form `<label for>`
+  # (an `id` is always emitted so the label can target it), and on error
+  # `invalid: true` + `describedby:`.
+  #
+  # ## Use when
+  # - You need a single-choice dropdown from a known, finite list of options.
+  #
+  # ## Don't use when
+  # - The control needs free-text entry or async search — that's a combobox, not a
+  #   native `<select>`.
+  #
+  # ## Accessibility contract
+  # - **Guarantees:** AAA border/focus-ring tokens, an `id` ALWAYS emitted on the
+  #   `<select>`, `aria-invalid="true"` when `invalid: true`, and `aria-describedby`
+  #   wired when `describedby:` is supplied.
+  # - **You supply:** the visible label as an EXTERNAL `<label for="<id>">` — unlike
+  #   checkbox, this component does NOT bundle a label (a `<select>` is conventionally
+  #   labeled by a separate form label). On error, pass `invalid: true` and point
+  #   `describedby:` at the error element's id.
+  #
+  # No fail-loud guard — there's no enum axis to validate.
   class SelectComponent < ApplicationComponent
     BASE = "flex h-9 w-full rounded-md border border-border-strong bg-transparent px-3 py-1 text-sm shadow-sm " \
            "focus:outline-none focus:ring-1 focus:ring-interactive-focus " \
            "disabled:cursor-not-allowed disabled:opacity-50"
 
     # options: array of strings, or [value, label] pairs, or { value: label } hash
-    def initialize(options: [], selected: nil, include_blank: false, **html_attrs)
+    #   invalid:     sets `aria-invalid="true"` (absent when false)
+    #   describedby: sets `aria-describedby` (link to the error/hint element id)
+    def initialize(options: [], selected: nil, include_blank: false, invalid: false, describedby: nil, **html_attrs)
       @options = options
       @selected = selected
       @include_blank = include_blank
+      @invalid = invalid
+      @describedby = describedby
+      # External-label association: an id is ALWAYS emitted so a sibling
+      # `<label for>` can target this control. Prefer an explicit id, fall back to a
+      # sanitized name, then a stable per-instance id.
+      @id = html_attrs[:id] || html_attrs[:name]&.gsub(/\W/, "_") || "select_#{object_id}"
       @extra_class = html_attrs.delete(:class)
       @html_attrs = html_attrs
     end
 
     def call
-      content_tag(:select, class: cn(BASE, @extra_class), **@html_attrs) do
+      content_tag(:select, **select_attrs) do
         safe_join(option_tags)
       end
     end
 
     private
+
+    def select_attrs
+      attrs = @html_attrs.merge(id: @id, class: cn(BASE, @extra_class))
+      attrs["aria-invalid"] = "true" if @invalid
+      attrs["aria-describedby"] = @describedby if @describedby.present?
+      attrs
+    end
 
     def option_tags
       tags = []

--- a/lib/generators/modelrails_ui/add/templates/switch/switch_component.rb.tt
+++ b/lib/generators/modelrails_ui/add/templates/switch/switch_component.rb.tt
@@ -1,21 +1,49 @@
 # frozen_string_literal: true
 
 module UI
+  # # Switch
+  #
+  # A binary on/off toggle backed by a native `<input type="checkbox" role="switch">`.
+  # The visually-hidden checkbox is the `peer`; a clickable track `<label>` and an
+  # `aria-hidden` thumb render the visual switch and react via `peer-checked:` /
+  # `peer-focus-visible:` / `peer-disabled:`.
+  #
+  # ## Use when
+  # - You need an immediate on/off setting (notifications on, dark mode on) that takes
+  #   effect on toggle — not a value collected for later form submission.
+  #
+  # ## Don't use when
+  # - The choice is part of a form the user submits, or it isn't strictly binary —
+  #   use a checkbox or radio group instead.
+  #
+  # ## Accessibility contract
+  # - **Guarantees:** a real `role="switch"` checkbox whose **native `checked` state**
+  #   conveys on/off to assistive tech (no JS, no stale ARIA), and a >=44px clickable
+  #   target (AAA 2.5.5) even though the visual track is smaller.
+  # - **You supply:** an accessible name via `label:` (or `aria-label:` on a label-less
+  #   switch), the initial `checked:` state, and a `name:` so the value posts.
+  #
+  # ## State
+  # `checked:` (default `false`) sets the initial on/off; the native checkbox tracks
+  # the rest. No variant axis, so no fail-loud guard is needed.
   class SwitchComponent < ApplicationComponent
-    # sr-only input, track label, and thumb are all siblings inside a relative wrapper
-    # so every element can use peer-checked: / peer-focus-visible: / peer-disabled: directly.
-    WRAPPER = "relative inline-flex h-[1.15rem] w-8 shrink-0"
-    TRACK   = "absolute inset-0 cursor-pointer rounded-full border border-transparent shadow-xs " \
-              "transition-all bg-surface-sunken peer-checked:bg-interactive  " \
-              "peer-focus-visible:border-border-focus peer-focus-visible:ring-[3px] peer-focus-visible:ring-interactive-focus " \
+    # The track <label for=@id> is the click target: a transparent >=44px flex box
+    # (AAA 2.5.5) that centers the smaller visual track, so the hit area grows without
+    # enlarging the switch graphic. peer-* utilities reference the sr-only input peer.
+    TARGET  = "relative inline-flex min-h-11 min-w-11 shrink-0 cursor-pointer items-center justify-center " \
               "peer-disabled:cursor-not-allowed peer-disabled:opacity-50"
-    THUMB   = "pointer-events-none absolute inset-y-0 left-[1px] my-auto z-10 block size-4 rounded-full " \
+    TRACK   = "block h-[1.15rem] w-8 rounded-full border border-transparent shadow-xs " \
+              "transition-all bg-surface-sunken peer-checked:bg-interactive " \
+              "peer-focus-visible:border-border-focus peer-focus-visible:ring-[3px] peer-focus-visible:ring-interactive-focus"
+    THUMB   = "pointer-events-none absolute inset-y-0 left-[calc(50%-1rem+1px)] my-auto z-10 block size-4 rounded-full " \
               "bg-surface-raised ring-0 transition-transform " \
               "translate-x-0 peer-checked:translate-x-[calc(100%-2px)]"
 
-    def initialize(label: nil, checked: false, **html_attrs)
+    def initialize(label: nil, checked: false, invalid: false, describedby: nil, **html_attrs)
       @label = label
       @checked = checked
+      @invalid = invalid
+      @describedby = describedby
       @id = html_attrs[:id] || html_attrs[:name]&.gsub(/[\[\]]+/, "_") || "switch_#{object_id}"
       @extra_class = html_attrs.delete(:class)
       @html_attrs = html_attrs
@@ -31,14 +59,21 @@ module UI
     private
 
     def switch_widget
-      content_tag(:div, class: WRAPPER) do
-        input_attrs = { type: "checkbox", id: @id, class: "peer sr-only", role: "switch",
-                        "aria-checked": @checked.to_s }
+      content_tag(:div, class: "relative inline-flex shrink-0") do
+        input_attrs = { type: "checkbox", id: @id, class: "peer sr-only", role: "switch" }
+        # No explicit aria-checked: the native checkbox `checked` conveys switch state
+        # under role=switch; a static aria-checked went stale on toggle (the bug we fixed).
+        # No JS needed; the app's 0b axe gate verifies.
         input_attrs[:checked] = true if @checked
+        input_attrs["aria-invalid"] = "true" if @invalid
+        input_attrs["aria-describedby"] = @describedby if @describedby
         input_attrs.merge!(@html_attrs)
         concat content_tag(:input, nil, **input_attrs)
-        concat content_tag(:label, nil, for: @id, class: TRACK)
-        concat content_tag(:span, nil, class: THUMB, "aria-hidden": "true")
+        # The <label for=@id> is the >=44px click target; the visual track + thumb sit inside it.
+        concat content_tag(:label, for: @id, class: TARGET) {
+          concat content_tag(:span, nil, class: TRACK)
+          concat content_tag(:span, nil, class: THUMB, "aria-hidden": "true")
+        }
       end
     end
 

--- a/lib/generators/modelrails_ui/add/templates/switch/switch_component.rb.tt
+++ b/lib/generators/modelrails_ui/add/templates/switch/switch_component.rb.tt
@@ -27,15 +27,22 @@ module UI
   # `checked:` (default `false`) sets the initial on/off; the native checkbox tracks
   # the rest. No variant axis, so no fail-loud guard is needed.
   class SwitchComponent < ApplicationComponent
-    # The track <label for=@id> is the click target: a transparent >=44px flex box
-    # (AAA 2.5.5) that centers the smaller visual track, so the hit area grows without
-    # enlarging the switch graphic. peer-* utilities reference the sr-only input peer.
+    # The OUTER <label for=@id> is the >=44px click target (AAA 2.5.5): a transparent
+    # flex box that centers the smaller visual switch, so the hit area grows without
+    # enlarging the graphic. The `for` association toggles the input regardless of DOM
+    # nesting. has-[:disabled]: is a cosmetic cursor nicety (the label is an ancestor,
+    # not a peer, so peer-* can't reach it — the real peer-disabled: hooks live on TRACK).
     TARGET  = "relative inline-flex min-h-11 min-w-11 shrink-0 cursor-pointer items-center justify-center " \
-              "peer-disabled:cursor-not-allowed peer-disabled:opacity-50"
-    TRACK   = "block h-[1.15rem] w-8 rounded-full border border-transparent shadow-xs " \
+              "has-[:disabled]:cursor-not-allowed"
+    # WRAPPER keeps the original switch size; the input + TRACK + THUMB are siblings
+    # inside it so the input is the `peer` and TRACK/THUMB are its LATER SIBLINGS —
+    # the only DOM order in which Tailwind peer-* (`.peer:checked ~ .x`) matches.
+    WRAPPER = "relative inline-flex h-[1.15rem] w-8 shrink-0"
+    TRACK   = "pointer-events-none absolute inset-0 rounded-full border border-transparent shadow-xs " \
               "transition-all bg-surface-sunken peer-checked:bg-interactive " \
-              "peer-focus-visible:border-border-focus peer-focus-visible:ring-[3px] peer-focus-visible:ring-interactive-focus"
-    THUMB   = "pointer-events-none absolute inset-y-0 left-[calc(50%-1rem+1px)] my-auto z-10 block size-4 rounded-full " \
+              "peer-focus-visible:border-border-focus peer-focus-visible:ring-[3px] peer-focus-visible:ring-interactive-focus " \
+              "peer-disabled:opacity-50"
+    THUMB   = "pointer-events-none absolute inset-y-0 left-px my-auto z-10 block size-4 rounded-full " \
               "bg-surface-raised ring-0 transition-transform " \
               "translate-x-0 peer-checked:translate-x-[calc(100%-2px)]"
 
@@ -44,7 +51,7 @@ module UI
       @checked = checked
       @invalid = invalid
       @describedby = describedby
-      @id = html_attrs[:id] || html_attrs[:name]&.gsub(/[\[\]]+/, "_") || "switch_#{object_id}"
+      @id = html_attrs[:id] || html_attrs[:name]&.gsub(/\W/, "_") || "switch_#{object_id}"
       @extra_class = html_attrs.delete(:class)
       @html_attrs = html_attrs
     end
@@ -59,21 +66,25 @@ module UI
     private
 
     def switch_widget
-      content_tag(:div, class: "relative inline-flex shrink-0") do
-        input_attrs = { type: "checkbox", id: @id, class: "peer sr-only", role: "switch" }
-        # No explicit aria-checked: the native checkbox `checked` conveys switch state
-        # under role=switch; a static aria-checked went stale on toggle (the bug we fixed).
-        # No JS needed; the app's 0b axe gate verifies.
-        input_attrs[:checked] = true if @checked
-        input_attrs["aria-invalid"] = "true" if @invalid
-        input_attrs["aria-describedby"] = @describedby if @describedby
-        input_attrs.merge!(@html_attrs)
-        concat content_tag(:input, nil, **input_attrs)
-        # The <label for=@id> is the >=44px click target; the visual track + thumb sit inside it.
-        concat content_tag(:label, for: @id, class: TARGET) {
+      # The OUTER <label for=@id> is the >=44px click target; the `for` association
+      # toggles the input regardless of nesting. The visual switch is the inner WRAPPER:
+      # input (the peer) followed by its LATER SIBLINGS, the track and thumb — the DOM
+      # order Tailwind peer-* requires (`.peer:checked ~ .x` is a sibling combinator).
+      content_tag(:label, for: @id, class: TARGET) do
+        content_tag(:span, nil, class: WRAPPER) do
+          # Component attrs (role/type/aria-*) are applied AFTER @html_attrs so the
+          # caller can't clobber the a11y contract (role="switch" and the aria-* we set).
+          input_attrs = @html_attrs.merge(type: "checkbox", id: @id, class: "peer sr-only", role: "switch")
+          # No explicit aria-checked: the native checkbox `checked` conveys switch state
+          # under role=switch; a static aria-checked went stale on toggle (the bug we fixed).
+          # No JS needed; the app's 0b axe gate verifies.
+          input_attrs[:checked] = true if @checked
+          input_attrs["aria-invalid"] = "true" if @invalid
+          input_attrs["aria-describedby"] = @describedby if @describedby.present?
+          concat content_tag(:input, nil, **input_attrs)
           concat content_tag(:span, nil, class: TRACK)
           concat content_tag(:span, nil, class: THUMB, "aria-hidden": "true")
-        }
+        end
       end
     end
 

--- a/lib/generators/modelrails_ui/add/templates/toggle/toggle_component.rb.tt
+++ b/lib/generators/modelrails_ui/add/templates/toggle/toggle_component.rb.tt
@@ -1,6 +1,26 @@
 # frozen_string_literal: true
 
 module UI
+  # # Toggle
+  #
+  # A two-state press button — an `<button type="button">` carrying `aria-pressed`
+  # (and a mirrored `data-state`) that flips on click. Use it for a standalone
+  # on/off control (bold, mute, pin), not as a checkbox replacement in a form.
+  #
+  # ## Use when
+  # - You need a single, instantly-applied on/off action with no separate submit.
+  #
+  # ## Don't use when
+  # - It's a form field whose value posts on submit — use a checkbox/switch input.
+  #
+  # ## Accessibility contract
+  # - **Guarantees:** a real interactive element with `aria-pressed` reflecting the
+  #   pressed state, and a 44px-minimum touch target at every size (AAA 2.5.5).
+  # - **You supply:** an accessible name — visible text/content, or an `aria-label:`
+  #   for an icon-only toggle — and a valid `size` (an unknown one raises in development).
+  #
+  # ## Sizes
+  # `default` · `sm` · `lg` — all rendered >=44px tall (the AAA target-size floor).
   class ToggleComponent < ApplicationComponent
     BASE = "inline-flex items-center justify-center gap-2 rounded-md text-sm font-medium whitespace-nowrap " \
            "transition-[color,box-shadow] outline-none hover:bg-surface-sunken hover:text-text-muted " \
@@ -10,16 +30,19 @@ module UI
            "data-[state=on]:bg-surface-sunken data-[state=on]:text-text-heading " \
            "[&_svg]:pointer-events-none [&_svg]:shrink-0 [&_svg:not([class*='size-'])]:size-4"
 
+    # AAA 2.5.5 target-size floor: every size renders >=44px tall (h-11 = 44px).
+    # `sm` differs only in width/padding — its height is held at the 44px floor;
+    # sub-44px heights are disallowed under AAA, so the historical h-8/h-9 are gone.
     SIZES = {
-      default: "h-9 min-w-9 px-2",
-      sm:      "h-8 min-w-8 px-1.5",
-      lg:      "h-10 min-w-10 px-2.5"
+      default: "h-11 min-w-11 px-2",
+      sm:      "h-11 min-w-11 px-1.5",
+      lg:      "h-12 min-w-12 px-2.5"
     }.freeze
 
     def initialize(label = nil, pressed: false, size: :default, value: nil, **html_attrs)
       @label = label || html_attrs.delete(:label)
       @pressed = pressed
-      @size = size.to_sym
+      @size = coerce_size(size.to_sym)
       @value = value
       @extra_class = html_attrs.delete(:class)
       @html_attrs = html_attrs
@@ -34,8 +57,27 @@ module UI
         "data-controller": "toggle",
         "data-action": "click->toggle#toggle",
         value: @value,
-        class: cn(BASE, SIZES.fetch(@size, SIZES[:default]), @extra_class),
+        class: cn(BASE, SIZES.fetch(@size), @extra_class),
         **@html_attrs)
+    end
+
+    private
+
+    # Fail loud on an unknown size in development/test so misuse is caught
+    # immediately; fall back to :default in production so a bad size never
+    # 500s a page. The Rails.respond_to?(:env) guard stays correct even when the Rails
+    # module is defined but Rails.env isn't booted (the gem's Rails-less tests load
+    # rails/generators, which defines Rails without Rails.env).
+    def coerce_size(size)
+      return size if SIZES.key?(size)
+
+      unless defined?(Rails) && Rails.respond_to?(:env) && Rails.env.production?
+        raise ArgumentError,
+          "UI::ToggleComponent: unknown size #{size.inspect}. " \
+          "Expected one of: #{SIZES.keys.join(", ")}."
+      end
+
+      :default
     end
   end
 end

--- a/lib/generators/modelrails_ui/lookbook/templates/previews/ui/checkbox_component_preview.rb
+++ b/lib/generators/modelrails_ui/lookbook/templates/previews/ui/checkbox_component_preview.rb
@@ -1,0 +1,47 @@
+# frozen_string_literal: true
+
+module UI
+  # # Checkbox
+  #
+  # A single labelled native checkbox — the form-control pattern-setter. Always
+  # carries an `id` so the `<label for=...>` association never breaks.
+  #
+  # ## Use when
+  # - A single on/off choice tied to a label ("Accept terms", "Remember me").
+  #
+  # ## Don't use when
+  # - It's an immediate-effect setting toggle — use `switch`.
+  # - It's a mutually-exclusive set of options — use `radio_group`.
+  #
+  # ## Accessibility contract
+  # - **Guarantees:** a labelled, keyboard-operable checkbox with an AAA focus ring;
+  #   the clickable label provides the larger AAA target.
+  # - **You supply:** a `label` and, on error, `invalid: true` + `describedby:`.
+  class CheckboxComponentPreview < ViewComponent::Preview
+    include UIHelper
+
+    # A labelled, unchecked checkbox.
+    def default
+    end
+
+    # Pre-checked.
+    def checked
+    end
+
+    # Error state — aria-invalid wired to a described-by error message.
+    def invalid
+    end
+
+    # Non-interactive — the label dims via the peer-disabled hook.
+    def disabled
+    end
+
+    # ## Don't — an unlabelled checkbox
+    #
+    # No `label` and no `aria-label` leaves an unlabelled control — screen-reader
+    # users hear no purpose. Always pass a `label` (or an `aria-label`).
+    # @label Don't · no label
+    def dont_no_label
+    end
+  end
+end

--- a/lib/generators/modelrails_ui/lookbook/templates/previews/ui/checkbox_component_preview/checked.html.erb
+++ b/lib/generators/modelrails_ui/lookbook/templates/previews/ui/checkbox_component_preview/checked.html.erb
@@ -1,0 +1,1 @@
+<%= ui :checkbox, label: "Remember me on this device", name: "remember", checked: true %>

--- a/lib/generators/modelrails_ui/lookbook/templates/previews/ui/checkbox_component_preview/default.html.erb
+++ b/lib/generators/modelrails_ui/lookbook/templates/previews/ui/checkbox_component_preview/default.html.erb
@@ -1,0 +1,1 @@
+<%= ui :checkbox, label: "Email me about product updates", name: "updates" %>

--- a/lib/generators/modelrails_ui/lookbook/templates/previews/ui/checkbox_component_preview/disabled.html.erb
+++ b/lib/generators/modelrails_ui/lookbook/templates/previews/ui/checkbox_component_preview/disabled.html.erb
@@ -1,0 +1,1 @@
+<%= ui :checkbox, label: "Beta features (unavailable on your plan)", name: "beta", disabled: true %>

--- a/lib/generators/modelrails_ui/lookbook/templates/previews/ui/checkbox_component_preview/dont_no_label.html.erb
+++ b/lib/generators/modelrails_ui/lookbook/templates/previews/ui/checkbox_component_preview/dont_no_label.html.erb
@@ -1,0 +1,2 @@
+<%# ✗ no label and no aria-label — an unlabelled control; screen readers announce no purpose %>
+<%= ui :checkbox, name: "mystery" %>

--- a/lib/generators/modelrails_ui/lookbook/templates/previews/ui/checkbox_component_preview/invalid.html.erb
+++ b/lib/generators/modelrails_ui/lookbook/templates/previews/ui/checkbox_component_preview/invalid.html.erb
@@ -1,0 +1,5 @@
+<%# invalid: true sets aria-invalid; describedby: wires the error message id %>
+<div>
+  <%= ui :checkbox, label: "Accept the terms of service", name: "terms", invalid: true, describedby: "terms_error" %>
+  <p id="terms_error" class="mt-1 text-sm text-danger">You must accept the terms to continue.</p>
+</div>

--- a/lib/generators/modelrails_ui/lookbook/templates/previews/ui/radio_group_component_preview.rb
+++ b/lib/generators/modelrails_ui/lookbook/templates/previews/ui/radio_group_component_preview.rb
@@ -1,0 +1,49 @@
+# frozen_string_literal: true
+
+module UI
+  # # RadioGroup
+  #
+  # A labelled single-choice control — a `role="radiogroup"` wrapping one native
+  # `<input type="radio">` per option, each tied to its own `<label for>`.
+  #
+  # ## Use when
+  # - You are choosing one value from a small, fixed set (a plan, a visibility
+  #   level, a cadence).
+  #
+  # ## Don't use when
+  # - There are many or dynamic options — use `ui :select`.
+  # - The choice is binary on/off — use `ui :toggle` or `ui :checkbox`.
+  #
+  # ## Accessibility contract
+  # - **Guarantees:** an accessible group name (`aria-label` / `aria-labelledby`),
+  #   matched `<label for>`/input `id` per option, and on error `aria-invalid="true"`
+  #   plus an `aria-describedby` link to the message.
+  # - **You supply:** a group `label:` (or `labelledby:`), `items:` as
+  #   `[{ value:, label:, checked?:, disabled?: }]`, and on error `invalid:` +
+  #   `describedby:`.
+  class RadioGroupComponentPreview < ViewComponent::Preview
+    include UIHelper
+
+    # Baseline: a named group with a few options and no current selection.
+    def default
+    end
+
+    # One option pre-selected via `checked: true` on its item.
+    def with_selection
+    end
+
+    # Error state: the group carries `aria-invalid="true"` and `aria-describedby`
+    # pointing at a sibling `<p>` that holds the message.
+    def invalid
+    end
+
+    # ## Don't — a radiogroup with no accessible name
+    #
+    # A `role="radiogroup"` with neither `label:` nor `labelledby:` exposes no
+    # accessible name — screen-reader users hear an unlabelled group. Always pass
+    # `label:` (or point `labelledby:` at a visible heading).
+    # @label Don't · no group label
+    def dont_no_group_label
+    end
+  end
+end

--- a/lib/generators/modelrails_ui/lookbook/templates/previews/ui/radio_group_component_preview/default.html.erb
+++ b/lib/generators/modelrails_ui/lookbook/templates/previews/ui/radio_group_component_preview/default.html.erb
@@ -1,0 +1,5 @@
+<%= ui :radio_group, name: "plan", label: "Billing plan", items: [
+  { value: "free", label: "Free" },
+  { value: "pro", label: "Pro" },
+  { value: "team", label: "Team" }
+] %>

--- a/lib/generators/modelrails_ui/lookbook/templates/previews/ui/radio_group_component_preview/dont_no_group_label.html.erb
+++ b/lib/generators/modelrails_ui/lookbook/templates/previews/ui/radio_group_component_preview/dont_no_group_label.html.erb
@@ -1,0 +1,5 @@
+<%# ✗ no label:/labelledby: — the radiogroup has no accessible name %>
+<%= ui :radio_group, name: "plan", items: [
+  { value: "free", label: "Free" },
+  { value: "pro", label: "Pro" }
+] %>

--- a/lib/generators/modelrails_ui/lookbook/templates/previews/ui/radio_group_component_preview/invalid.html.erb
+++ b/lib/generators/modelrails_ui/lookbook/templates/previews/ui/radio_group_component_preview/invalid.html.erb
@@ -1,0 +1,8 @@
+<%= ui :radio_group, name: "plan", label: "Billing plan", invalid: true,
+  describedby: "plan-error", items: [
+    { value: "free", label: "Free" },
+    { value: "pro", label: "Pro" },
+    { value: "team", label: "Team" }
+  ] %>
+<%# describedby points at this sibling — the error message the group announces %>
+<p id="plan-error" class="mt-2 text-sm text-danger">Choose a billing plan to continue.</p>

--- a/lib/generators/modelrails_ui/lookbook/templates/previews/ui/radio_group_component_preview/with_selection.html.erb
+++ b/lib/generators/modelrails_ui/lookbook/templates/previews/ui/radio_group_component_preview/with_selection.html.erb
@@ -1,0 +1,5 @@
+<%= ui :radio_group, name: "plan", label: "Billing plan", items: [
+  { value: "free", label: "Free" },
+  { value: "pro", label: "Pro", checked: true },
+  { value: "team", label: "Team" }
+] %>

--- a/lib/generators/modelrails_ui/lookbook/templates/previews/ui/select_component_preview.rb
+++ b/lib/generators/modelrails_ui/lookbook/templates/previews/ui/select_component_preview.rb
@@ -1,0 +1,55 @@
+# frozen_string_literal: true
+
+module UI
+  # # Select
+  #
+  # A styled native `<select>` for single-choice from a known list. You supply the
+  # options and an EXTERNAL `<label for>`; an `id` is always emitted so the label can
+  # target it. On error, pass `invalid: true` + `describedby:`.
+  #
+  # ## Use when
+  # - You need a single-choice dropdown from a known, finite list of options.
+  #
+  # ## Don't use when
+  # - The control needs free-text entry or async search — that's a combobox.
+  #
+  # ## Accessibility contract
+  # - **Guarantees:** AAA border/focus-ring tokens, an `id` always emitted,
+  #   `aria-invalid="true"` when `invalid: true`, and `aria-describedby` wired when
+  #   `describedby:` is supplied.
+  # - **You supply:** the visible label as an external `<label for="<id>">` — unlike
+  #   checkbox, this component does NOT bundle a label.
+  class SelectComponentPreview < ViewComponent::Preview
+    include UIHelper
+
+    # A native select with a sibling label — the baseline appearance.
+    def default
+    end
+
+    # A pre-selected option (`selected:` matches by value).
+    def selected
+    end
+
+    # A leading empty option via `include_blank: true` — useful as a "choose one" prompt.
+    def include_blank
+    end
+
+    # Error state: `aria-invalid="true"` plus `aria-describedby` wired to a sibling
+    # error message. In a real form the form builder sets both automatically.
+    def invalid
+    end
+
+    # Disabled control — passed straight through via `**html_attrs`.
+    def disabled
+    end
+
+    # ## Don't — a select with no associated label
+    #
+    # A `<select>` with no external `<label for="<id>">` has no accessible name —
+    # screen-reader users hear only "combobox". Always pair it with a label that
+    # targets the emitted id.
+    # @label Don't · no label
+    def dont_no_label
+    end
+  end
+end

--- a/lib/generators/modelrails_ui/lookbook/templates/previews/ui/select_component_preview/default.html.erb
+++ b/lib/generators/modelrails_ui/lookbook/templates/previews/ui/select_component_preview/default.html.erb
@@ -1,0 +1,2 @@
+<label for="demo_status" class="block text-sm font-medium text-text-heading mb-1">Status</label>
+<%= ui :select, id: "demo_status", name: "demo_status", options: %w[Draft Published Archived] %>

--- a/lib/generators/modelrails_ui/lookbook/templates/previews/ui/select_component_preview/disabled.html.erb
+++ b/lib/generators/modelrails_ui/lookbook/templates/previews/ui/select_component_preview/disabled.html.erb
@@ -1,0 +1,3 @@
+<label for="demo_status_disabled" class="block text-sm font-medium text-text-heading mb-1">Status</label>
+<%= ui :select, id: "demo_status_disabled", name: "demo_status_disabled",
+   options: %w[Draft Published Archived], selected: "Draft", disabled: true %>

--- a/lib/generators/modelrails_ui/lookbook/templates/previews/ui/select_component_preview/dont_no_label.html.erb
+++ b/lib/generators/modelrails_ui/lookbook/templates/previews/ui/select_component_preview/dont_no_label.html.erb
@@ -1,0 +1,2 @@
+<%# ✗ no external <label for> — the select has no accessible name %>
+<%= ui :select, options: %w[Draft Published Archived] %>

--- a/lib/generators/modelrails_ui/lookbook/templates/previews/ui/select_component_preview/include_blank.html.erb
+++ b/lib/generators/modelrails_ui/lookbook/templates/previews/ui/select_component_preview/include_blank.html.erb
@@ -1,0 +1,3 @@
+<label for="demo_status_blank" class="block text-sm font-medium text-text-heading mb-1">Status</label>
+<%= ui :select, id: "demo_status_blank", name: "demo_status_blank",
+   options: %w[Draft Published Archived], include_blank: true %>

--- a/lib/generators/modelrails_ui/lookbook/templates/previews/ui/select_component_preview/invalid.html.erb
+++ b/lib/generators/modelrails_ui/lookbook/templates/previews/ui/select_component_preview/invalid.html.erb
@@ -1,0 +1,4 @@
+<label for="demo_status_err" class="block text-sm font-medium text-text-heading mb-1">Status</label>
+<%= ui :select, id: "demo_status_err", name: "demo_status_err",
+   options: %w[Draft Published Archived], invalid: true, describedby: "demo-status-error" %>
+<p id="demo-status-error" class="mt-1 text-sm text-danger">Please choose a status.</p>

--- a/lib/generators/modelrails_ui/lookbook/templates/previews/ui/select_component_preview/selected.html.erb
+++ b/lib/generators/modelrails_ui/lookbook/templates/previews/ui/select_component_preview/selected.html.erb
@@ -1,0 +1,3 @@
+<label for="demo_status_sel" class="block text-sm font-medium text-text-heading mb-1">Status</label>
+<%= ui :select, id: "demo_status_sel", name: "demo_status_sel",
+   options: %w[Draft Published Archived], selected: "Published" %>

--- a/lib/generators/modelrails_ui/lookbook/templates/previews/ui/switch_component_preview.rb
+++ b/lib/generators/modelrails_ui/lookbook/templates/previews/ui/switch_component_preview.rb
@@ -1,0 +1,49 @@
+# frozen_string_literal: true
+
+module UI
+  # # Switch
+  #
+  # A binary on/off toggle backed by a native `<input type="checkbox" role="switch">`.
+  # The native `checked` state conveys on/off to assistive tech — no JS, no stale ARIA.
+  #
+  # ## Use when
+  # - An immediate on/off setting (notifications on, dark mode on) that takes effect
+  #   on toggle.
+  #
+  # ## Don't use when
+  # - The choice is part of a submitted form, or it isn't strictly binary — use a
+  #   checkbox or radio group.
+  #
+  # ## Accessibility contract
+  # - **Guarantees:** a `role="switch"` checkbox whose native `checked` conveys state,
+  #   and a >=44px clickable target (AAA 2.5.5) even though the visual track is smaller.
+  # - **You supply:** an accessible name (`label:` or `aria-label:`), the initial
+  #   `checked:` state, and a `name:` so the value posts.
+  class SwitchComponentPreview < ViewComponent::Preview
+    include UIHelper
+
+    # Off — the default unchecked state.
+    def off
+    end
+
+    # On — the initial checked state.
+    def on
+    end
+
+    # With a visible text label, associated with the control.
+    def with_label
+    end
+
+    # Disabled — non-interactive, dimmed via peer-disabled styling.
+    def disabled
+    end
+
+    # ## Don't — a switch with no accessible name
+    #
+    # A label-less switch with no `aria-label:` has nothing to announce — screen-reader
+    # users hear only "switch, off". Always pass a `label:` or an `aria-label:`.
+    # @label Don't · no accessible name
+    def dont_no_label
+    end
+  end
+end

--- a/lib/generators/modelrails_ui/lookbook/templates/previews/ui/switch_component_preview/disabled.html.erb
+++ b/lib/generators/modelrails_ui/lookbook/templates/previews/ui/switch_component_preview/disabled.html.erb
@@ -1,0 +1,1 @@
+<%= ui :switch, label: "Email notifications", name: "notifications", checked: true, disabled: true %>

--- a/lib/generators/modelrails_ui/lookbook/templates/previews/ui/switch_component_preview/dont_no_label.html.erb
+++ b/lib/generators/modelrails_ui/lookbook/templates/previews/ui/switch_component_preview/dont_no_label.html.erb
@@ -1,0 +1,2 @@
+<%# ✗ no label and no aria-label — screen readers announce only "switch, off" %>
+<%= ui :switch, name: "notifications" %>

--- a/lib/generators/modelrails_ui/lookbook/templates/previews/ui/switch_component_preview/off.html.erb
+++ b/lib/generators/modelrails_ui/lookbook/templates/previews/ui/switch_component_preview/off.html.erb
@@ -1,0 +1,1 @@
+<%= ui :switch, label: "Email notifications", name: "notifications" %>

--- a/lib/generators/modelrails_ui/lookbook/templates/previews/ui/switch_component_preview/on.html.erb
+++ b/lib/generators/modelrails_ui/lookbook/templates/previews/ui/switch_component_preview/on.html.erb
@@ -1,0 +1,1 @@
+<%= ui :switch, label: "Email notifications", name: "notifications", checked: true %>

--- a/lib/generators/modelrails_ui/lookbook/templates/previews/ui/switch_component_preview/with_label.html.erb
+++ b/lib/generators/modelrails_ui/lookbook/templates/previews/ui/switch_component_preview/with_label.html.erb
@@ -1,0 +1,2 @@
+<%# the label is clickable and toggles the switch (label for = input id) %>
+<%= ui :switch, label: "Dark mode", name: "dark_mode" %>

--- a/lib/generators/modelrails_ui/lookbook/templates/previews/ui/toggle_component_preview.rb
+++ b/lib/generators/modelrails_ui/lookbook/templates/previews/ui/toggle_component_preview.rb
@@ -1,0 +1,57 @@
+# frozen_string_literal: true
+
+module UI
+  # # Toggle
+  #
+  # A two-state press button — a real `<button type="button">` carrying `aria-pressed`
+  # (mirrored as `data-state`) that flips on click via the `toggle` Stimulus controller.
+  # Use it for a standalone on/off action (bold, mute, pin), not as a form checkbox.
+  #
+  # ## Use when
+  # - You need a single, instantly-applied on/off action with no separate submit.
+  #
+  # ## Don't use when
+  # - It's a form field whose value posts on submit — use a checkbox/switch input.
+  #
+  # ## Accessibility contract
+  # - **Guarantees:** `aria-pressed` reflecting state, and a 44px-minimum touch target
+  #   at every size (AAA 2.5.5 target-size).
+  # - **You supply:** an accessible name — visible text/content, or an `aria-label:` for
+  #   an icon-only toggle — and a valid `size` (an unknown one raises in development).
+  #
+  # ## Sizes
+  # `default` · `sm` · `lg` — all >=44px tall.
+  class ToggleComponentPreview < ViewComponent::Preview
+    include UIHelper
+
+    # Unpressed (off) by default — aria-pressed="false", data-state="off".
+    def default
+    end
+
+    # Pressed (on) — aria-pressed="true", data-state="on".
+    def pressed
+    end
+
+    # All sizes render >=44px tall (the AAA target-size floor); sm differs only
+    # in width/padding, lg is taller.
+    def sizes
+    end
+
+    # Edit `label`, `pressed`, and `size` live to explore the component.
+    # @param label text
+    # @param pressed toggle
+    # @param size select [default, sm, lg]
+    def playground(label: "Bold", pressed: false, size: :default)
+      ui :toggle, label, pressed: pressed, size: size.to_sym
+    end
+
+    # ## Don't — icon-only toggle with no accessible name
+    #
+    # An icon-only toggle **must** carry an `aria-label:`, or screen-reader users hear
+    # nothing. Prefer visible text; if the design is truly icon-only, pass a label:
+    # `ui :toggle, "★", "aria-label": "Favorite"`.
+    # @label Don't · icon-only without a label
+    def dont_icon_only_without_label
+    end
+  end
+end

--- a/lib/generators/modelrails_ui/lookbook/templates/previews/ui/toggle_component_preview/default.html.erb
+++ b/lib/generators/modelrails_ui/lookbook/templates/previews/ui/toggle_component_preview/default.html.erb
@@ -1,0 +1,1 @@
+<%= ui :toggle, "Bold" %>

--- a/lib/generators/modelrails_ui/lookbook/templates/previews/ui/toggle_component_preview/dont_icon_only_without_label.html.erb
+++ b/lib/generators/modelrails_ui/lookbook/templates/previews/ui/toggle_component_preview/dont_icon_only_without_label.html.erb
@@ -1,0 +1,2 @@
+<%# ✗ icon-only with no aria-label — nothing for a screen reader to announce %>
+<%= ui :toggle, "★" %>

--- a/lib/generators/modelrails_ui/lookbook/templates/previews/ui/toggle_component_preview/pressed.html.erb
+++ b/lib/generators/modelrails_ui/lookbook/templates/previews/ui/toggle_component_preview/pressed.html.erb
@@ -1,0 +1,1 @@
+<%= ui :toggle, "Bold", pressed: true %>

--- a/lib/generators/modelrails_ui/lookbook/templates/previews/ui/toggle_component_preview/sizes.html.erb
+++ b/lib/generators/modelrails_ui/lookbook/templates/previews/ui/toggle_component_preview/sizes.html.erb
@@ -1,0 +1,5 @@
+<div class="flex items-center gap-3">
+  <%= ui :toggle, "Small", size: :sm %>
+  <%= ui :toggle, "Default", size: :default %>
+  <%= ui :toggle, "Large", size: :lg %>
+</div>

--- a/test/render/checkbox_render_test.rb
+++ b/test/render/checkbox_render_test.rb
@@ -1,0 +1,68 @@
+# frozen_string_literal: true
+
+require "render_test_helper"
+load_component "checkbox", "checkbox_component.rb.tt"
+
+class CheckboxRenderTest < ViewComponent::TestCase
+  def test_renders_a_checkbox_input
+    render_inline(UI::CheckboxComponent.new(label: "Accept terms", name: "terms"))
+
+    assert_selector "input[type='checkbox']"
+  end
+
+  # AAA semantic tokens (the design-token guarantee), not raw Tailwind:
+  def test_renders_with_aaa_tokens
+    render_inline(UI::CheckboxComponent.new(label: "Accept terms", name: "terms"))
+
+    assert_selector "input.border-border-strong"
+    assert_selector "input.focus-visible\\:ring-interactive-focus"
+    assert_selector "input.checked\\:bg-interactive"
+  end
+
+  # Label association: the <label for=...> targets the input's id.
+  def test_label_is_associated_via_for_matching_input_id
+    render_inline(UI::CheckboxComponent.new(label: "Accept terms", name: "terms"))
+
+    input_id = page.find("input[type='checkbox']")[:id]
+
+    refute_nil input_id, "input must carry an id so the label can associate"
+    assert_selector "label[for='#{input_id}']", text: "Accept terms"
+  end
+
+  # Fallback id: with NEITHER id nor name, the input STILL has an id and the
+  # label's `for` matches it (so the control is always labelled).
+  def test_label_associates_even_without_id_or_name
+    render_inline(UI::CheckboxComponent.new(label: "Accept terms"))
+
+    input_id = page.find("input[type='checkbox']")[:id]
+
+    refute_nil input_id, "input must carry a fallback id even without id/name"
+    refute_empty input_id.to_s
+    assert_selector "label[for='#{input_id}']", text: "Accept terms"
+  end
+
+  def test_checked_sets_the_checked_attribute
+    render_inline(UI::CheckboxComponent.new(label: "Accept terms", name: "terms", checked: true))
+
+    assert_selector "input[type='checkbox'][checked]"
+  end
+
+  # invalid: drives the server-validation-driven aria-invalid posture.
+  def test_invalid_sets_aria_invalid
+    render_inline(UI::CheckboxComponent.new(label: "Accept terms", name: "terms", invalid: true))
+
+    assert_selector "input[type='checkbox'][aria-invalid='true']"
+  end
+
+  def test_not_invalid_by_default
+    render_inline(UI::CheckboxComponent.new(label: "Accept terms", name: "terms"))
+
+    assert_no_selector "input[aria-invalid='true']"
+  end
+
+  def test_describedby_sets_aria_describedby
+    render_inline(UI::CheckboxComponent.new(label: "Accept terms", name: "terms", describedby: "terms_error"))
+
+    assert_selector "input[type='checkbox'][aria-describedby='terms_error']"
+  end
+end

--- a/test/render/radio_group_render_test.rb
+++ b/test/render/radio_group_render_test.rb
@@ -78,6 +78,20 @@ class RadioGroupRenderTest < ViewComponent::TestCase
     assert_no_selector "div[role='radiogroup'][aria-describedby]"
   end
 
+  def test_caller_html_attrs_cannot_clobber_the_groups_a11y_contract
+    render_inline(
+      UI::RadioGroupComponent.new(
+        name: "plan", label: "Billing plan", items: PLAN_ITEMS, invalid: true,
+        role: "group", "aria-label": "Caller override", "aria-invalid": "false"
+      )
+    )
+
+    # Component wins: its role/aria-label/aria-invalid survive caller-supplied conflicts.
+    assert_selector "div[role='radiogroup'][aria-label='Billing plan'][aria-invalid='true']"
+    assert_no_selector "div[role='group']"
+    assert_no_selector "div[aria-label='Caller override']"
+  end
+
   # AAA semantic tokens (the design-token guarantee), not raw Tailwind:
   def test_inputs_use_semantic_aaa_tokens
     render_inline(UI::RadioGroupComponent.new(name: "plan", label: "Billing plan", items: PLAN_ITEMS))

--- a/test/render/radio_group_render_test.rb
+++ b/test/render/radio_group_render_test.rb
@@ -1,0 +1,88 @@
+# frozen_string_literal: true
+
+require "render_test_helper"
+load_component "radio_group", "radio_group_component.rb.tt"
+
+class RadioGroupRenderTest < ViewComponent::TestCase
+  PLAN_ITEMS = [
+    {value: "free", label: "Free"},
+    {value: "pro", label: "Pro"},
+    {value: "team plan", label: "Team plan"}
+  ].freeze
+
+  def test_renders_a_named_radiogroup
+    render_inline(UI::RadioGroupComponent.new(name: "plan", label: "Billing plan", items: PLAN_ITEMS))
+
+    # A role=radiogroup MUST carry an accessible name (empty group name is an a11y failure).
+    assert_selector "div[role='radiogroup'][aria-label='Billing plan']"
+  end
+
+  def test_each_item_is_a_radio_input_with_a_matching_label
+    render_inline(UI::RadioGroupComponent.new(name: "plan", label: "Billing plan", items: PLAN_ITEMS))
+
+    PLAN_ITEMS.each do |item|
+      id = "plan_#{item[:value].gsub(/\W/, "_")}"
+
+      assert_selector "input[type='radio'][name='plan'][value='#{item[:value]}'][id='#{id}']"
+      assert_selector "label[for='#{id}']", text: item[:label]
+    end
+  end
+
+  def test_a_checked_item_marks_only_that_input
+    items = [
+      {value: "free", label: "Free"},
+      {value: "pro", label: "Pro", checked: true}
+    ]
+    render_inline(UI::RadioGroupComponent.new(name: "plan", label: "Billing plan", items: items))
+
+    assert_selector "input[type='radio'][id='plan_pro'][checked]"
+    assert_no_selector "input[type='radio'][id='plan_free'][checked]"
+  end
+
+  def test_a_disabled_item_is_honored
+    items = [
+      {value: "free", label: "Free"},
+      {value: "enterprise", label: "Enterprise", disabled: true}
+    ]
+    render_inline(UI::RadioGroupComponent.new(name: "plan", label: "Billing plan", items: items))
+
+    assert_selector "input[type='radio'][id='plan_enterprise'][disabled]"
+    assert_no_selector "input[type='radio'][id='plan_free'][disabled]"
+  end
+
+  def test_invalid_sets_aria_invalid_on_the_group
+    render_inline(UI::RadioGroupComponent.new(name: "plan", label: "Billing plan", items: PLAN_ITEMS, invalid: true))
+
+    assert_selector "div[role='radiogroup'][aria-invalid='true']"
+  end
+
+  def test_absent_invalid_does_not_set_aria_invalid
+    render_inline(UI::RadioGroupComponent.new(name: "plan", label: "Billing plan", items: PLAN_ITEMS))
+
+    assert_no_selector "div[role='radiogroup'][aria-invalid]"
+  end
+
+  def test_describedby_links_the_group_to_a_hint_or_error
+    render_inline(
+      UI::RadioGroupComponent.new(
+        name: "plan", label: "Billing plan", items: PLAN_ITEMS, describedby: "plan-error"
+      )
+    )
+
+    assert_selector "div[role='radiogroup'][aria-describedby='plan-error']"
+  end
+
+  def test_absent_describedby_does_not_set_aria_describedby
+    render_inline(UI::RadioGroupComponent.new(name: "plan", label: "Billing plan", items: PLAN_ITEMS))
+
+    assert_no_selector "div[role='radiogroup'][aria-describedby]"
+  end
+
+  # AAA semantic tokens (the design-token guarantee), not raw Tailwind:
+  def test_inputs_use_semantic_aaa_tokens
+    render_inline(UI::RadioGroupComponent.new(name: "plan", label: "Billing plan", items: PLAN_ITEMS))
+
+    assert_selector "input.border-interactive"
+    assert_selector "input.accent-interactive"
+  end
+end

--- a/test/render/select_render_test.rb
+++ b/test/render/select_render_test.rb
@@ -1,0 +1,71 @@
+# frozen_string_literal: true
+
+require "render_test_helper"
+load_component "select", "select_component.rb.tt"
+
+class SelectRenderTest < ViewComponent::TestCase
+  def test_renders_native_select_with_options
+    render_inline(UI::SelectComponent.new(options: %w[Draft Published]))
+
+    assert_selector "select"
+    assert_selector "select option", text: "Draft"
+    assert_selector "select option", text: "Published"
+  end
+
+  # AAA semantic tokens (the design-token guarantee), not raw Tailwind:
+  def test_renders_with_aaa_tokens
+    render_inline(UI::SelectComponent.new(options: %w[A B]))
+
+    assert_selector "select.border-border-strong"
+    assert_selector "select.focus\\:ring-interactive-focus"
+  end
+
+  def test_selected_marks_the_right_option
+    render_inline(UI::SelectComponent.new(options: %w[Draft Published], selected: "Published"))
+
+    assert_selector "select option[value='Published'][selected]", text: "Published"
+    assert_no_selector "select option[value='Draft'][selected]"
+  end
+
+  def test_include_blank_adds_a_leading_blank_option
+    render_inline(UI::SelectComponent.new(options: %w[Draft Published], include_blank: true))
+
+    assert_selector "select option:first-child[value='']"
+  end
+
+  def test_invalid_sets_aria_invalid
+    render_inline(UI::SelectComponent.new(options: %w[A B], invalid: true))
+
+    assert_selector "select[aria-invalid='true']"
+  end
+
+  def test_not_invalid_omits_aria_invalid
+    render_inline(UI::SelectComponent.new(options: %w[A B]))
+
+    assert_no_selector "select[aria-invalid]"
+  end
+
+  def test_describedby_sets_aria_describedby
+    render_inline(UI::SelectComponent.new(options: %w[A B], describedby: "status-error"))
+
+    assert_selector "select[aria-describedby='status-error']"
+  end
+
+  def test_id_from_explicit_id_attr
+    render_inline(UI::SelectComponent.new(options: %w[A B], id: "my_select"))
+
+    assert_selector "select#my_select"
+  end
+
+  def test_id_falls_back_to_name
+    render_inline(UI::SelectComponent.new(options: %w[A B], name: "post[status]"))
+
+    assert_selector "select#post_status_"
+  end
+
+  def test_id_is_always_emitted_with_neither_id_nor_name
+    render_inline(UI::SelectComponent.new(options: %w[A B]))
+
+    assert_selector "select[id]"
+  end
+end

--- a/test/render/switch_render_test.rb
+++ b/test/render/switch_render_test.rb
@@ -18,6 +18,18 @@ class SwitchRenderTest < ViewComponent::TestCase
     assert_no_selector "[aria-checked]"
   end
 
+  # STRUCTURAL CASCADE GUARD: the visual track/thumb react to the input via Tailwind
+  # `peer-*` utilities, which compile to the subsequent-sibling combinator
+  # (`.peer:checked ~ .x`). That only matches LATER SIBLINGS of the input — never
+  # descendants of a sibling. So a span MUST appear as a later sibling of the
+  # role=switch input, or peer-checked:/peer-focus-visible:/peer-disabled: silently
+  # no-op and the switch renders frozen OFF with no focus ring (the bug).
+  def test_track_thumb_are_later_siblings_of_the_peer_input
+    render_inline(UI::SwitchComponent.new(checked: true))
+
+    assert_selector "input[role='switch'][type='checkbox'] ~ span"
+  end
+
   def test_checked_sets_native_checked_on_the_input
     render_inline(UI::SwitchComponent.new(name: "notifications", checked: true))
 
@@ -68,6 +80,24 @@ class SwitchRenderTest < ViewComponent::TestCase
     render_inline(UI::SwitchComponent.new(name: "notifications"))
 
     assert_no_selector "input[aria-describedby]"
+  end
+
+  # An empty describedby must not leak aria-describedby="" (present? guard, matching
+  # the sibling components).
+  def test_describedby_blank_omits_aria_describedby
+    render_inline(UI::SwitchComponent.new(name: "notifications", describedby: ""))
+
+    assert_no_selector "input[aria-describedby]"
+  end
+
+  # Component attrs win over caller **html_attrs: a caller must not be able to clobber
+  # role="switch" or the aria-* the component sets (a11y guarantee, matching select).
+  def test_component_attrs_win_over_caller_html_attrs
+    render_inline(UI::SwitchComponent.new(name: "notifications", invalid: true, role: "checkbox"))
+
+    assert_selector "input[role='switch']"
+    assert_no_selector "input[role='checkbox']"
+    assert_selector "input[aria-invalid='true']"
   end
 
   def test_id_falls_back_when_no_id_or_name_given

--- a/test/render/switch_render_test.rb
+++ b/test/render/switch_render_test.rb
@@ -1,0 +1,85 @@
+# frozen_string_literal: true
+
+require "render_test_helper"
+load_component "switch", "switch_component.rb.tt"
+
+class SwitchRenderTest < ViewComponent::TestCase
+  def test_renders_a_native_checkbox_with_switch_role
+    render_inline(UI::SwitchComponent.new(name: "notifications"))
+
+    assert_selector "input[type='checkbox'][role='switch']"
+  end
+
+  # The bug fix: a static aria-checked goes stale on toggle, so it must not exist
+  # anywhere — the native checkbox `checked` conveys switch state under role=switch.
+  def test_has_no_static_aria_checked_attribute
+    render_inline(UI::SwitchComponent.new(name: "notifications", checked: true))
+
+    assert_no_selector "[aria-checked]"
+  end
+
+  def test_checked_sets_native_checked_on_the_input
+    render_inline(UI::SwitchComponent.new(name: "notifications", checked: true))
+
+    assert_selector "input[type='checkbox'][role='switch'][checked]"
+  end
+
+  def test_unchecked_omits_native_checked
+    render_inline(UI::SwitchComponent.new(name: "notifications"))
+
+    assert_no_selector "input[checked]"
+  end
+
+  # The clickable track <label for> must point at the input id — clicking the
+  # track toggles the control (association + click target).
+  def test_track_label_is_associated_with_the_input
+    render_inline(UI::SwitchComponent.new(id: "notify_switch"))
+
+    assert_selector "input#notify_switch[type='checkbox']"
+    assert_selector "label[for='notify_switch']"
+  end
+
+  # AAA 2.5.5 target size: the clickable track label carries a >=44px hit area.
+  def test_clickable_track_label_meets_44px_target
+    render_inline(UI::SwitchComponent.new(id: "notify_switch"))
+
+    assert_selector "label.min-h-11.min-w-11"
+  end
+
+  def test_invalid_sets_aria_invalid_on_the_input
+    render_inline(UI::SwitchComponent.new(name: "notifications", invalid: true))
+
+    assert_selector "input[type='checkbox'][aria-invalid='true']"
+  end
+
+  def test_invalid_false_omits_aria_invalid
+    render_inline(UI::SwitchComponent.new(name: "notifications"))
+
+    assert_no_selector "input[aria-invalid]"
+  end
+
+  def test_describedby_sets_aria_describedby_on_the_input
+    render_inline(UI::SwitchComponent.new(name: "notifications", describedby: "notify_hint"))
+
+    assert_selector "input[type='checkbox'][aria-describedby='notify_hint']"
+  end
+
+  def test_describedby_absent_omits_aria_describedby
+    render_inline(UI::SwitchComponent.new(name: "notifications"))
+
+    assert_no_selector "input[aria-describedby]"
+  end
+
+  def test_id_falls_back_when_no_id_or_name_given
+    render_inline(UI::SwitchComponent.new)
+
+    assert_selector "input[type='checkbox'][role='switch']"
+    assert_selector "label[for^='switch_']"
+  end
+
+  def test_renders_a_text_label_associated_with_the_input
+    render_inline(UI::SwitchComponent.new(id: "notify_switch", label: "Email notifications"))
+
+    assert_selector "label[for='notify_switch']", text: "Email notifications"
+  end
+end

--- a/test/render/toggle_render_test.rb
+++ b/test/render/toggle_render_test.rb
@@ -1,0 +1,58 @@
+# frozen_string_literal: true
+
+require "render_test_helper"
+load_component "toggle", "toggle_component.rb.tt"
+
+class ToggleRenderTest < ViewComponent::TestCase
+  def test_default_renders_unpressed_toggle_button
+    render_inline(UI::ToggleComponent.new("Bold"))
+
+    assert_selector "button[type='button'][aria-pressed='false'][data-state='off']", text: "Bold"
+  end
+
+  def test_pressed_renders_pressed_state
+    render_inline(UI::ToggleComponent.new("Bold", pressed: true))
+
+    assert_selector "button[type='button'][aria-pressed='true'][data-state='on']", text: "Bold"
+  end
+
+  def test_keeps_toggle_stimulus_wiring
+    render_inline(UI::ToggleComponent.new("Bold"))
+
+    assert_selector "button[data-controller='toggle'][data-action='click->toggle#toggle']"
+  end
+
+  # AAA 2.5.5 target-size: every size must render a >=44px tall control.
+  # h-11 = 44px (default/sm), h-12 = 48px (lg). Sub-44px heights are an AAA fail.
+  def test_default_size_meets_44px_floor
+    render_inline(UI::ToggleComponent.new("Bold"))
+
+    assert_selector "button.h-11"
+  end
+
+  def test_sm_size_meets_44px_floor
+    render_inline(UI::ToggleComponent.new("Bold", size: :sm))
+
+    assert_selector "button.h-11"
+  end
+
+  def test_lg_size_meets_44px_floor
+    render_inline(UI::ToggleComponent.new("Bold", size: :lg))
+
+    assert_selector "button.h-12"
+  end
+
+  # Fail-loud size guard: an unknown size raises in development/test.
+  def test_unknown_size_raises
+    assert_raises(ArgumentError) do
+      render_inline(UI::ToggleComponent.new("Bold", size: :bogus))
+    end
+  end
+
+  # AAA semantic token (the design-token guarantee), not raw Tailwind:
+  def test_renders_with_aaa_token
+    render_inline(UI::ToggleComponent.new("Bold", pressed: true))
+
+    assert_selector "button.data-\\[state\\=on\\]\\:bg-surface-sunken"
+  end
+end


### PR DESCRIPTION
## Summary

Wave 1 sub-wave 1 — the five form-control components hardened to the 10-point DoD, following the proven `alert` groove. Bundled (one PR) per the sub-wave's shared pattern.

- **checkbox** (form-control pattern-setter): id fallback so labels always associate; `invalid:`→`aria-invalid`, `describedby:`→`aria-describedby`.
- **select**: styled native `<select>` (no custom listbox); id fallback for external-label association; invalid/describedby.
- **radio_group**: required group accessible name (`label:`→`aria-label`, `labelledby:`→`aria-labelledby`); per-option ids; invalid/describedby on the group; component-wins attr merge.
- **switch**: **fixed a real ARIA bug** — dropped the stale static `aria-checked` (the native checkbox `checked` conveys state under `role="switch"`); restructured so the track/thumb are genuine `peer` siblings of the input while a ≥44px outer label provides the AAA target.
- **toggle**: fail-loud `coerce_size` guard; all sizes ≥44px (AAA 2.5.5). (Nit: `sm`≈`default` under the 44px floor — drop/rename deferred.)

Each ships a render test (0a) + a template-backed Lookbook preview. Shared `invalid:`/`describedby:`/id-fallback API is uniform across the set. `COMPONENT_STATUS.md`: these 5 → `hardened`; `alert` → `proven`.

## Test Plan

- [x] `rake` green — `test:structural` 441/0 + `test:render` **60/0** (7 components) + rubocop clean
- [ ] 0b: app-side preview-host axe specs (companion `modelrails_base` PR; switch gets extra on/off visual-transition + focus-ring assertions, since the render harness proves structure but not the computed `peer-*` cascade)