### PR TITLE
feat(form-controls): consistency + state-visibility pass

### DIFF
--- a/lib/generators/modelrails_ui/add/templates/alert/alert_component.rb.tt
+++ b/lib/generators/modelrails_ui/add/templates/alert/alert_component.rb.tt
@@ -45,17 +45,20 @@ module UI
     # title: and description: are kwarg shorthands for plain-text content.
     # Use slots (with_alert_title / with_alert_description) for rich HTML.
     # Slots take precedence over kwargs when both are provided.
-    def initialize(variant: :default, title: nil, description: nil)
+    def initialize(variant: :default, title: nil, description: nil, **html_attrs)
       @variant = coerce_variant(variant.to_sym)
       @title = title
       @description = description
+      @extra_class = html_attrs.delete(:class)
+      @html_attrs = html_attrs
     end
 
     def call
       content_tag(:div, safe_join([resolved_title, resolved_description].compact),
+        **@html_attrs,
         role: ROLES.fetch(@variant),
         "aria-live": LIVE.fetch(@variant),
-        class: cn(OUTER_CLASSES, VARIANTS.fetch(@variant)))
+        class: cn(OUTER_CLASSES, VARIANTS.fetch(@variant), @extra_class))
     end
 
     class TitleComponent < ApplicationComponent

--- a/lib/generators/modelrails_ui/add/templates/file_input/file_input_component.rb.tt
+++ b/lib/generators/modelrails_ui/add/templates/file_input/file_input_component.rb.tt
@@ -8,7 +8,9 @@ module UI
     BASE = "block w-full text-sm text-text-body " \
            "file:mr-4 file:py-2 file:px-4 file:rounded-md file:border-0 file:text-sm file:font-medium " \
            "file:bg-interactive file:text-text-on-interactive hover:file:bg-interactive-hover " \
-           "file:cursor-pointer file:min-h-[var(--form-input-height)]"
+           "file:cursor-pointer file:min-h-[var(--form-input-height)] " \
+           "disabled:cursor-not-allowed disabled:opacity-50 " \
+           "aria-invalid:border-danger-border aria-invalid:ring-danger"
 
     # accept:   MIME types or extensions, e.g. "image/*" or ".pdf,.docx"
     # multiple: allow selecting multiple files

--- a/lib/generators/modelrails_ui/add/templates/input/input_component.rb.tt
+++ b/lib/generators/modelrails_ui/add/templates/input/input_component.rb.tt
@@ -7,7 +7,8 @@ module UI
     # (FIELD_BASE / FIELD_NORMAL / FIELD_ERROR in app/form_builders/tailwind_form_builder.rb)
     BASE   = "block w-full rounded-md border px-3 py-2 placeholder:text-text-muted " \
              "focus:outline-none focus:ring-2 min-h-[var(--form-input-height)]"
-    NORMAL = "border-border-strong bg-surface-raised text-text-heading focus:ring-interactive-focus"
+    NORMAL = "border-border-strong bg-surface-raised text-text-heading focus:ring-interactive-focus " \
+             "disabled:cursor-not-allowed disabled:opacity-50"
     ERROR  = "border-danger ring-2 ring-danger bg-danger-surface text-danger focus:ring-danger"
 
     # First-class accessibility/form params so the component is usable standalone

--- a/lib/generators/modelrails_ui/add/templates/radio_group/radio_group_component.rb.tt
+++ b/lib/generators/modelrails_ui/add/templates/radio_group/radio_group_component.rb.tt
@@ -82,7 +82,7 @@ module UI
     def radio_input(item, id)
       attrs = { type: "radio", name: @name, value: item[:value], id: id,
                 class: "h-4 w-4 border border-interactive text-interactive accent-interactive " \
-                       "focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-interactive-focus " \
+                       "focus-visible:outline-none focus-visible:border-border-focus focus-visible:ring-[3px] focus-visible:ring-interactive-focus " \
                        "disabled:cursor-not-allowed disabled:opacity-50" }
       attrs[:checked] = true if item[:checked]
       attrs[:disabled] = true if item[:disabled]

--- a/lib/generators/modelrails_ui/add/templates/range/range_component.rb.tt
+++ b/lib/generators/modelrails_ui/add/templates/range/range_component.rb.tt
@@ -39,6 +39,7 @@ module UI
     BASE = "w-full cursor-pointer appearance-none rounded-full bg-surface-sunken outline-none " \
            "h-2 accent-interactive " \
            "focus-visible:outline-none focus-visible:ring-[3px] focus-visible:ring-interactive-focus " \
+           "aria-invalid:ring-danger " \
            "disabled:pointer-events-none disabled:opacity-50 " \
            "[&::-webkit-slider-thumb]:size-4 [&::-webkit-slider-thumb]:appearance-none " \
            "[&::-webkit-slider-thumb]:rounded-full [&::-webkit-slider-thumb]:bg-interactive " \

--- a/lib/generators/modelrails_ui/add/templates/search_input/search_input_component.rb.tt
+++ b/lib/generators/modelrails_ui/add/templates/search_input/search_input_component.rb.tt
@@ -51,8 +51,8 @@ module UI
     #   invalid:     sets `aria-invalid="true"` (drives the error border/ring tokens)
     #   describedby: sets `aria-describedby` (link to hint/error element ids)
     # Everything else (name, id, value, data-*, ...) passes through.
-    def initialize(placeholder: "Search…", label: nil, required: false, invalid: false, describedby: nil, **html_attrs)
-      @placeholder = placeholder
+    def initialize(placeholder: nil, label: nil, required: false, invalid: false, describedby: nil, **html_attrs)
+      @placeholder = placeholder || I18n.t("modelrails_ui.search_input.placeholder", default: "Search…")
       @label       = label || I18n.t("modelrails_ui.search_input.label", default: "Search")
       @required    = required
       @invalid     = invalid

--- a/lib/generators/modelrails_ui/add/templates/select/select_component.rb.tt
+++ b/lib/generators/modelrails_ui/add/templates/select/select_component.rb.tt
@@ -25,8 +25,9 @@ module UI
   #
   # No fail-loud guard — there's no enum axis to validate.
   class SelectComponent < ApplicationComponent
-    BASE = "flex h-9 w-full rounded-md border border-border-strong bg-transparent px-3 py-1 text-sm shadow-sm " \
-           "focus:outline-none focus:ring-1 focus:ring-interactive-focus " \
+    BASE = "flex min-h-[var(--form-input-height)] w-full rounded-md border border-border-strong bg-transparent px-3 py-1 text-sm shadow-sm " \
+           "outline-none focus-visible:border-border-focus focus-visible:ring-[3px] focus-visible:ring-interactive-focus " \
+           "aria-invalid:border-danger-border aria-invalid:ring-danger " \
            "disabled:cursor-not-allowed disabled:opacity-50"
 
     # options: array of strings, or [value, label] pairs, or { value: label } hash

--- a/lib/generators/modelrails_ui/add/templates/switch/switch_component.rb.tt
+++ b/lib/generators/modelrails_ui/add/templates/switch/switch_component.rb.tt
@@ -41,6 +41,7 @@ module UI
     TRACK   = "pointer-events-none absolute inset-0 rounded-full border border-transparent shadow-xs " \
               "transition-all bg-surface-sunken peer-checked:bg-interactive " \
               "peer-focus-visible:border-border-focus peer-focus-visible:ring-[3px] peer-focus-visible:ring-interactive-focus " \
+              "peer-aria-invalid:ring-2 peer-aria-invalid:ring-danger " \
               "peer-disabled:opacity-50"
     THUMB   = "pointer-events-none absolute inset-y-0 left-px my-auto z-10 block size-4 rounded-full " \
               "bg-surface-raised ring-0 transition-transform " \

--- a/lib/generators/modelrails_ui/add/templates/textarea/textarea_component.rb.tt
+++ b/lib/generators/modelrails_ui/add/templates/textarea/textarea_component.rb.tt
@@ -6,7 +6,8 @@ module UI
     # with UI::InputComponent) so the builder can delegate to it invisibly.
     BASE   = "block w-full rounded-md border px-3 py-2 placeholder:text-text-muted " \
              "focus:outline-none focus:ring-2 min-h-[var(--form-input-height)]"
-    NORMAL = "border-border-strong bg-surface-raised text-text-heading focus:ring-interactive-focus"
+    NORMAL = "border-border-strong bg-surface-raised text-text-heading focus:ring-interactive-focus " \
+             "disabled:cursor-not-allowed disabled:opacity-50"
     ERROR  = "border-danger ring-2 ring-danger bg-danger-surface text-danger focus:ring-danger"
 
     # value:       textarea body (builder-driven); falls back to block content for standalone use

--- a/test/render/alert_render_test.rb
+++ b/test/render/alert_render_test.rb
@@ -41,4 +41,18 @@ class AlertRenderTest < ViewComponent::TestCase
       render_inline(UI::AlertComponent.new(variant: :bogus))
     end
   end
+
+  # html_attrs pass through onto the root, matching the sibling components.
+  def test_passes_through_html_attrs_onto_the_root
+    render_inline(UI::AlertComponent.new(title: "Heads up", id: "save-alert", data: {testid: "alert"}))
+
+    assert_selector "div#save-alert[role='status'][data-testid='alert']"
+  end
+
+  # A caller-supplied class merges onto the root without clobbering the variant tokens.
+  def test_merges_caller_class_onto_the_root
+    render_inline(UI::AlertComponent.new(title: "Heads up", class: "mt-4"))
+
+    assert_selector "div.mt-4.bg-surface-raised"
+  end
 end

--- a/test/render/file_input_render_test.rb
+++ b/test/render/file_input_render_test.rb
@@ -25,6 +25,20 @@ class FileInputRenderTest < ViewComponent::TestCase
     assert_selector "input.file\\:bg-interactive.file\\:text-text-on-interactive.hover\\:file\\:bg-interactive-hover"
   end
 
+  # A disabled file input is visually distinct.
+  def test_renders_disabled_styling
+    render_inline(UI::FileInputComponent.new)
+
+    assert_selector "input.disabled\\:cursor-not-allowed.disabled\\:opacity-50"
+  end
+
+  # invalid: drives a visible danger ring, not just aria-invalid.
+  def test_carries_a_danger_ring_token_for_invalid
+    render_inline(UI::FileInputComponent.new)
+
+    assert_selector "input.aria-invalid\\:ring-danger"
+  end
+
   def test_accept_passes_through
     render_inline(UI::FileInputComponent.new(accept: "image/*"))
 

--- a/test/render/input_render_test.rb
+++ b/test/render/input_render_test.rb
@@ -31,6 +31,13 @@ class InputRenderTest < ViewComponent::TestCase
     assert_selector "input.border-border-strong.bg-surface-raised.text-text-heading.focus\\:ring-interactive-focus"
   end
 
+  # A disabled field is visually distinct (NORMAL carries disabled styling).
+  def test_normal_carries_disabled_styling
+    render_inline(UI::InputComponent.new)
+
+    assert_selector "input.disabled\\:cursor-not-allowed.disabled\\:opacity-50"
+  end
+
   # invalid: drives the server-validation-driven aria-invalid posture AND
   # swaps NORMAL styling for the ERROR token.
   def test_invalid_sets_aria_invalid

--- a/test/render/radio_group_render_test.rb
+++ b/test/render/radio_group_render_test.rb
@@ -99,4 +99,12 @@ class RadioGroupRenderTest < ViewComponent::TestCase
     assert_selector "input.border-interactive"
     assert_selector "input.accent-interactive"
   end
+
+  # Standard library 3px focus ring (not ring-1), matching the other form controls.
+  def test_inputs_use_the_standard_3px_focus_ring
+    render_inline(UI::RadioGroupComponent.new(name: "plan", label: "Billing plan", items: PLAN_ITEMS))
+
+    assert_selector "input.focus-visible\\:ring-\\[3px\\]"
+    assert_selector "input.focus-visible\\:ring-interactive-focus"
+  end
 end

--- a/test/render/range_render_test.rb
+++ b/test/render/range_render_test.rb
@@ -33,6 +33,13 @@ class RangeRenderTest < ViewComponent::TestCase
     assert_selector "input.accent-interactive"
   end
 
+  # invalid: drives a visible danger ring on the slider, not just aria-invalid.
+  def test_carries_a_danger_ring_token_for_invalid
+    render_inline(UI::RangeComponent.new)
+
+    assert_selector "input.aria-invalid\\:ring-danger"
+  end
+
   def test_invalid_sets_aria_invalid
     render_inline(UI::RangeComponent.new(invalid: true))
 

--- a/test/render/search_input_render_test.rb
+++ b/test/render/search_input_render_test.rb
@@ -91,4 +91,15 @@ class SearchInputRenderTest < ViewComponent::TestCase
 
     assert_selector "input[type='search'][name='q'][placeholder='Find a thing…']"
   end
+
+  # The default placeholder is i18n-resolved (falls back to "Search…"), never a
+  # hardcoded string — a placeholder is set by default but is only a hint, not a name.
+  def test_default_placeholder_is_i18n_resolved
+    render_inline(UI::SearchInputComponent.new(name: "q"))
+
+    placeholder = page.find("input[type='search']")["placeholder"]
+
+    refute_nil placeholder
+    refute_empty placeholder.to_s
+  end
 end

--- a/test/render/select_render_test.rb
+++ b/test/render/select_render_test.rb
@@ -17,7 +17,21 @@ class SelectRenderTest < ViewComponent::TestCase
     render_inline(UI::SelectComponent.new(options: %w[A B]))
 
     assert_selector "select.border-border-strong"
-    assert_selector "select.focus\\:ring-interactive-focus"
+    assert_selector "select.focus-visible\\:ring-interactive-focus"
+  end
+
+  # WCAG 2.5.5 target size: the control sits at the 44px floor (--form-input-height).
+  def test_meets_44px_target_floor
+    render_inline(UI::SelectComponent.new(options: %w[A B]))
+
+    assert_selector "select.min-h-\\[var\\(--form-input-height\\)\\]"
+  end
+
+  # invalid: drives a visible danger ring/border, not just aria-invalid.
+  def test_invalid_carries_a_danger_ring_token
+    render_inline(UI::SelectComponent.new(options: %w[A B]))
+
+    assert_selector "select.aria-invalid\\:ring-danger"
   end
 
   def test_selected_marks_the_right_option

--- a/test/render/switch_render_test.rb
+++ b/test/render/switch_render_test.rb
@@ -70,6 +70,14 @@ class SwitchRenderTest < ViewComponent::TestCase
     assert_no_selector "input[aria-invalid]"
   end
 
+  # The TRACK carries a peer-aria-invalid danger ring so an invalid switch is
+  # visible (the peer input gets aria-invalid; the later-sibling track reacts).
+  def test_track_carries_a_peer_aria_invalid_danger_ring
+    render_inline(UI::SwitchComponent.new(name: "notifications"))
+
+    assert_selector "span.peer-aria-invalid\\:ring-danger"
+  end
+
   def test_describedby_sets_aria_describedby_on_the_input
     render_inline(UI::SwitchComponent.new(name: "notifications", describedby: "notify_hint"))
 

--- a/test/render/textarea_render_test.rb
+++ b/test/render/textarea_render_test.rb
@@ -31,6 +31,13 @@ class TextareaRenderTest < ViewComponent::TestCase
     assert_selector "textarea.border-border-strong.bg-surface-raised.text-text-heading.focus\\:ring-interactive-focus"
   end
 
+  # A disabled field is visually distinct (NORMAL carries disabled styling).
+  def test_normal_carries_disabled_styling
+    render_inline(UI::TextareaComponent.new)
+
+    assert_selector "textarea.disabled\\:cursor-not-allowed.disabled\\:opacity-50"
+  end
+
   # invalid: drives aria-invalid AND swaps NORMAL styling for the ERROR token.
   def test_invalid_sets_aria_invalid
     render_inline(UI::TextareaComponent.new(invalid: true))


### PR DESCRIPTION
Addresses the component-review consistency findings (form-control family):
- **select**: `h-9`→44px (AAA target floor); `focus:ring-1`→`focus-visible:ring-[3px]`+border-border-focus; added `aria-invalid` visual (danger ring).
- **radio_group**: focus ring `ring-1`→`ring-[3px]` (library standard).
- **input/textarea/file_input**: added disabled visual (`disabled:opacity-50 cursor-not-allowed`) — were indistinguishable from active.
- **range/switch/file_input**: added invalid visual (danger ring) — ARIA was set but nothing showed.
- **search_input**: placeholder now i18n (`modelrails_ui.search_input.placeholder`, default Search…).
- **alert**: now accepts `**html_attrs` (was the only component without passthrough).

0a render tests updated with positive assertions + stale select focus-ring assertion fixed. `rake test:render` 251/0, rubocop clean. App counterpart + browser-reviewed visuals in the modelrails_base PR.