### PR TITLE
feat(cn): back cn with tailwind_merge so class: overrides win

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -255,6 +255,7 @@ GEM
       simplecov_json_formatter (~> 0.1)
     simplecov-html (0.13.2)
     simplecov_json_formatter (0.1.4)
+    sin_lru_redux (2.5.2)
     standard (1.54.0)
       language_server-protocol (~> 3.17.0.2)
       lint_roller (~> 1.0)
@@ -268,6 +269,8 @@ GEM
       lint_roller (~> 1.1)
       rubocop-performance (~> 1.26.0)
     stringio (3.2.0)
+    tailwind_merge (1.5.1)
+      sin_lru_redux (~> 2.5)
     thor (1.5.0)
     timeout (0.6.1)
     tsort (0.2.0)
@@ -313,6 +316,7 @@ DEPENDENCIES
   rubocop-performance
   simplecov (~> 0.21)
   standard
+  tailwind_merge
 
 CHECKSUMS
   action_text-trix (2.1.19) sha256=7012f59421009cf284aa651294896414d653a61a2417c9b8714c8476d2f74009
@@ -402,10 +406,12 @@ CHECKSUMS
   simplecov (0.22.0) sha256=fe2622c7834ff23b98066bb0a854284b2729a569ac659f82621fc22ef36213a5
   simplecov-html (0.13.2) sha256=bd0b8e54e7c2d7685927e8d6286466359b6f16b18cb0df47b508e8d73c777246
   simplecov_json_formatter (0.1.4) sha256=529418fbe8de1713ac2b2d612aa3daa56d316975d307244399fa4838c601b428
+  sin_lru_redux (2.5.2) sha256=feed104c943afaeeecb1ad83f3f63562088b9785a816625c32b2305eccbd9963
   standard (1.54.0) sha256=7a4b08f83d9893083c8f03bc486f0feeb6a84d48233b40829c03ef4767ea0100
   standard-custom (1.0.2) sha256=424adc84179a074f1a2a309bb9cf7cd6bfdb2b6541f20c6bf9436c0ba22a652b
   standard-performance (1.9.0) sha256=49483d31be448292951d80e5e67cdcb576c2502103c7b40aec6f1b6e9c88e3f2
   stringio (3.2.0) sha256=c37cb2e58b4ffbd33fe5cd948c05934af997b36e0b6ca6fdf43afa234cf222e1
+  tailwind_merge (1.5.1) sha256=cf307d491870948c0fa19a327b5af1cc799a27931bdd1dcac56c18a85c36c266
   thor (1.5.0) sha256=e3a9e55fe857e44859ce104a84675ab6e8cd59c650a49106a05f55f136425e73
   timeout (0.6.1) sha256=78f57368a7e7bbadec56971f78a3f5ecbcfb59b7fcbb0a3ed6ddc08a5094accb
   tsort (0.2.0) sha256=9650a793f6859a43b6641671278f79cfead60ac714148aabe4e3f0060480089f

--- a/lib/generators/modelrails_ui/install/install_generator.rb
+++ b/lib/generators/modelrails_ui/install/install_generator.rb
@@ -28,6 +28,19 @@ module ModelrailsUi
         end
       end
 
+      def add_tailwind_merge_gem
+        gemfile = File.join(destination_root, "Gemfile")
+
+        if File.exist?(gemfile) && File.read(gemfile).match?(/^\s*gem\s+["']tailwind_merge["']/)
+          say "  Gemfile already requires tailwind_merge — skipping.", :yellow
+          return
+        end
+
+        gem "tailwind_merge"
+        say "  Added gem \"tailwind_merge\" to your Gemfile — the generated ApplicationComponent's " \
+            "`cn` helper requires it at runtime so `class:` overrides win conflicts. Run `bundle install`.", :green
+      end
+
       def create_inflection_initializer
         target = "config/initializers/modelrails_ui_inflections.rb"
 

--- a/lib/generators/modelrails_ui/install/templates/application_component.rb.tt
+++ b/lib/generators/modelrails_ui/install/templates/application_component.rb.tt
@@ -1,16 +1,26 @@
 # frozen_string_literal: true
 
+require "tailwind_merge"
+
 # Base class for modelrails_ui components.
 #
-# Self-contained on purpose: the `cn` class-merge helper is inlined so your app
-# carries NO runtime dependency on the modelrails_ui gem. modelrails_ui is a
-# dev-only scaffolding tool (it generates these files); production loads only
-# your vendored components + view_component.
+# The `cn` class-merge helper is backed by `tailwind_merge` (a small pure-Ruby
+# runtime dependency) so a per-instance `class:` passthrough correctly OVERRIDES
+# conflicting base utilities — e.g. `class: "rounded-full"` beats a base
+# `rounded-md`, instead of both being emitted and CSS source-order deciding the
+# winner. The install generator adds `gem "tailwind_merge"` to your Gemfile.
 class ApplicationComponent < ViewComponent::Base
   private
 
-  # Join Tailwind class lists into one string, dropping nils and blanks.
+  # Merge Tailwind class lists into one string, dropping nils/blanks and letting
+  # later (passthrough) utilities win conflicts via tailwind_merge.
+  #
+  # tailwind_merge 1.x builds its internal LruRedux::Cache (NOT the thread-safe
+  # variant), so a single shared Merger is not concurrency-safe under Puma.
+  # We keep one Merger per thread: each thread owns its cache, so there is no
+  # shared mutable state and no lock on this hot path.
   def cn(*classes)
-    classes.flatten.compact.reject { |c| c.to_s.empty? }.join(" ")
+    joined = classes.flatten.compact.reject { |c| c.to_s.empty? }.join(" ")
+    (Thread.current[:modelrails_ui_tw_merge] ||= TailwindMerge::Merger.new).merge(joined)
   end
 end

--- a/modelrails_ui.gemspec
+++ b/modelrails_ui.gemspec
@@ -33,4 +33,5 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency "appraisal"
   spec.add_development_dependency "capybara" # render-test assertions (ViewComponent::TestCase matchers)
   spec.add_development_dependency "lefthook"
+  spec.add_development_dependency "tailwind_merge" # render harness backs cn with real tailwind_merge (host gets it via install generator)
 end

--- a/test/render/button_render_test.rb
+++ b/test/render/button_render_test.rb
@@ -30,4 +30,14 @@ class ButtonRenderTest < ViewComponent::TestCase
       render_inline(UI::ButtonComponent.new("X", variant: :bogus))
     end
   end
+
+  # Behavioral proof of the tailwind_merge-backed `cn`: a `class:` passthrough
+  # must OVERRIDE a conflicting base utility. The filled base is `rounded-md`;
+  # passing `class: "rounded-full"` must win, and `rounded-md` must be dropped.
+  def test_class_passthrough_overrides_conflicting_base_utility
+    render_inline(UI::ButtonComponent.new("X", variant: :primary, class: "rounded-full"))
+
+    assert_selector "button.rounded-full"
+    refute_selector "button.rounded-md"
+  end
 end

--- a/test/render/render_test_helper.rb
+++ b/test/render/render_test_helper.rb
@@ -9,6 +9,7 @@ require "action_controller/railtie"
 require "action_view/railtie"
 require "view_component"
 require "view_component/test_helpers"
+require "tailwind_merge"
 
 class RenderHarnessApp < Rails::Application
   config.eager_load = false
@@ -28,12 +29,14 @@ require "view_component/test_case"
 require "minitest/autorun"
 
 # Real ApplicationComponent — mirrors install/templates/application_component.rb.tt
-# exactly (cn is inlined; no gem runtime dependency).
+# exactly (cn is backed by tailwind_merge so the render tests exercise components
+# under real merge behavior: a per-thread Merger, class: overrides win conflicts).
 class ApplicationComponent < ViewComponent::Base
   private
 
   def cn(*classes)
-    classes.flatten.compact.reject { |c| c.to_s.empty? }.join(" ")
+    joined = classes.flatten.compact.reject { |c| c.to_s.empty? }.join(" ")
+    (Thread.current[:modelrails_ui_tw_merge] ||= TailwindMerge::Merger.new).merge(joined)
   end
 end
 


### PR DESCRIPTION
## Summary

Swaps the vendored `cn` helper from a plain string-join to a real **`tailwind_merge`** (gjtorikian, v1.5.1, Tailwind-v4-aware), so a `class:` passthrough now **overrides** a conflicting base utility (e.g. `class: "rounded-full"` beats the base `rounded-md`) instead of leaving CSS source-order to decide.

**This intentionally reverses the prior "zero runtime dependency" design** (user-approved): the vendored `ApplicationComponent` now `require`s `tailwind_merge` (a small pure-Ruby dep + transitive `sin_lru_redux`). The doc-comment is updated to say so.

- `cn` (both the install **template** and the render **harness**, identical) → joined-then-`merge`, using a **thread-local** `Merger` (`Thread.current[…] ||= Merger.new`). Verified from the gem source that `tailwind_merge` 1.5.1 backs its cache with the non-thread-safe `LruRedux::Cache`, so a shared instance would race under Puma; thread-local gives a per-thread cache, no lock on the hot path, config built once per thread.
- Gemspec: `tailwind_merge` as a **dev** dependency (render harness needs it; also reaches the Appraisal lane). NOT a runtime `add_dependency` (the gem is dev-only in hosts).
- Install generator: idempotently adds `gem "tailwind_merge"` to the host Gemfile.
- `ModelrailsUi::ClassHelper` (structural-test-only, never ships to hosts) left as plain-join — conscious divergence.

A spike confirmed tailwind_merge resolves real conflicts AND preserves this library's arbitrary variants/custom tokens untouched (`[&>svg]:…`, `*:data-[slot=…]:…`, `[&::-webkit-slider-thumb]:…`, `peer-checked:…`, `aria-invalid:…`).

## Test Plan

- [x] `rake` green — structural 441/0 + render **188/0** (all 18 components' token-class assertions intact → tailwind_merge drops/mangles nothing) + rubocop
- [x] Override-proof render test: `class: "rounded-full"` → `rounded-full` present, base `rounded-md` gone (fails against the old plain-join cn; passes now)
- [ ] App side: Gemfile + vendored cn + full suite + 0b AAA (companion app PR)