### PR TITLE
feat(display): harden badge + data_table to DoD (Wave 1 sub-wave 2)

### DIFF
--- a/COMPONENT_STATUS.md
+++ b/COMPONENT_STATUS.md
@@ -19,8 +19,8 @@ without extra verification.
 | radio_group | hardened | ✅ | ⏳ | Wave 1 sub-wave 1 (group aria-label; per-option ids; invalid on group) |
 | switch | hardened | ✅ | ⏳ | Wave 1 sub-wave 1 (aria-checked bug fixed; peer-sibling track; 44px target) |
 | toggle | hardened | ✅ | ⏳ | Wave 1 sub-wave 1 (fail-loud size guard; 44px sizes; sm≈default nit deferred) |
-| badge | experimental | ❌ | ❌ | Wave 1 sub-wave 2 |
-| data_table | experimental | ❌ | ❌ | Wave 1 sub-wave 2 (kbd sort, 44px) |
+| badge | hardened | ✅ | ⏳ | Wave 1 sub-wave 2 (fail-loud guard; destructive dark-AAA fix; href polymorphism) |
+| data_table | hardened | ✅ | ⏳ | Wave 1 sub-wave 2 (kbd-sortable headers + aria-sort; live region; 44px; i18n) |
 
 All other gem components: **experimental** (unverified) unless listed above.
 

--- a/lib/generators/modelrails_ui/add/templates/badge/badge_component.rb.tt
+++ b/lib/generators/modelrails_ui/add/templates/badge/badge_component.rb.tt
@@ -1,6 +1,30 @@
 # frozen_string_literal: true
 
 module UI
+  # # Badge
+  #
+  # A small status/category label — a compact, non-interactive pill that tags a
+  # surrounding item (a status, a count, a category). Renders a `<span>` by default,
+  # or an `<a>` when `href:` is given (a clickable tag/filter link).
+  #
+  # ## Use when
+  # - You need a short inline label that classifies or annotates nearby content:
+  #   a status pill ("Active"), a category tag, a small count.
+  #
+  # ## Don't use when
+  # - It's a real action — use `UI::ButtonComponent` (or `button_to` for non-GET).
+  #   A badge is presentational; `href:` is for navigation/filtering, not actions.
+  #
+  # ## Accessibility contract
+  # - **Guarantees:** AAA-contrast text on every variant's surface, including the
+  #   adaptive `destructive` treatment (which stays legible in dark mode).
+  # - **You supply:** if the badge conveys status that isn't already in the
+  #   surrounding text (e.g. a color-coded "destructive" pill), give it an accessible
+  #   name so screen-reader users get the same signal. A valid `variant` is required —
+  #   an unknown one raises in development.
+  #
+  # ## Variants
+  # `default` · `secondary` · `destructive` · `outline` · `ghost` · `link`
   class BadgeComponent < ApplicationComponent
     BASE = "inline-flex w-fit shrink-0 items-center justify-center gap-1 overflow-hidden rounded-full " \
            "border border-transparent px-2 py-0.5 text-xs font-medium whitespace-nowrap " \
@@ -9,27 +33,58 @@ module UI
            "aria-invalid:border-danger-border aria-invalid:ring-danger  " \
            "[&>svg]:pointer-events-none [&>svg]:size-3"
 
+    # `text-text-on-interactive` (not `text-white`) on destructive: the adaptive token
+    # is white in light mode and a dark neutral in dark mode, so it keeps AAA contrast
+    # against the light-pink dark-mode `--color-danger` — exactly how the danger button
+    # handles it. Raw `text-white` would fail AAA on that dark surface.
     VARIANTS = {
       default: "bg-interactive text-text-on-interactive [a&]:hover:bg-interactive-hover",
       secondary: "bg-interactive-subtle text-interactive [a&]:hover:bg-interactive-subtle",
-      destructive: "bg-danger text-white focus-visible:ring-danger " \
+      destructive: "bg-danger text-text-on-interactive focus-visible:ring-danger " \
                    "  [a&]:hover:bg-danger-hover",
       outline: "border-border text-text-heading [a&]:hover:bg-surface-sunken [a&]:hover:text-text-heading",
       ghost: "[a&]:hover:bg-surface-sunken [a&]:hover:text-text-heading",
       link: "text-interactive underline-offset-4 [a&]:hover:underline"
     }.freeze
 
-    def initialize(label = nil, variant: :default, **html_attrs)
+    # label — positional or keyword shorthand for plain-text badges without a block.
+    # href  — renders an <a> tag (a clickable tag/filter link); sets tag: :a automatically.
+    def initialize(label = nil, variant: :default, href: nil, **html_attrs)
       @label = label || html_attrs.delete(:label)
-      @variant = variant.to_sym
+      @variant = coerce_variant(variant.to_sym)
+      @tag = html_attrs.delete(:tag)
       @extra_class = html_attrs.delete(:class)
       @html_attrs = html_attrs
+
+      if href
+        @html_attrs[:href] = href
+        @tag ||= :a
+      end
     end
 
     def call
-      content_tag(:span, content.presence || @label,
-        class: cn(BASE, VARIANTS.fetch(@variant, VARIANTS[:default]), @extra_class),
+      content_tag(@tag || :span, content.presence || @label,
+        class: cn(BASE, VARIANTS.fetch(@variant), @extra_class),
         **@html_attrs)
+    end
+
+    private
+
+    # Fail loud on an unknown variant in development/test so misuse is caught
+    # immediately; fall back to :default in production so a bad variant never
+    # 500s a page. The Rails.respond_to?(:env) guard stays correct even when the Rails
+    # module is defined but Rails.env isn't booted (the gem's Rails-less tests load
+    # rails/generators, which defines Rails without Rails.env).
+    def coerce_variant(variant)
+      return variant if VARIANTS.key?(variant)
+
+      unless defined?(Rails) && Rails.respond_to?(:env) && Rails.env.production?
+        raise ArgumentError,
+          "UI::BadgeComponent: unknown variant #{variant.inspect}. " \
+          "Expected one of: #{VARIANTS.keys.join(", ")}."
+      end
+
+      :default
     end
   end
 end

--- a/lib/generators/modelrails_ui/add/templates/data_table/data_table_component.rb.tt
+++ b/lib/generators/modelrails_ui/add/templates/data_table/data_table_component.rb.tt
@@ -1,34 +1,69 @@
 # frozen_string_literal: true
 
 module UI
+  # # DataTable
+  #
+  # A sortable, filterable table with client-side search and pagination. The
+  # markup is the static scaffold; all interaction (filter / sort / paginate)
+  # lives in the `data-table` Stimulus controller that ships alongside.
+  #
+  # ## Use when
+  # - You have a bounded, already-loaded set of rows the user benefits from
+  #   searching, sorting, or paging through entirely on the client.
+  #
+  # ## Don't use when
+  # - The dataset is large or server-paginated — client-side filtering only sees
+  #   the rows already in the DOM. Render a server-driven table instead.
+  # - The "table" is really a layout grid — use semantic layout, not <table>.
+  #
+  # ## Accessibility contract
+  # - **Guarantees:** sortable columns are real keyboard-operable `<button>`s
+  #   (Enter/Space activate; the bare `<th>` is not focusable), each wrapped in a
+  #   `th[aria-sort]` the controller flips to `ascending`/`descending`/`none`;
+  #   a visually-hidden `role="status"` live region announces the result count
+  #   after filtering; all controls (search, sort headers, pager) meet the AAA
+  #   44px target floor; and every user-facing string is localized.
+  # - **You supply:** a `caption:` — a table without an accessible name leaves
+  #   screen-reader users without context. Pass one whenever practical.
+  #
+  # No fail-loud variant guard: this component has no enum/variant axis. Its
+  # inputs are open-ended data (`columns:`, `rows:`, `per_page:`), not a closed
+  # set to validate against, so there is nothing to coerce.
   class DataTableComponent < ApplicationComponent
-    # Sortable, filterable data table with client-side pagination.
-    #
-    # columns: array of { key:, label:, sortable: true }
-    # rows:    array of hashes (keys must match column keys)
-    # per_page: rows per page (default 10, 0 = no pagination)
-    # caption:  optional <caption> text
-
     WRAPPER    = "w-full overflow-auto rounded-lg border border-border"
     TOOLBAR    = "flex items-center gap-3 border-b border-border bg-surface-raised px-4 py-3"
-    SEARCH_CLS = "flex h-8 flex-1 items-center gap-2 rounded-md border border-border-strong bg-surface-raised " \
+    # h-11 keeps the search control at the AAA 44px target floor (WCAG 2.5.5).
+    SEARCH_CLS = "flex h-11 flex-1 items-center gap-2 rounded-md border border-border-strong bg-surface-raised " \
                  "px-3 text-sm text-text-muted focus-within:border-border-focus focus-within:ring-[3px] " \
                  "focus-within:ring-interactive-focus transition"
     SEARCH_INPUT = "w-full bg-transparent outline-none placeholder:text-text-muted text-text-heading text-sm"
     TABLE_CLS  = "w-full caption-bottom text-sm"
     THEAD_CLS  = "bg-surface-sunken/40"
-    TH_CLS     = "h-10 px-4 text-left align-middle font-medium text-text-muted whitespace-nowrap"
-    TH_SORT    = "cursor-pointer select-none hover:text-text-heading transition-colors"
+    # h-11 keeps the header row (and therefore the sort buttons that fill it) at
+    # the AAA 44px target floor.
+    TH_CLS     = "h-11 px-4 text-left align-middle font-medium text-text-muted whitespace-nowrap"
+    # The sort trigger is a real <button>: focusable + Enter/Space-activatable
+    # for free. It spans the cell (left-aligned) and fills the >=44px height.
+    SORT_BTN   = "flex min-h-11 w-full items-center gap-1 -mx-4 px-4 text-left font-medium " \
+                 "cursor-pointer select-none hover:text-text-heading focus-visible:outline-none " \
+                 "focus-visible:ring-[3px] focus-visible:ring-interactive-focus transition-colors"
     TR_CLS     = "border-t border-border transition-colors hover:bg-surface-sunken/30"
     TD_CLS     = "px-4 py-3 align-middle"
     FOOTER_CLS = "flex items-center justify-between border-t border-border bg-surface-raised px-4 py-3 " \
                  "text-sm text-text-muted"
-    PAGE_BTN   = "inline-flex h-8 w-8 items-center justify-center rounded-md border border-border " \
+    # h-11 w-11 keeps the pager buttons at the AAA 44px target floor.
+    PAGE_BTN   = "inline-flex h-11 w-11 items-center justify-center rounded-md border border-border " \
                  "hover:bg-surface-sunken hover:text-text-heading disabled:pointer-events-none " \
-                 "disabled:opacity-40 transition"
+                 "disabled:opacity-40 focus-visible:outline-none focus-visible:ring-[3px] " \
+                 "focus-visible:ring-interactive-focus transition"
     SORT_ASC   = "▲"
     SORT_DESC  = "▼"
 
+    # columns: array of { key:, label:, sortable: true }
+    # rows:    array of hashes (keys must match column keys)
+    # per_page: rows per page (default 10, 0 = no pagination)
+    # caption:  optional <caption> text (strongly encouraged — it is the table's
+    #           accessible name)
     def initialize(columns:, rows:, per_page: 10, caption: nil, **html_attrs)
       @columns   = columns
       @rows      = rows
@@ -44,9 +79,16 @@ module UI
         data: {
           controller: "data-table",
           data_table_per_page_value: @per_page,
-          data_table_total_value: @rows.size
+          data_table_total_value: @rows.size,
+          # JS-interpolated %{...} templates (the controller does plain %{key}
+          # substitution client-side). Localized here so the strings live in the
+          # app's locale files, not in the JS.
+          data_table_results_template: I18n.t("modelrails_ui.data_table.results", default: "%{count} results"),
+          data_table_page_template: I18n.t("modelrails_ui.data_table.page",
+            default: "Page %{page} of %{pages} (%{rows} rows)")
         },
         **@html_attrs) do
+        concat status_region
         concat toolbar
         concat table_element
         concat footer if @per_page > 0
@@ -54,6 +96,14 @@ module UI
     end
 
     private
+
+    # Always-present polite live region. The controller writes the localized
+    # result count here after filtering so screen-reader users hear the outcome.
+    def status_region
+      content_tag(:div, nil,
+        role: "status", "aria-live": "polite", class: "sr-only",
+        data: { data_table_target: "status" })
+    end
 
     def toolbar
       content_tag(:div, class: TOOLBAR) do
@@ -66,7 +116,9 @@ module UI
         concat search_icon
         concat tag.input(
           type: "search", class: SEARCH_INPUT,
-          placeholder: "Search…",
+          # aria-label is the accessible name; the placeholder is only a hint.
+          "aria-label": I18n.t("modelrails_ui.data_table.search_label", default: "Search"),
+          placeholder: I18n.t("modelrails_ui.data_table.search_placeholder", default: "Search…"),
           data: {
             data_table_target: "search",
             action: "input->data-table#filter"
@@ -91,27 +143,31 @@ module UI
     end
 
     def th_cell(col)
-      key     = col[:key].to_s
-      label   = col[:label] || key.humanize
+      key      = col[:key].to_s
+      label    = col[:label] || key.humanize
       sortable = col.fetch(:sortable, false)
 
-      content_tag(:th, class: cn(TH_CLS, sortable ? TH_SORT : nil),
-        data: sortable ? {
-          action: "click->data-table#sort",
-          data_table_key_param: key
-        } : {}) do
-        content_tag(:span, class: "flex items-center gap-1") do
-          concat label
-          if sortable
-            concat content_tag(:span, SORT_ASC,
-              class: "text-xs opacity-0 data-[active=asc]:opacity-100",
-              data: { data_table_target: "sortIndicator", data_table_sort_key: key, data_table_dir: "asc" })
-            concat content_tag(:span, SORT_DESC,
-              class: "text-xs opacity-0 data-[active=desc]:opacity-100",
-              data: { data_table_target: "sortIndicator", data_table_sort_key: key, data_table_dir: "desc" })
-          end
-        end
+      return content_tag(:th, label, class: TH_CLS) unless sortable
+
+      # Sortable: th[aria-sort] (the controller flips it) wrapping a focusable
+      # button that carries the sort action + key param.
+      content_tag(:th, sort_button(key, label), class: TH_CLS, "aria-sort": "none")
+    end
+
+    def sort_button(key, label)
+      content_tag(:button, type: "button", class: SORT_BTN,
+        data: { action: "click->data-table#sort", data_table_key_param: key }) do
+        concat label
+        concat sort_indicator(key, "asc", SORT_ASC)
+        concat sort_indicator(key, "desc", SORT_DESC)
       end
+    end
+
+    def sort_indicator(key, dir, glyph)
+      content_tag(:span, glyph,
+        class: "text-xs opacity-0 data-[active=#{dir}]:opacity-100",
+        "aria-hidden": "true",
+        data: { data_table_target: "sortIndicator", data_table_sort_key: key, data_table_dir: dir })
     end
 
     def tbody
@@ -132,11 +188,13 @@ module UI
 
     def footer
       content_tag(:div, class: FOOTER_CLS) do
-        concat content_tag(:span, "Page 1",
+        concat content_tag(:span, "",
           data: { data_table_target: "pageLabel" })
         concat(content_tag(:div, class: "flex items-center gap-1") {
-          concat page_btn("‹", "click->data-table#prevPage", "Previous page")
-          concat page_btn("›", "click->data-table#nextPage", "Next page")
+          concat page_btn("‹", "click->data-table#prevPage",
+            I18n.t("modelrails_ui.data_table.prev_page", default: "Previous page"))
+          concat page_btn("›", "click->data-table#nextPage",
+            I18n.t("modelrails_ui.data_table.next_page", default: "Next page"))
         })
       end
     end

--- a/lib/generators/modelrails_ui/add/templates/data_table/data_table_controller.js
+++ b/lib/generators/modelrails_ui/add/templates/data_table/data_table_controller.js
@@ -1,7 +1,7 @@
 import { Controller } from "@hotwired/stimulus"
 
 export default class extends Controller {
-  static targets = ["body", "search", "pageLabel", "sortIndicator"]
+  static targets = ["body", "search", "pageLabel", "sortIndicator", "status"]
   static values = {
     perPage: { type: Number, default: 10 },
     total:   { type: Number, default: 0 }
@@ -27,6 +27,7 @@ export default class extends Controller {
     this.#sortKey = null
     this.#sortDir = null
     this.#clearSortIndicators()
+    this.#clearAriaSort()
     this.#render()
   }
 
@@ -47,6 +48,10 @@ export default class extends Controller {
       )
       if (indicator) indicator.dataset.active = this.#sortDir
     }
+
+    // Reflect the active sort to assistive tech: the owning th gets
+    // aria-sort=ascending|descending, every other sortable th resets to none.
+    this.#updateAriaSort()
 
     if (this.#sortKey) {
       const colIdx = this.#columnIndex(this.#sortKey)
@@ -83,12 +88,18 @@ export default class extends Controller {
     rows.slice(start, end).forEach(row => { row.style.display = "" })
 
     if (this.hasPageLabelTarget) {
-      if (perPage > 0 && total > 0) {
-        this.pageLabelTarget.textContent =
-          `Page ${this.#page} of ${this.#totalPages} (${total} rows)`
-      } else {
-        this.pageLabelTarget.textContent = `${total} rows`
-      }
+      this.pageLabelTarget.textContent =
+        perPage > 0 && total > 0
+          ? this.#interpolate(this.#pageTemplate, {
+              page: this.#page, pages: this.#totalPages, rows: total
+            })
+          : this.#interpolate(this.#resultsTemplate, { count: total })
+    }
+
+    // Announce the result count to screen readers (filter/sort/page outcome).
+    if (this.hasStatusTarget) {
+      this.statusTarget.textContent =
+        this.#interpolate(this.#resultsTemplate, { count: total })
     }
   }
 
@@ -96,9 +107,49 @@ export default class extends Controller {
     this.sortIndicatorTargets.forEach(el => delete el.dataset.active)
   }
 
+  #updateAriaSort() {
+    this.#sortableHeaders().forEach(th => {
+      const key = th.querySelector("[data-data-table-key-param]")?.dataset.dataTableKeyParam
+      th.setAttribute(
+        "aria-sort",
+        this.#sortKey && key === this.#sortKey
+          ? (this.#sortDir === "asc" ? "ascending" : "descending")
+          : "none"
+      )
+    })
+  }
+
+  #clearAriaSort() {
+    this.#sortableHeaders().forEach(th => th.setAttribute("aria-sort", "none"))
+  }
+
+  #sortableHeaders() {
+    return Array.from(this.element.querySelectorAll("th[aria-sort]"))
+  }
+
+  // Index among ALL header cells (not just sortable ones) so the cell offset
+  // is correct even when non-sortable columns precede the sorted one.
   #columnIndex(key) {
-    const headers = this.element.querySelectorAll("th[data-data-table-key-param]")
-    return Array.from(headers).findIndex(h => h.dataset.dataTableKeyParam === key)
+    const headers = Array.from(this.element.querySelectorAll("thead th"))
+    return headers.findIndex(
+      th => th.querySelector("[data-data-table-key-param]")?.dataset.dataTableKeyParam === key
+    )
+  }
+
+  // Plain %{name} substitution matching the I18n template strings passed from
+  // the component (data-data-table-*-template attributes on the root).
+  #interpolate(template, vars) {
+    return (template || "").replace(/%\{(\w+)\}/g, (_, name) =>
+      name in vars ? vars[name] : `%{${name}}`
+    )
+  }
+
+  get #resultsTemplate() {
+    return this.element.dataset.dataTableResultsTemplate ?? ""
+  }
+
+  get #pageTemplate() {
+    return this.element.dataset.dataTablePageTemplate ?? ""
   }
 
   get #totalPages() {

--- a/lib/generators/modelrails_ui/lookbook/templates/previews/ui/badge_component_preview.rb
+++ b/lib/generators/modelrails_ui/lookbook/templates/previews/ui/badge_component_preview.rb
@@ -1,0 +1,71 @@
+# frozen_string_literal: true
+
+module UI
+  # # Badge
+  #
+  # A small status/category label — a compact pill that tags surrounding content.
+  # Renders a `<span>`, or an `<a>` when `href:` is given (a clickable tag/filter link).
+  #
+  # ## Use when
+  # - A short inline label that classifies or annotates nearby content (status pill,
+  #   category tag, small count).
+  #
+  # ## Don't use when
+  # - It's a real action — use `UI::ButtonComponent` (or `button_to` for non-GET).
+  #
+  # ## Accessibility contract
+  # - **Guarantees:** AAA-contrast text on every variant, including the adaptive
+  #   `destructive` treatment that stays legible in dark mode.
+  # - **You supply:** an accessible name when the badge conveys status not already in
+  #   the surrounding text, and a valid `variant` (an unknown one raises in development).
+  #
+  # ## Variants
+  # `default` · `secondary` · `destructive` · `outline` · `ghost` · `link`
+  class BadgeComponentPreview < ViewComponent::Preview
+    include UIHelper
+
+    # The default, high-emphasis label.
+    def default
+    end
+
+    # Neutral / lower-emphasis label.
+    def secondary
+    end
+
+    # Error / removed / failed status. Uses the adaptive on-interactive token (AAA in dark mode).
+    def destructive
+    end
+
+    # Outlined label — a border with no fill.
+    def outline
+    end
+
+    # Minimal label — no fill, no border; reveals a surface tint on hover when linked.
+    def ghost
+    end
+
+    # Link-styled label — pair with `href:` for a clickable tag/filter.
+    def link
+    end
+
+    # Linked badge: pass `href:` and the component renders an `<a>`.
+    def link_href
+    end
+
+    # Edit `label` and `variant` live to explore the component.
+    # @param label text
+    # @param variant select [default, secondary, destructive, outline, ghost, link]
+    def playground(label: "Badge", variant: :default)
+      ui :badge, label, variant: variant.to_sym
+    end
+
+    # ## Don't — a badge as an action
+    #
+    # A badge is presentational. Don't wire a click handler onto a bare badge to fake
+    # a button — screen-reader and keyboard users get no interactive affordance.
+    # Use `UI::ButtonComponent` for actions, or pass `href:` for genuine navigation.
+    # @label Don't · badge as an action
+    def dont_action
+    end
+  end
+end

--- a/lib/generators/modelrails_ui/lookbook/templates/previews/ui/badge_component_preview/default.html.erb
+++ b/lib/generators/modelrails_ui/lookbook/templates/previews/ui/badge_component_preview/default.html.erb
@@ -1,0 +1,1 @@
+<%= ui :badge, "New" %>

--- a/lib/generators/modelrails_ui/lookbook/templates/previews/ui/badge_component_preview/destructive.html.erb
+++ b/lib/generators/modelrails_ui/lookbook/templates/previews/ui/badge_component_preview/destructive.html.erb
@@ -1,0 +1,1 @@
+<%= ui :badge, "Failed", variant: :destructive %>

--- a/lib/generators/modelrails_ui/lookbook/templates/previews/ui/badge_component_preview/dont_action.html.erb
+++ b/lib/generators/modelrails_ui/lookbook/templates/previews/ui/badge_component_preview/dont_action.html.erb
@@ -1,0 +1,2 @@
+<%# ✗ a bare badge is not interactive — use ui :button (or href: for navigation) %>
+<%= ui :badge, "Delete", variant: :destructive %>

--- a/lib/generators/modelrails_ui/lookbook/templates/previews/ui/badge_component_preview/ghost.html.erb
+++ b/lib/generators/modelrails_ui/lookbook/templates/previews/ui/badge_component_preview/ghost.html.erb
@@ -1,0 +1,1 @@
+<%= ui :badge, "Archived", variant: :ghost %>

--- a/lib/generators/modelrails_ui/lookbook/templates/previews/ui/badge_component_preview/link.html.erb
+++ b/lib/generators/modelrails_ui/lookbook/templates/previews/ui/badge_component_preview/link.html.erb
@@ -1,0 +1,1 @@
+<%= ui :badge, "Learn more", variant: :link %>

--- a/lib/generators/modelrails_ui/lookbook/templates/previews/ui/badge_component_preview/link_href.html.erb
+++ b/lib/generators/modelrails_ui/lookbook/templates/previews/ui/badge_component_preview/link_href.html.erb
@@ -1,0 +1,1 @@
+<%= ui :badge, "Rails", href: "/tags/rails", variant: :secondary %>

--- a/lib/generators/modelrails_ui/lookbook/templates/previews/ui/badge_component_preview/outline.html.erb
+++ b/lib/generators/modelrails_ui/lookbook/templates/previews/ui/badge_component_preview/outline.html.erb
@@ -1,0 +1,1 @@
+<%= ui :badge, "Beta", variant: :outline %>

--- a/lib/generators/modelrails_ui/lookbook/templates/previews/ui/badge_component_preview/secondary.html.erb
+++ b/lib/generators/modelrails_ui/lookbook/templates/previews/ui/badge_component_preview/secondary.html.erb
@@ -1,0 +1,1 @@
+<%= ui :badge, "Draft", variant: :secondary %>

--- a/lib/generators/modelrails_ui/lookbook/templates/previews/ui/data_table_component_preview.rb
+++ b/lib/generators/modelrails_ui/lookbook/templates/previews/ui/data_table_component_preview.rb
@@ -1,0 +1,52 @@
+# frozen_string_literal: true
+
+module UI
+  # # DataTable
+  #
+  # A sortable, filterable table with client-side search and pagination. Sortable
+  # columns are keyboard-operable `<button>`s inside `th[aria-sort]`; a visually-hidden
+  # live region announces the result count after filtering. Behavior lives in the
+  # `data-table` Stimulus controller that ships alongside this component.
+  #
+  # ## Use when
+  # - You have a bounded, already-loaded set of rows worth searching, sorting, or
+  #   paging through entirely on the client.
+  #
+  # ## Don't use when
+  # - The dataset is large or server-paginated — client-side filtering only sees the
+  #   rows already in the DOM; render a server-driven table instead.
+  #
+  # ## Accessibility contract
+  # - **Guarantees:** keyboard-operable sort headers with `aria-sort` flipped by the
+  #   controller, a polite live-region result-count announcement on filter, AAA 44px
+  #   targets on every control, and fully localized strings.
+  # - **You supply:** a `caption:` — the table's accessible name. Pass one whenever
+  #   practical so screen-reader users get context.
+  class DataTableComponentPreview < ViewComponent::Preview
+    include UIHelper
+
+    # A few sortable + one non-sortable column, rows, and a caption (the
+    # accessible name). Try Tab-ing to a header and pressing Enter to sort.
+    def default
+    end
+
+    # Small `per_page` so the pager renders. The footer shows the localized
+    # "Page X of Y (N rows)" label; filtering announces "N results".
+    def paginated
+    end
+
+    # No `sortable: true` on any column — plain `<th>`s, no sort buttons, no
+    # `aria-sort`. Search still works.
+    def not_sortable
+    end
+
+    # ## Don't — a table with no caption
+    #
+    # A `<table>` with no `caption:` (and no other accessible name) leaves
+    # screen-reader users without context for what the data represents. Always
+    # pass a descriptive `caption:`.
+    # @label Don't · no caption (no accessible name)
+    def dont_no_caption
+    end
+  end
+end

--- a/lib/generators/modelrails_ui/lookbook/templates/previews/ui/data_table_component_preview/default.html.erb
+++ b/lib/generators/modelrails_ui/lookbook/templates/previews/ui/data_table_component_preview/default.html.erb
@@ -1,0 +1,14 @@
+<%# Sortable name/email + non-sortable role; caption is the accessible name. %>
+<%= ui :data_table,
+      caption: "Team members",
+      columns: [
+        { key: :name,  label: "Name",  sortable: true },
+        { key: :email, label: "Email", sortable: true },
+        { key: :role,  label: "Role" }
+      ],
+      rows: [
+        { name: "Ada Lovelace",   email: "ada@example.com",   role: "Owner" },
+        { name: "Alan Turing",    email: "alan@example.com",  role: "Admin" },
+        { name: "Grace Hopper",   email: "grace@example.com", role: "Member" },
+        { name: "Katherine J.",   email: "kj@example.com",    role: "Member" }
+      ] %>

--- a/lib/generators/modelrails_ui/lookbook/templates/previews/ui/data_table_component_preview/dont_no_caption.html.erb
+++ b/lib/generators/modelrails_ui/lookbook/templates/previews/ui/data_table_component_preview/dont_no_caption.html.erb
@@ -1,0 +1,10 @@
+<%# ✗ no caption — the table has no accessible name; screen-reader users get no context. Always pass caption:. %>
+<%= ui :data_table,
+      columns: [
+        { key: :name, label: "Name", sortable: true },
+        { key: :role, label: "Role" }
+      ],
+      rows: [
+        { name: "Ada Lovelace", role: "Owner" },
+        { name: "Alan Turing",  role: "Admin" }
+      ] %>

--- a/lib/generators/modelrails_ui/lookbook/templates/previews/ui/data_table_component_preview/not_sortable.html.erb
+++ b/lib/generators/modelrails_ui/lookbook/templates/previews/ui/data_table_component_preview/not_sortable.html.erb
@@ -1,0 +1,13 @@
+<%# No sortable columns: plain <th>s, no sort buttons, no aria-sort. Search still filters. %>
+<%= ui :data_table,
+      caption: "Recent events",
+      columns: [
+        { key: :event, label: "Event" },
+        { key: :actor, label: "Actor" },
+        { key: :at,    label: "When" }
+      ],
+      rows: [
+        { event: "Signed in",      actor: "ada@example.com",  at: "2m ago" },
+        { event: "Updated profile", actor: "alan@example.com", at: "1h ago" },
+        { event: "Invited member", actor: "grace@example.com", at: "3h ago" }
+      ] %>

--- a/lib/generators/modelrails_ui/lookbook/templates/previews/ui/data_table_component_preview/paginated.html.erb
+++ b/lib/generators/modelrails_ui/lookbook/templates/previews/ui/data_table_component_preview/paginated.html.erb
@@ -1,0 +1,18 @@
+<%# Small per_page forces the pager; the footer label and live region are localized. %>
+<%= ui :data_table,
+      caption: "Products",
+      per_page: 3,
+      columns: [
+        { key: :sku,   label: "SKU",   sortable: true },
+        { key: :name,  label: "Name",  sortable: true },
+        { key: :price, label: "Price", sortable: true }
+      ],
+      rows: [
+        { sku: "A-100", name: "Widget",   price: "$9.00" },
+        { sku: "A-101", name: "Gadget",   price: "$14.00" },
+        { sku: "A-102", name: "Gizmo",    price: "$7.50" },
+        { sku: "A-103", name: "Doohickey", price: "$22.00" },
+        { sku: "A-104", name: "Thingamajig", price: "$3.25" },
+        { sku: "A-105", name: "Contraption", price: "$48.00" },
+        { sku: "A-106", name: "Whatsit",  price: "$11.75" }
+      ] %>

--- a/test/render/badge_render_test.rb
+++ b/test/render/badge_render_test.rb
@@ -1,0 +1,42 @@
+# frozen_string_literal: true
+
+require "render_test_helper"
+load_component "badge", "badge_component.rb.tt"
+
+class BadgeRenderTest < ViewComponent::TestCase
+  def test_default_renders_span_with_label
+    render_inline(UI::BadgeComponent.new("New"))
+
+    assert_selector "span", text: "New"
+  end
+
+  # AAA semantic tokens (the design-token guarantee), not raw Tailwind:
+  def test_default_renders_with_aaa_tokens
+    render_inline(UI::BadgeComponent.new("New"))
+
+    assert_selector "span.bg-interactive"
+    assert_selector "span.text-text-on-interactive"
+  end
+
+  # Per-surface dark-AAA fix: destructive must use the adaptive text-text-on-interactive
+  # token, NOT text-white (white-on-light-pink fails AAA in dark mode).
+  def test_destructive_uses_adaptive_on_interactive_token
+    render_inline(UI::BadgeComponent.new("Error", variant: :destructive))
+
+    assert_selector "span.bg-danger"
+    assert_selector "span.text-text-on-interactive"
+    refute_selector "span.text-white"
+  end
+
+  def test_href_renders_anchor
+    render_inline(UI::BadgeComponent.new("Docs", href: "/docs"))
+
+    assert_selector "a[href='/docs']", text: "Docs"
+  end
+
+  def test_unknown_variant_raises
+    assert_raises(ArgumentError) do
+      render_inline(UI::BadgeComponent.new("X", variant: :bogus))
+    end
+  end
+end

--- a/test/render/data_table_render_test.rb
+++ b/test/render/data_table_render_test.rb
@@ -1,0 +1,147 @@
+# frozen_string_literal: true
+
+require "render_test_helper"
+load_component "data_table", "data_table_component.rb.tt"
+
+# STRUCTURE-only render tests. The data-table Stimulus controller's behavior
+# (aria-sort flipping on click, the live region announcing result counts on
+# filter, page-label interpolation) is verified by an app-level 0b browser
+# spec — the render harness CANNOT exercise JS, so we assert the static
+# scaffolding the controller relies on, never the runtime behavior itself.
+class DataTableRenderTest < ViewComponent::TestCase
+  COLUMNS = [
+    {key: :name, label: "Name", sortable: true},
+    {key: :email, label: "Email", sortable: true},
+    {key: :role, label: "Role"} # non-sortable
+  ].freeze
+
+  ROWS = [
+    {name: "Ada", email: "ada@example.com", role: "Admin"},
+    {name: "Babbage", email: "chuck@example.com", role: "Member"}
+  ].freeze
+
+  def render_default(**overrides)
+    render_inline(UI::DataTableComponent.new(columns: COLUMNS, rows: ROWS, **overrides))
+  end
+
+  # --- Keyboard-operable sort header + aria-sort -----------------------------
+
+  # A sortable column renders th[aria-sort='none'] containing a focusable
+  # <button> that carries the sort action + key param. The button (not the th)
+  # is keyboard-operable for free.
+  def test_sortable_header_is_a_button_inside_an_aria_sort_th
+    render_default
+
+    assert_selector "th[aria-sort='none'] button[type='button'][data-action~='click->data-table#sort']"
+    assert_selector "th[aria-sort='none'] button[data-data-table-key-param='name']"
+    assert_selector "th[aria-sort='none'] button[data-data-table-key-param='email']"
+  end
+
+  # The click handler must live on the BUTTON, not the (non-focusable) <th>.
+  def test_sort_action_is_not_on_the_th_itself
+    render_default
+
+    assert_no_selector "th[data-action~='click->data-table#sort']"
+  end
+
+  # Non-sortable columns stay a plain <th> with no aria-sort and no sort button.
+  def test_non_sortable_header_has_no_aria_sort_and_no_button
+    render_default
+
+    role_th = page.find("th", text: "Role")
+
+    assert_nil role_th[:"aria-sort"], "non-sortable th must not advertise aria-sort"
+    assert_no_selector "th button[data-data-table-key-param='role']"
+  end
+
+  # --- Live region for result count -----------------------------------------
+
+  # An always-present visually-hidden polite status region the controller
+  # writes the localized result count into on filter/sort/page.
+  def test_renders_a_polite_status_live_region
+    render_default
+
+    assert_selector "div[role='status'][aria-live='polite'].sr-only[data-data-table-target='status']"
+  end
+
+  # --- 44px AAA targets (WCAG 2.5.5) -----------------------------------------
+
+  def test_pager_buttons_are_44px
+    render_default(per_page: 1)
+
+    assert_selector "button.h-11.w-11", minimum: 2 # prev + next
+  end
+
+  def test_search_control_is_44px_tall
+    render_default
+
+    assert_selector "label.h-11" # the search wrapper row
+  end
+
+  def test_sortable_header_button_is_at_least_44px_tall
+    render_default
+
+    # The header button fills the (>=44px) cell height.
+    assert_selector "th button.min-h-11"
+  end
+
+  # --- AAA semantic tokens, not raw Tailwind ---------------------------------
+
+  def test_renders_with_aaa_semantic_tokens
+    render_default
+
+    assert_selector "div.border-border"        # wrapper
+    assert_selector "th.text-text-muted"        # header cell
+  end
+
+  # --- i18n: server-rendered defaults ----------------------------------------
+
+  def test_search_input_has_default_placeholder_and_accessible_name
+    render_default
+
+    assert_selector "input[type='search'][placeholder='Search…']"
+    assert_selector "input[type='search'][aria-label='Search']"
+  end
+
+  def test_pager_aria_labels_render_defaults
+    render_default(per_page: 1)
+
+    assert_selector "button[aria-label='Previous page']"
+    assert_selector "button[aria-label='Next page']"
+  end
+
+  # --- i18n: JS templates exposed as data attributes on the root -------------
+
+  # The controller interpolates these %{...} templates client-side; the render
+  # harness only asserts they are present with their default English text.
+  def test_js_interpolation_templates_are_on_the_root
+    render_default
+
+    root = page.find("div[data-controller~='data-table']")
+
+    assert_equal "%{count} results", root["data-data-table-results-template"]
+    assert_equal "Page %{page} of %{pages} (%{rows} rows)", root["data-data-table-page-template"]
+  end
+
+  # --- Rows / cells / caption ------------------------------------------------
+
+  def test_renders_rows_and_cells
+    render_default
+
+    assert_selector "tbody tr[data-data-table-row]", count: 2
+    assert_selector "td", text: "ada@example.com"
+    assert_selector "td", text: "Admin"
+  end
+
+  def test_renders_caption_when_given
+    render_default(caption: "Active users")
+
+    assert_selector "caption", text: "Active users"
+  end
+
+  def test_no_caption_by_default
+    render_default
+
+    assert_no_selector "caption"
+  end
+end


### PR DESCRIPTION
## Summary

Wave 1 sub-wave 2 — the two display components hardened to the 10-point DoD. Bundled (one PR).

- **badge**: fail-loud `coerce_variant` guard; **per-surface danger AAA fix** — `destructive` was `bg-danger text-white`, which fails AAA in dark mode (dark `--color-danger` is a light pink) → now `text-text-on-interactive` (adaptive, matches the danger button); `href:`→`<a>` polymorphism (makes the `[a&]:` link styles meaningful). Render test (with a `text-white` regression guard) + preview.
- **data_table** (program's heaviest): **keyboard-operable sort** — sortable headers are now `<th aria-sort><button>` (the `<th>` click handler was mouse-only); the controller flips `aria-sort` ascending/descending/none and resets on filter. **Live region** (`role="status" aria-live="polite"`) announces filtered result counts. **44px** targets (pager/search/header all ≥44px). **i18n** — server strings via inline `I18n.t(…, default:)`, JS-generated strings ("Page X of Y", "N results") via I18n'd templates passed as data-attrs + interpolated. Fixed a latent `#columnIndex` bug (key-param moved to the button → re-derived so a sortable column after a non-sortable one sorts the right cells). Render test (structure) + preview.

`COMPONENT_STATUS.md`: badge + data_table → `hardened`.

## Test Plan

- [x] `rake` green — `test:structural` 441/0 + `test:render` **79/0** (9 components) + rubocop clean
- [ ] 0b: app-side axe specs (companion app PR). badge: audit all variants both themes (destructive dark, ghost/outline context-dependent). data_table gets an enhanced browser spec: keyboard sort activation, `aria-sort` flip, live-region announce, 44px geometry, and the `#columnIndex` correctness on a column after a non-sortable one.