### PR TITLE
feat(dialog): harden to DoD (Wave 4 overlays exemplar)

### DIFF
--- a/COMPONENT_STATUS.md
+++ b/COMPONENT_STATUS.md
@@ -38,6 +38,7 @@ without extra verification.
 | indicator | proven | ✅ | ✅ | Wave 3 (raw palette → semantic success/warning + text-on-interactive; fail-loud variant) |
 | image | proven | ✅ | ✅ | Wave 3 (required alt; loading-mode validation; conditional srcset/sizes/width/height) |
 | figure | proven | ✅ | ✅ | Wave 3 (figcaption only when caption given; text-text-muted is AAA here) |
+| dialog | hardened | ✅ | ⏳ | Wave 4 overlays exemplar (native <dialog>; 0a + JS-behavior 0b: open/escape/aria-modal + AAA on live modal). Was adopted unverified; now has render test + 0b. App 0b CI-pending |
 
 All other gem components: **experimental** (unverified) unless listed above.
 

--- a/lib/generators/modelrails_ui/add/templates/dialog/dialog_component.rb.tt
+++ b/lib/generators/modelrails_ui/add/templates/dialog/dialog_component.rb.tt
@@ -1,11 +1,32 @@
 # frozen_string_literal: true
 
 module UI
+  # # Dialog
+  #
+  # A native `<dialog>` modal — focus-trapped, `aria-modal`, with native Escape
+  # (cancel event) and `::backdrop`. The native element is chosen over a div so
+  # focus-trapping and the inert background come for free. Behavior lives in the
+  # `modal` Stimulus controller shipped alongside this component.
+  #
+  # ## Use when
+  # - You need a focus-trapped modal for a confirmation, form, or detail overlay.
+  # - You are building a custom wrapper (pass `wrapper: false` and own the
+  #   `data-controller="modal"` element + trigger).
+  #
+  # ## Don't use when
+  # - The action is a destructive non-GET — keep the submit in a `button_to` form;
+  #   the dialog is the container, not the action mechanism.
+  # - You need a non-blocking notification — use the toast / notification system.
+  #
+  # ## Accessibility contract
+  # - **Guarantees:** native `<dialog>` semantics (`role="dialog"`, `aria-modal="true"`),
+  #   `aria-labelledby` wired to the heading, `aria-describedby` when `description:` is
+  #   given, an accessible close button, and focus trap + restore via the `modal`
+  #   controller.
+  # - **You supply:** a `title:` (required — it is the accessible name). With
+  #   `wrapper: true` (default) the `trigger` slot is the open button; `wrapper: false`
+  #   requires you to wire `data-controller="modal"` and a trigger yourself.
   class DialogComponent < ApplicationComponent
-    # Native-<dialog> modal adopted from the host app's shared/_modal + modal_controller.
-    # Chosen over a div-based dialog because the native element gives free focus-trapping,
-    # an inert background, native Escape (cancel event) and ::backdrop — meeting the app's
-    # accessibility standard. Behavior lives in modal_controller.js (shipped alongside).
     renders_one :trigger
     renders_one :footer
 

--- a/test/render/dialog_render_test.rb
+++ b/test/render/dialog_render_test.rb
@@ -1,0 +1,82 @@
+# frozen_string_literal: true
+
+require "render_test_helper"
+require "securerandom"
+load_component "dialog", "dialog_component.rb.tt"
+
+# STRUCTURE-only render specs. The modal Stimulus controller's BEHAVIOR (showModal
+# on trigger, Escape/backdrop close, focus trap + restore) is verified by the
+# preview-host browser spec (spec/system/ui/dialog_component_spec.rb in the app) —
+# the render harness CANNOT exercise JS, so here we assert the static <dialog>
+# scaffolding the controller relies on (a closed native dialog with full ARIA).
+class DialogRenderTest < ViewComponent::TestCase
+  def test_renders_a_native_dialog_with_modal_semantics
+    render_inline(UI::DialogComponent.new(title: "Edit profile"))
+
+    assert_selector "dialog[role='dialog'][aria-modal='true']", visible: :all
+  end
+
+  def test_title_is_the_accessible_name_via_aria_labelledby
+    render_inline(UI::DialogComponent.new(title: "Edit profile", id: "m1"))
+
+    assert_selector "dialog[aria-labelledby='m1-title']", visible: :all
+    assert_selector "h2#m1-title", text: "Edit profile", visible: :all
+  end
+
+  def test_description_wires_aria_describedby
+    render_inline(UI::DialogComponent.new(title: "T", id: "m2", description: "Sub text"))
+
+    assert_selector "dialog[aria-describedby='m2-description']", visible: :all
+    assert_selector "p#m2-description", text: "Sub text", visible: :all
+  end
+
+  def test_omits_aria_describedby_without_a_description
+    render_inline(UI::DialogComponent.new(title: "T", id: "m3"))
+
+    assert_no_selector "dialog[aria-describedby]", visible: :all
+  end
+
+  def test_renders_an_accessible_close_button_wired_to_the_controller
+    render_inline(UI::DialogComponent.new(title: "T"))
+
+    assert_selector "button[type='button'][aria-label='Close'][data-action~='click->modal#close']", visible: :all
+  end
+
+  # AAA semantic tokens (the design-token guarantee), not raw Tailwind:
+  def test_renders_with_aaa_tokens
+    render_inline(UI::DialogComponent.new(title: "T"))
+
+    assert_selector "[data-modal-target='panel'].bg-surface-overlay", visible: :all
+    assert_selector "h2.text-text-heading", visible: :all
+  end
+
+  def test_wrapper_renders_the_modal_controller_and_trigger_action
+    render_inline(UI::DialogComponent.new(title: "T")) do |dialog|
+      dialog.with_trigger { "Open" }
+    end
+
+    assert_selector "div[data-controller='modal']", visible: :all
+    assert_selector "span[data-action~='click->modal#open']", text: "Open", visible: :all
+  end
+
+  def test_wrapper_false_renders_only_the_dialog
+    render_inline(UI::DialogComponent.new(title: "T", wrapper: false))
+
+    assert_no_selector "[data-controller='modal']", visible: :all
+    assert_selector "dialog[role='dialog']", visible: :all
+  end
+
+  def test_size_maps_to_a_max_width_on_the_panel
+    render_inline(UI::DialogComponent.new(title: "T", size: :lg))
+
+    assert_selector "[data-modal-target='panel'].max-w-2xl", visible: :all
+  end
+
+  def test_footer_slot_renders_in_a_footer_area
+    render_inline(UI::DialogComponent.new(title: "T")) do |dialog|
+      dialog.with_footer { "Footer actions" }
+    end
+
+    assert_text "Footer actions"
+  end
+end


### PR DESCRIPTION
## Wave 4 — Overlays exemplar: dialog

`dialog` was adopted earlier (vendored + previews) but never verified to the DoD. This adds the missing verification layer and establishes the **JS-behavior 0b pattern** the rest of the overlays family will follow.

- **0a** `test/render/dialog_render_test.rb` (10 tests): native `<dialog>` scaffolding — role/aria-modal/aria-labelledby/aria-describedby, accessible close button, sizes, wrapper modes. Full render lane 249/0.
- **doc**: promoted the terse impl note to the full groove doc-comment (Use / Don't / Accessibility contract).
- **ledger**: `hardened ⏳` (flips to `proven` once the app 0b is CI-green).

App-side counterpart (the 0b modal-behavior spec: open → audit live modal both themes → Escape closes) is in the matching modelrails_base PR.