### PR TITLE
feat(lookbook): light/dark preview toggle

### DIFF
--- a/lib/generators/modelrails_ui/lookbook/lookbook_generator.rb
+++ b/lib/generators/modelrails_ui/lookbook/lookbook_generator.rb
@@ -15,6 +15,13 @@ module ModelrailsUi
         copy_file "component_preview.html.erb", "app/views/layouts/component_preview.html.erb"
       end
 
+      # Self-contained light/dark toggle for the preview host (used by the
+      # toggle button in component_preview.html.erb). Auto-registered by
+      # stimulus-loading's eagerLoadControllersFrom as the `preview-theme` controller.
+      def copy_preview_theme_controller
+        copy_file "preview_theme_controller.js", "app/javascript/controllers/preview_theme_controller.js"
+      end
+
       def copy_initializer
         copy_file "lookbook.rb", "config/initializers/modelrails_ui_lookbook.rb"
       end

--- a/lib/generators/modelrails_ui/lookbook/templates/component_preview.html.erb
+++ b/lib/generators/modelrails_ui/lookbook/templates/component_preview.html.erb
@@ -9,6 +9,16 @@
     <%= javascript_importmap_tags %>
   </head>
   <body class="bg-surface-raised text-text-body p-6">
+    <%# Dev-only light/dark toggle for previewing components in both themes. %>
+    <div data-controller="preview-theme" class="fixed right-2 top-2 z-50">
+      <button type="button"
+              data-action="click->preview-theme#toggle"
+              aria-label="Toggle light or dark preview"
+              class="inline-flex min-h-[var(--form-input-height)] items-center gap-2 rounded-md border border-border bg-surface-raised px-3 text-sm font-medium text-text-body shadow-sm hover:bg-surface-sunken focus-visible:outline-none focus-visible:ring-[3px] focus-visible:ring-interactive-focus">
+        <span aria-hidden="true">◐</span>
+        <span data-preview-theme-target="label">Light</span>
+      </button>
+    </div>
     <%= yield %>
   </body>
 </html>

--- a/lib/generators/modelrails_ui/lookbook/templates/component_preview.html.erb
+++ b/lib/generators/modelrails_ui/lookbook/templates/component_preview.html.erb
@@ -9,7 +9,10 @@
     <%= javascript_importmap_tags %>
   </head>
   <body class="bg-surface-raised text-text-body p-6">
-    <%# Dev-only light/dark toggle for previewing components in both themes. %>
+    <%= yield %>
+    <%# Dev-only light/dark toggle. Rendered AFTER yield (it's position:fixed, so DOM
+        order doesn't affect placement) so component content is always first in the
+        DOM — specs that use first-match querySelector find the component, not this chrome. %>
     <div data-controller="preview-theme" class="fixed right-2 top-2 z-50">
       <button type="button"
               data-action="click->preview-theme#toggle"
@@ -19,6 +22,5 @@
         <span data-preview-theme-target="label">Light</span>
       </button>
     </div>
-    <%= yield %>
   </body>
 </html>

--- a/lib/generators/modelrails_ui/lookbook/templates/preview_theme_controller.js
+++ b/lib/generators/modelrails_ui/lookbook/templates/preview_theme_controller.js
@@ -1,0 +1,33 @@
+import { Controller } from "@hotwired/stimulus"
+
+// Dev-only light/dark toggle for the component preview host (Lookbook + the
+// ViewComponent preview controller). Flips `.dark` on <html> and remembers the
+// choice in a `preview_theme` cookie.
+//
+// Intentionally self-contained: it does NOT reuse the host app's real theme
+// system (typically auth/route/icon-coupled and absent from the minimal preview
+// host, so axe audits scope cleanly to the component under test).
+export default class extends Controller {
+  static targets = ["label"]
+
+  connect() {
+    const cookie = document.cookie.match(/(?:^|; )preview_theme=(\w+)/)
+    this.dark = cookie
+      ? cookie[1] === "dark"
+      : window.matchMedia("(prefers-color-scheme: dark)").matches
+    this.#apply()
+  }
+
+  toggle() {
+    this.dark = !this.dark
+    document.cookie = `preview_theme=${this.dark ? "dark" : "light"};path=/;max-age=31536000;SameSite=Lax`
+    this.#apply()
+  }
+
+  #apply() {
+    document.documentElement.classList.toggle("dark", this.dark)
+    if (this.hasLabelTarget) {
+      this.labelTarget.textContent = this.dark ? "Dark" : "Light"
+    }
+  }
+}


### PR DESCRIPTION
Adds a dev-only light/dark toggle button to the component preview host so components can be reviewed in both themes from Lookbook or the preview URL.

- Self-contained preview-theme Stimulus controller (flips the dark class on html + a preview_theme cookie). Deliberately NOT the app's real theme system, which is auth/route/icon-coupled and absent from the minimal preview host (keeps axe audits cleanly scoped to the component).
- The lookbook generator now also installs preview_theme_controller.js (auto-registered via eagerLoadControllersFrom).
- App counterpart in modelrails_base includes a verifying system spec (asserts the dark class flips).