### PR TITLE
fix(data_table): re-insert sorted rows in render (sort was display-only)

### DIFF
--- a/lib/generators/modelrails_ui/add/templates/data_table/data_table_controller.js
+++ b/lib/generators/modelrails_ui/add/templates/data_table/data_table_controller.js
@@ -85,6 +85,13 @@ export default class extends Controller {
     const end   = perPage > 0 ? start + perPage : total
 
     this.#allRows.forEach(row => { row.style.display = "none" })
+    // Re-insert the filtered rows in SORTED order so the DOM matches the sort.
+    // The previous display-only approach left the tbody in its original order,
+    // so aria-sort announced an order the visible rows did not actually have
+    // (a WCAG false state) and sort was a visible no-op on a single page.
+    // appendChild MOVES each node, so iterating the sorted array reorders the
+    // tbody; filtered-out rows stay hidden and their position is irrelevant.
+    rows.forEach(row => this.bodyTarget.appendChild(row))
     rows.slice(start, end).forEach(row => { row.style.display = "" })
 
     if (this.hasPageLabelTarget) {

--- a/lib/generators/modelrails_ui/lookbook/templates/previews/ui/data_table_component_preview/default.html.erb
+++ b/lib/generators/modelrails_ui/lookbook/templates/previews/ui/data_table_component_preview/default.html.erb
@@ -7,8 +7,8 @@
         { key: :role,  label: "Role" }
       ],
       rows: [
-        { name: "Ada Lovelace",   email: "ada@example.com",   role: "Owner" },
-        { name: "Alan Turing",    email: "alan@example.com",  role: "Admin" },
         { name: "Grace Hopper",   email: "grace@example.com", role: "Member" },
-        { name: "Katherine J.",   email: "kj@example.com",    role: "Member" }
+        { name: "Ada Lovelace",   email: "ada@example.com",   role: "Owner" },
+        { name: "Katherine J.",   email: "alan@example.com",  role: "Member" },
+        { name: "Alan Turing",    email: "kj@example.com",    role: "Admin" }
       ] %>


### PR DESCRIPTION
## Summary

Fixes a functional + WCAG bug in `data_table` surfaced by the app's 0b browser spec.

`data_table_controller.js#render()` sorted the `#filtered` array correctly but only toggled each row's `display` — it never re-inserted the `<tr>` nodes in sorted order. So when rows fit on one page, activating a sortable header flipped `aria-sort` to `ascending`/`descending` while the visible rows **did not move** — the table announced an order it didn't have (WCAG false state) and sort was a visible no-op. (Pagination only masked it by changing *which* rows showed.)

**Fix:** in `#render()`, re-append the sorted `#filtered` rows to the tbody before the page-slice display toggle, so the DOM matches the announced order:
```js
rows.forEach(row => this.bodyTarget.appendChild(row))
```

Also un-sorted the `default` preview's demo rows (they were pre-sorted ascending by both name and email, which masked the bug and made a sort test a no-op).

## Test Plan

- [x] `rake` green (render harness can't see JS behavior — unaffected)
- [x] Verified by the companion app 0b Playwright spec: DOM physically reorders on sort (`[Grace, Ada, Katherine, Alan]` → `[Ada, Alan, Grace, Katherine]`), email-sort keys the correct column, aria-sort cycle + live region + 44px all pass