### PR TITLE
fix(toggle): distinct selected vs hover surface

### DIFF
--- a/lib/generators/modelrails_ui/add/templates/toggle/toggle_component.rb.tt
+++ b/lib/generators/modelrails_ui/add/templates/toggle/toggle_component.rb.tt
@@ -22,12 +22,20 @@ module UI
   # ## Sizes
   # `default` · `sm` · `lg` — all rendered >=44px tall (the AAA target-size floor).
   class ToggleComponent < ApplicationComponent
+    # Hover and selected are intentionally DISTINCT surfaces so clicking to select
+    # gives immediate feedback (the prior version painted both `bg-surface-sunken`,
+    # so an off item already looked selected on hover and the click produced no
+    # visible change). Off-hover is the neutral `surface-sunken`; the selected (on)
+    # state is the tinted `interactive-subtle` / `text-interactive` pairing (AAA,
+    # same as badge `:secondary`). Hover is scoped to `data-[state=off]` so a
+    # selected toggle keeps its tinted look on hover instead of reverting to neutral.
     BASE = "inline-flex items-center justify-center gap-2 rounded-md text-sm font-medium whitespace-nowrap " \
-           "transition-[color,box-shadow] outline-none hover:bg-surface-sunken hover:text-text-muted " \
+           "transition-[color,box-shadow] outline-none " \
+           "data-[state=off]:hover:bg-surface-sunken data-[state=off]:hover:text-text-body " \
            "focus-visible:border-border-focus focus-visible:ring-[3px] focus-visible:ring-interactive-focus " \
            "disabled:pointer-events-none disabled:opacity-50 " \
            "aria-invalid:border-danger-border aria-invalid:ring-danger  " \
-           "data-[state=on]:bg-surface-sunken data-[state=on]:text-text-heading " \
+           "data-[state=on]:bg-interactive-subtle data-[state=on]:text-interactive " \
            "[&_svg]:pointer-events-none [&_svg]:shrink-0 [&_svg:not([class*='size-'])]:size-4"
 
     # AAA 2.5.5 target-size floor: every size renders >=44px tall (h-11 = 44px).

--- a/test/render/toggle_render_test.rb
+++ b/test/render/toggle_render_test.rb
@@ -49,10 +49,23 @@ class ToggleRenderTest < ViewComponent::TestCase
     end
   end
 
-  # AAA semantic token (the design-token guarantee), not raw Tailwind:
-  def test_renders_with_aaa_token
+  # AAA semantic tokens (the design-token guarantee), not raw Tailwind. Selected
+  # (on) uses the tinted interactive-subtle surface — DISTINCT from the neutral
+  # off-hover surface — so clicking to select gives immediate visible feedback.
+  def test_selected_state_is_a_distinct_tinted_surface
     render_inline(UI::ToggleComponent.new("Bold", pressed: true))
 
-    assert_selector "button.data-\\[state\\=on\\]\\:bg-surface-sunken"
+    assert_selector "button.data-\\[state\\=on\\]\\:bg-interactive-subtle"
+    assert_selector "button.data-\\[state\\=on\\]\\:text-interactive"
+  end
+
+  # Hover is scoped to the OFF state so a selected toggle keeps its tinted look on
+  # hover. Regression guard: the prior unscoped `hover:bg-surface-sunken` made the
+  # hover surface identical to the selected surface (hover looked like selected).
+  def test_hover_is_scoped_to_the_off_state
+    render_inline(UI::ToggleComponent.new("Bold"))
+
+    assert_selector "button.data-\\[state\\=off\\]\\:hover\\:bg-surface-sunken"
+    refute_selector "button.hover\\:bg-surface-sunken"
   end
 end


### PR DESCRIPTION
Selected (on) and hover both painted `bg-surface-sunken`, so hovering an off toggle looked selected and clicking produced no visible change until the mouse left. Now selected uses the tinted `bg-interactive-subtle` / `text-interactive` pairing (AAA, same as badge `:secondary`) and the neutral hover is scoped to `data-[state=off]`. 0a render test updated with regression guards (selected must be tinted; old unscoped hover must be gone). App-side counterpart in modelrails_base.