### PR TITLE
feat(ui): unify severity vocabulary + tinted signal treatment

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+- Unified signal vocabulary to a canonical `info·success·warning·danger` ladder across alert/badge/button/indicator (`destructive` kept as a non-breaking alias for `danger`). Alert gains all four tinted signal levels; badge signal chips move from solid base-token fills to tinted surfaces (`bg-*-surface` + `text-*` + `*-border`), since the base tokens are TEXT colors and rendered as muddy dark chips when used as fills.
+
+### Fixed
+- Indicator `warning` count text used the non-adaptive `text-text-heading` (low-contrast on the fill in both themes); now uses the adaptive `text-text-on-interactive`.
+
 ## [0.2.0] - 2026-05-30
 
 ### Added

--- a/lib/generators/modelrails_ui/add/templates/alert/alert_component.rb.tt
+++ b/lib/generators/modelrails_ui/add/templates/alert/alert_component.rb.tt
@@ -16,28 +16,39 @@ module UI
   #
   # ## Accessibility contract
   # - **Guarantees:** a live region matched to urgency — `role="status"`/`aria-live="polite"`
-  #   for the neutral `default`, `role="alert"`/`aria-live="assertive"` for `destructive` —
-  #   and AAA-contrast text on the banner surface.
+  #   for the neutral `default` (and `info`/`success`/`warning`), `role="alert"`/
+  #   `aria-live="assertive"` for `danger` — and AAA-contrast text on the banner surface.
   # - **You supply:** a title and/or description (kwargs or the `alert_title` /
   #   `alert_description` slots) and a valid `variant` (an unknown one raises in development).
   #
   # ## Variants
-  # `default` · `destructive`
+  # `default` · `info` · `success` · `warning` · `danger`
+  # (`destructive` is a non-breaking alias for `danger`.)
   class AlertComponent < ApplicationComponent
     OUTER_CLASSES = "relative grid w-full grid-cols-[0_1fr] items-start gap-y-0.5 rounded-lg border " \
                     "px-4 py-3 text-sm has-[>svg]:grid-cols-[calc(var(--spacing)*4)_1fr] " \
                     "has-[>svg]:gap-x-3 [&>svg]:size-4 [&>svg]:translate-y-0.5 [&>svg]:text-current"
 
-    # `text-danger` (not `text-danger/90`): an opacity modifier strictly lowers
-    # contrast and risks the AAA 7:1 floor on the description text.
+    # Signal levels share the tinted-surface treatment used by the toast cards
+    # (`bg-<level>-surface` + `border-<level>-border` + `text-<level>`), so an alert
+    # reads its severity the same way a toast does. `text-<level>` (no `/90` opacity
+    # modifier — that would lower contrast below the AAA 7:1 floor on the description).
     VARIANTS = {
       default: "bg-surface-raised text-text-body",
-      destructive: "bg-surface-raised text-danger [&>svg]:text-current *:data-[slot=alert-description]:text-danger"
+      info:    "bg-info-surface border-info-border text-info [&>svg]:text-current *:data-[slot=alert-description]:text-info",
+      success: "bg-success-surface border-success-border text-success [&>svg]:text-current *:data-[slot=alert-description]:text-success",
+      warning: "bg-warning-surface border-warning-border text-warning [&>svg]:text-current *:data-[slot=alert-description]:text-warning",
+      danger:  "bg-danger-surface border-danger-border text-danger [&>svg]:text-current *:data-[slot=alert-description]:text-danger"
     }.freeze
 
-    # Live-region semantics by urgency: neutral announces politely, errors assertively.
-    ROLES = { default: "status", destructive: "alert" }.freeze
-    LIVE  = { default: "polite", destructive: "assertive" }.freeze
+    # `destructive` is a non-breaking alias for the canonical `danger` (matching the
+    # signal tokens). Resolved in coerce_variant before lookup.
+    VARIANT_ALIASES = { destructive: :danger }.freeze
+
+    # Live-region semantics by urgency: only `danger` is urgent (assertive); the
+    # neutral default and info/success/warning announce politely.
+    ROLES = { default: "status", info: "status", success: "status", warning: "status", danger: "alert" }.freeze
+    LIVE  = { default: "polite", info: "polite", success: "polite", warning: "polite", danger: "assertive" }.freeze
 
     renders_one :alert_title, "UI::AlertComponent::TitleComponent"
     renders_one :alert_description, "UI::AlertComponent::DescriptionComponent"
@@ -85,12 +96,13 @@ module UI
     # module is defined but Rails.env isn't booted (the gem's Rails-less tests load
     # rails/generators, which defines Rails without Rails.env).
     def coerce_variant(variant)
+      variant = VARIANT_ALIASES.fetch(variant, variant)
       return variant if VARIANTS.key?(variant)
 
       unless defined?(Rails) && Rails.respond_to?(:env) && Rails.env.production?
         raise ArgumentError,
           "UI::AlertComponent: unknown variant #{variant.inspect}. " \
-          "Expected one of: #{VARIANTS.keys.join(", ")}."
+          "Expected one of: #{VARIANTS.keys.join(", ")} (alias: destructive→danger)."
       end
 
       :default

--- a/lib/generators/modelrails_ui/add/templates/badge/badge_component.rb.tt
+++ b/lib/generators/modelrails_ui/add/templates/badge/badge_component.rb.tt
@@ -17,14 +17,17 @@ module UI
   #
   # ## Accessibility contract
   # - **Guarantees:** AAA-contrast text on every variant's surface, including the
-  #   adaptive `destructive` treatment (which stays legible in dark mode).
+  #   adaptive signal treatments (`danger`/`success`/`info`/`warning`) which stay
+  #   legible in dark mode.
   # - **You supply:** if the badge conveys status that isn't already in the
-  #   surrounding text (e.g. a color-coded "destructive" pill), give it an accessible
+  #   surrounding text (e.g. a color-coded "danger" pill), give it an accessible
   #   name so screen-reader users get the same signal. A valid `variant` is required —
   #   an unknown one raises in development.
   #
   # ## Variants
-  # `default` · `secondary` · `destructive` · `outline` · `ghost` · `link`
+  # Signal levels: `info` · `success` · `warning` · `danger` (tinted chips).
+  # Style levels: `default` · `secondary` · `outline` · `ghost` · `link`.
+  # (`destructive` is a non-breaking alias for `danger`.)
   class BadgeComponent < ApplicationComponent
     BASE = "inline-flex w-fit shrink-0 items-center justify-center gap-1 overflow-hidden rounded-full " \
            "border border-transparent px-2 py-0.5 text-xs font-medium whitespace-nowrap " \
@@ -33,19 +36,29 @@ module UI
            "aria-invalid:border-danger-border aria-invalid:ring-danger  " \
            "[&>svg]:pointer-events-none [&>svg]:size-3"
 
-    # `text-text-on-interactive` (not `text-white`) on destructive: the adaptive token
-    # is white in light mode and a dark neutral in dark mode, so it keeps AAA contrast
-    # against the light-pink dark-mode `--color-danger` — exactly how the danger button
-    # handles it. Raw `text-white` would fail AAA on that dark surface.
+    # Signal levels use the TINTED treatment (soft `*-surface` background + saturated
+    # `text-<level>` + `*-border`), matching the alert + toast cards. The `--color-<level>`
+    # base tokens are TEXT colors (dark in light mode for AAA-on-light readability), so
+    # using them as solid fills produces dark, muddy chips — e.g. `bg-warning` is amber-900
+    # (a dark brown), which reads nothing like "warning." The tinted pairing is what the
+    # `*-surface` tokens are for, and `text-<level>` on `bg-<level>-surface` is AAA-proven
+    # on the toast cards. (info/success on their tinted surfaces: CI-verify.)
     VARIANTS = {
       default: "bg-interactive text-text-on-interactive [a&]:hover:bg-interactive-hover",
       secondary: "bg-interactive-subtle text-interactive [a&]:hover:bg-interactive-subtle",
-      destructive: "bg-danger text-text-on-interactive focus-visible:ring-danger " \
-                   "  [a&]:hover:bg-danger-hover",
+      info: "bg-info-surface text-info border-info-border [a&]:hover:bg-info-hover",
+      success: "bg-success-surface text-success border-success-border [a&]:hover:bg-success-hover",
+      warning: "bg-warning-surface text-warning border-warning-border [a&]:hover:bg-warning-hover",
+      danger: "bg-danger-surface text-danger border-danger-border focus-visible:ring-danger " \
+              "[a&]:hover:bg-danger-hover",
       outline: "border-border text-text-heading [a&]:hover:bg-surface-sunken [a&]:hover:text-text-heading",
       ghost: "[a&]:hover:bg-surface-sunken [a&]:hover:text-text-heading",
       link: "text-interactive underline-offset-4 [a&]:hover:underline"
     }.freeze
+
+    # `destructive` is a non-breaking alias for the canonical `danger`. Resolved in
+    # coerce_variant before lookup.
+    VARIANT_ALIASES = { destructive: :danger }.freeze
 
     # label — positional or keyword shorthand for plain-text badges without a block.
     # href  — renders an <a> tag (a clickable tag/filter link); sets tag: :a automatically.
@@ -76,12 +89,13 @@ module UI
     # module is defined but Rails.env isn't booted (the gem's Rails-less tests load
     # rails/generators, which defines Rails without Rails.env).
     def coerce_variant(variant)
+      variant = VARIANT_ALIASES.fetch(variant, variant)
       return variant if VARIANTS.key?(variant)
 
       unless defined?(Rails) && Rails.respond_to?(:env) && Rails.env.production?
         raise ArgumentError,
           "UI::BadgeComponent: unknown variant #{variant.inspect}. " \
-          "Expected one of: #{VARIANTS.keys.join(", ")}."
+          "Expected one of: #{VARIANTS.keys.join(", ")} (alias: destructive→danger)."
       end
 
       :default

--- a/lib/generators/modelrails_ui/add/templates/button/button_component.rb.tt
+++ b/lib/generators/modelrails_ui/add/templates/button/button_component.rb.tt
@@ -24,6 +24,10 @@ module UI
     # so default is empty; kept for API symmetry / future use).
     SIZES = {default: ""}.freeze
 
+    # `destructive` is a non-breaking alias for the canonical `danger`, so the whole
+    # UI vocabulary speaks one severity ladder. Resolved in coerce_variant before lookup.
+    VARIANT_ALIASES = {destructive: :danger}.freeze
+
     # label — positional or keyword shorthand for plain-text buttons without a block.
     # href  — renders an <a> tag; sets tag: :a automatically.
     def initialize(label = nil, variant: :primary, size: :default, href: nil, **html_attrs)
@@ -56,12 +60,13 @@ module UI
     # module is defined but Rails.env isn't booted (the gem's Rails-less tests load
     # rails/generators, which defines Rails without Rails.env).
     def coerce_variant(variant)
+      variant = VARIANT_ALIASES.fetch(variant, variant)
       return variant if VARIANTS.key?(variant)
 
       unless defined?(Rails) && Rails.respond_to?(:env) && Rails.env.production?
         raise ArgumentError,
           "UI::ButtonComponent: unknown variant #{variant.inspect}. " \
-          "Expected one of: #{VARIANTS.keys.join(", ")}."
+          "Expected one of: #{VARIANTS.keys.join(", ")} (alias: destructive→danger)."
       end
 
       :primary

--- a/lib/generators/modelrails_ui/add/templates/indicator/indicator_component.rb.tt
+++ b/lib/generators/modelrails_ui/add/templates/indicator/indicator_component.rb.tt
@@ -23,14 +23,23 @@ module UI
   class IndicatorComponent < ApplicationComponent
     DOT_BASE = "absolute flex items-center justify-center rounded-full text-[10px] font-medium leading-none"
 
-    # `text-text-on-interactive` (not `text-white`) on filled dots: the adaptive token
-    # stays AAA-legible in both themes. success/warning graphic contrast: CI-verify.
+    # Dots use a SOLID fill (like the brand `default`): a dot must be a visible graphic,
+    # so the tinted chip treatment used by alert/badge would be near-invisible at dot
+    # size. `text-text-on-interactive` (adaptive — white in light, dark in dark) keeps
+    # the count text AAA on the dark-enough base fills. `warning` uses it too — NOT the
+    # non-adaptive `text-text-heading`, which went low-contrast in BOTH themes (it tracked
+    # the fill's lightness instead of opposing it). Dot graphic contrast: CI-verify.
     VARIANTS = {
-      default:     "bg-interactive text-text-on-interactive",
-      destructive: "bg-danger text-text-on-interactive",
-      success:     "bg-success text-text-on-interactive",
-      warning:     "bg-warning text-text-heading"
+      default: "bg-interactive text-text-on-interactive",
+      info:    "bg-info text-text-on-interactive",
+      success: "bg-success text-text-on-interactive",
+      warning: "bg-warning text-text-on-interactive",
+      danger:  "bg-danger text-text-on-interactive"
     }.freeze
+
+    # `destructive` is a non-breaking alias for the canonical `danger`. Resolved in
+    # coerce_variant before lookup.
+    VARIANT_ALIASES = { destructive: :danger }.freeze
 
     POSITIONS = {
       top_right:    "-top-1 -right-1",
@@ -70,12 +79,13 @@ module UI
     # module is defined but Rails.env isn't booted (the gem's Rails-less tests load
     # rails/generators, which defines Rails without Rails.env).
     def coerce_variant(variant)
+      variant = VARIANT_ALIASES.fetch(variant, variant)
       return variant if VARIANTS.key?(variant)
 
       unless defined?(Rails) && Rails.respond_to?(:env) && Rails.env.production?
         raise ArgumentError,
           "UI::IndicatorComponent: unknown variant #{variant.inspect}. " \
-          "Expected one of: #{VARIANTS.keys.join(", ")}."
+          "Expected one of: #{VARIANTS.keys.join(", ")} (alias: destructive→danger)."
       end
 
       :default

--- a/lib/generators/modelrails_ui/lookbook/templates/previews/ui/alert_component_preview.rb
+++ b/lib/generators/modelrails_ui/lookbook/templates/previews/ui/alert_component_preview.rb
@@ -19,7 +19,8 @@ module UI
   # - **You supply:** a title and/or description, and a valid `variant`.
   #
   # ## Variants
-  # `default` · `destructive`
+  # `default` · `info` · `success` · `warning` · `danger`
+  # (`destructive` is a non-breaking alias for `danger`.)
   class AlertComponentPreview < ViewComponent::Preview
     include UIHelper
 
@@ -27,7 +28,20 @@ module UI
     def default
     end
 
+    # Informational signal on the info-tinted surface — announced politely (role=status).
+    def info
+    end
+
+    # Success / confirmation on the success-tinted surface — announced politely (role=status).
+    def success
+    end
+
+    # Warning on the warning-tinted surface — announced politely (role=status).
+    def warning
+    end
+
     # Error / destructive message — announced assertively (role=alert).
+    # `variant: :destructive` is a non-breaking alias for `:danger`.
     def destructive
     end
 

--- a/lib/generators/modelrails_ui/lookbook/templates/previews/ui/alert_component_preview/info.html.erb
+++ b/lib/generators/modelrails_ui/lookbook/templates/previews/ui/alert_component_preview/info.html.erb
@@ -1,0 +1,1 @@
+<%= ui :alert, variant: :info, title: "Heads up", description: "A new version is available." %>

--- a/lib/generators/modelrails_ui/lookbook/templates/previews/ui/alert_component_preview/success.html.erb
+++ b/lib/generators/modelrails_ui/lookbook/templates/previews/ui/alert_component_preview/success.html.erb
@@ -1,0 +1,1 @@
+<%= ui :alert, variant: :success, title: "Saved", description: "Your changes were saved." %>

--- a/lib/generators/modelrails_ui/lookbook/templates/previews/ui/alert_component_preview/warning.html.erb
+++ b/lib/generators/modelrails_ui/lookbook/templates/previews/ui/alert_component_preview/warning.html.erb
@@ -1,0 +1,1 @@
+<%= ui :alert, variant: :warning, title: "Heads up", description: "Your trial ends in 3 days." %>

--- a/lib/generators/modelrails_ui/lookbook/templates/previews/ui/badge_component_preview.rb
+++ b/lib/generators/modelrails_ui/lookbook/templates/previews/ui/badge_component_preview.rb
@@ -15,12 +15,15 @@ module UI
   #
   # ## Accessibility contract
   # - **Guarantees:** AAA-contrast text on every variant, including the adaptive
-  #   `destructive` treatment that stays legible in dark mode.
+  #   signal treatments (`danger`/`success`/`info`/`warning`) that stay legible in dark mode.
   # - **You supply:** an accessible name when the badge conveys status not already in
   #   the surrounding text, and a valid `variant` (an unknown one raises in development).
   #
   # ## Variants
-  # `default` · `secondary` · `destructive` · `outline` · `ghost` · `link`
+  # Signal levels: `info` · `success` · `warning` · `danger` (tinted chips —
+  # soft `*-surface` + saturated `text-<level>`, matching the alert + toast cards).
+  # Style levels: `default` · `secondary` · `outline` · `ghost` · `link`.
+  # (`destructive` is a non-breaking alias for `danger`.)
   class BadgeComponentPreview < ViewComponent::Preview
     include UIHelper
 
@@ -32,7 +35,23 @@ module UI
     def secondary
     end
 
-    # Error / removed / failed status. Uses the adaptive on-interactive token (AAA in dark mode).
+    # Informational signal — tinted info chip.
+    def info
+    end
+
+    # Success / completed status — tinted success chip.
+    def success
+    end
+
+    # Warning status — tinted warning chip (soft amber surface + dark amber text).
+    def warning
+    end
+
+    # Error / removed / failed status — tinted danger chip; keeps a danger focus ring.
+    def danger
+    end
+
+    # `variant: :destructive` is a non-breaking alias for `:danger`.
     def destructive
     end
 
@@ -54,7 +73,7 @@ module UI
 
     # Edit `label` and `variant` live to explore the component.
     # @param label text
-    # @param variant select [default, secondary, destructive, outline, ghost, link]
+    # @param variant select [default, secondary, info, success, warning, danger, destructive, outline, ghost, link]
     def playground(label: "Badge", variant: :default)
       ui :badge, label, variant: variant.to_sym
     end

--- a/lib/generators/modelrails_ui/lookbook/templates/previews/ui/badge_component_preview/danger.html.erb
+++ b/lib/generators/modelrails_ui/lookbook/templates/previews/ui/badge_component_preview/danger.html.erb
@@ -1,0 +1,1 @@
+<%= ui :badge, "Failed", variant: :danger %>

--- a/lib/generators/modelrails_ui/lookbook/templates/previews/ui/badge_component_preview/info.html.erb
+++ b/lib/generators/modelrails_ui/lookbook/templates/previews/ui/badge_component_preview/info.html.erb
@@ -1,0 +1,1 @@
+<%= ui :badge, "Info", variant: :info %>

--- a/lib/generators/modelrails_ui/lookbook/templates/previews/ui/badge_component_preview/success.html.erb
+++ b/lib/generators/modelrails_ui/lookbook/templates/previews/ui/badge_component_preview/success.html.erb
@@ -1,0 +1,1 @@
+<%= ui :badge, "Active", variant: :success %>

--- a/lib/generators/modelrails_ui/lookbook/templates/previews/ui/badge_component_preview/warning.html.erb
+++ b/lib/generators/modelrails_ui/lookbook/templates/previews/ui/badge_component_preview/warning.html.erb
@@ -1,0 +1,1 @@
+<%= ui :badge, "Pending", variant: :warning %>

--- a/lib/generators/modelrails_ui/lookbook/templates/previews/ui/indicator_component_preview.rb
+++ b/lib/generators/modelrails_ui/lookbook/templates/previews/ui/indicator_component_preview.rb
@@ -28,7 +28,11 @@ module UI
     def with_count
     end
 
-    # The semantic variants side by side.
+    # An informational dot — solid info fill.
+    def info
+    end
+
+    # The semantic variants side by side (info · success · warning · danger).
     def variants
     end
 

--- a/lib/generators/modelrails_ui/lookbook/templates/previews/ui/indicator_component_preview/info.html.erb
+++ b/lib/generators/modelrails_ui/lookbook/templates/previews/ui/indicator_component_preview/info.html.erb
@@ -1,0 +1,3 @@
+<%= ui :indicator, variant: :info do %>
+  <span class="inline-flex size-9 items-center justify-center rounded-md bg-surface-sunken text-text-body">Info</span>
+<% end %>

--- a/lib/generators/modelrails_ui/lookbook/templates/previews/ui/indicator_component_preview/variants.html.erb
+++ b/lib/generators/modelrails_ui/lookbook/templates/previews/ui/indicator_component_preview/variants.html.erb
@@ -1,11 +1,16 @@
+<%# Counts on every level so the AAA audit measures count-text contrast on each
+    solid dot fill — warning included (its count text is the contrast risk). %>
 <div class="flex items-center gap-6">
-  <%= ui :indicator, variant: :success do %>
+  <%= ui :indicator, variant: :info, count: 2 do %>
+    <span class="inline-flex size-9 items-center justify-center rounded-md bg-surface-sunken text-text-body">Info</span>
+  <% end %>
+  <%= ui :indicator, variant: :success, count: 7 do %>
     <span class="inline-flex size-9 items-center justify-center rounded-md bg-surface-sunken text-text-body">OK</span>
   <% end %>
-  <%= ui :indicator, variant: :warning do %>
+  <%= ui :indicator, variant: :warning, count: 9 do %>
     <span class="inline-flex size-9 items-center justify-center rounded-md bg-surface-sunken text-text-body">Warn</span>
   <% end %>
-  <%= ui :indicator, variant: :destructive do %>
+  <%= ui :indicator, variant: :danger, count: 4 do %>
     <span class="inline-flex size-9 items-center justify-center rounded-md bg-surface-sunken text-text-body">Err</span>
   <% end %>
 </div>

--- a/test/render/alert_render_test.rb
+++ b/test/render/alert_render_test.rb
@@ -10,10 +10,24 @@ class AlertRenderTest < ViewComponent::TestCase
     assert_selector "div[role='status'][aria-live='polite']", text: "Heads up"
   end
 
-  def test_destructive_variant_is_an_assertive_alert_region
+  def test_danger_variant_is_an_assertive_alert_on_the_danger_surface
+    render_inline(UI::AlertComponent.new(variant: :danger, title: "Couldn't save"))
+
+    assert_selector "div[role='alert'][aria-live='assertive'].bg-danger-surface", text: "Couldn't save"
+  end
+
+  # `destructive` is a non-breaking alias for the canonical `danger` — it must
+  # render an identical root (same role + tinted danger surface).
+  def test_destructive_alias_renders_identically_to_danger
     render_inline(UI::AlertComponent.new(variant: :destructive, title: "Couldn't save"))
 
-    assert_selector "div[role='alert'][aria-live='assertive']", text: "Couldn't save"
+    assert_selector "div[role='alert'][aria-live='assertive'].bg-danger-surface", text: "Couldn't save"
+  end
+
+  def test_warning_variant_is_a_polite_status_on_the_warning_surface
+    render_inline(UI::AlertComponent.new(variant: :warning, title: "Heads up"))
+
+    assert_selector "div[role='status'][aria-live='polite'].bg-warning-surface", text: "Heads up"
   end
 
   # AAA semantic tokens (the design-token guarantee), not raw Tailwind:

--- a/test/render/badge_render_test.rb
+++ b/test/render/badge_render_test.rb
@@ -18,14 +18,47 @@ class BadgeRenderTest < ViewComponent::TestCase
     assert_selector "span.text-text-on-interactive"
   end
 
-  # Per-surface dark-AAA fix: destructive must use the adaptive text-text-on-interactive
-  # token, NOT text-white (white-on-light-pink fails AAA in dark mode).
-  def test_destructive_uses_adaptive_on_interactive_token
+  # The canonical `danger` signal uses the TINTED treatment (soft danger-surface +
+  # saturated text-danger + danger-border), not a solid fill. Never raw palette /
+  # text-white; danger uniquely keeps a danger-colored focus ring.
+  def test_danger_uses_tinted_surface
+    render_inline(UI::BadgeComponent.new("Error", variant: :danger))
+
+    assert_selector "span.bg-danger-surface.text-danger.border-danger-border"
+    assert_selector 'span.focus-visible\\:ring-danger'
+    refute_selector "span.text-white"
+  end
+
+  # `destructive` is a non-breaking alias for the canonical `danger` — identical fill.
+  def test_destructive_alias_renders_as_danger
     render_inline(UI::BadgeComponent.new("Error", variant: :destructive))
 
-    assert_selector "span.bg-danger"
-    assert_selector "span.text-text-on-interactive"
+    assert_selector "span.bg-danger-surface.text-danger.border-danger-border"
+  end
+
+  # Tinted signal chips (only AAA semantic tokens, never raw palette): soft *-surface
+  # background + saturated text-<level> + *-border, matching the alert + toast cards.
+  def test_info_uses_tinted_surface
+    render_inline(UI::BadgeComponent.new("Note", variant: :info))
+
+    assert_selector "span.bg-info-surface.text-info.border-info-border"
     refute_selector "span.text-white"
+  end
+
+  def test_success_uses_tinted_surface
+    render_inline(UI::BadgeComponent.new("Done", variant: :success))
+
+    assert_selector "span.bg-success-surface.text-success.border-success-border"
+    refute_selector "span.text-white"
+  end
+
+  # warning is tinted (soft amber surface + dark amber text), NOT a solid bg-warning
+  # fill (amber-900 = a dark brown chip) and NOT text-text-heading (low-contrast).
+  def test_warning_uses_tinted_surface
+    render_inline(UI::BadgeComponent.new("Careful", variant: :warning))
+
+    assert_selector "span.bg-warning-surface.text-warning.border-warning-border"
+    refute_selector "span.text-text-heading"
   end
 
   def test_href_renders_anchor

--- a/test/render/button_render_test.rb
+++ b/test/render/button_render_test.rb
@@ -25,6 +25,17 @@ class ButtonRenderTest < ViewComponent::TestCase
     assert_selector "a[href='/']", text: "Home"
   end
 
+  # `destructive` is a non-breaking alias for the canonical `danger` — identical render.
+  def test_destructive_alias_renders_like_danger
+    render_inline(UI::ButtonComponent.new("Delete", variant: :danger))
+    danger_class = page.find("button")[:class]
+
+    render_inline(UI::ButtonComponent.new("Delete", variant: :destructive))
+    destructive_class = page.find("button")[:class]
+
+    assert_equal danger_class, destructive_class
+  end
+
   def test_unknown_variant_raises
     assert_raises(ArgumentError) do
       render_inline(UI::ButtonComponent.new("X", variant: :bogus))

--- a/test/render/indicator_render_test.rb
+++ b/test/render/indicator_render_test.rb
@@ -22,15 +22,32 @@ class IndicatorRenderTest < ViewComponent::TestCase
     assert_selector "span.size-2", visible: :all
   end
 
-  def test_variant_tokens_are_semantic
+  def test_info_and_success_use_the_adaptive_on_interactive_token
+    render_inline(UI::IndicatorComponent.new(variant: :info)) { "x" }
+
+    assert_selector "span.bg-info.text-text-on-interactive", visible: :all
+
     render_inline(UI::IndicatorComponent.new(variant: :success)) { "x" }
 
     assert_selector "span.bg-success.text-text-on-interactive", visible: :all
+  end
 
+  # Dots are SOLID fills; count text uses the adaptive on-interactive token on EVERY
+  # level — warning included (NOT the non-adaptive text-text-heading, which went
+  # low-contrast on the fill in both themes).
+  def test_warning_and_danger_use_on_interactive
     render_inline(UI::IndicatorComponent.new(variant: :warning)) { "x" }
 
-    assert_selector "span.bg-warning.text-text-heading", visible: :all
+    assert_selector "span.bg-warning.text-text-on-interactive", visible: :all
+    refute_selector "span.text-text-heading", visible: :all
 
+    render_inline(UI::IndicatorComponent.new(variant: :danger)) { "x" }
+
+    assert_selector "span.bg-danger.text-text-on-interactive", visible: :all
+  end
+
+  # `destructive` is a non-breaking alias for the canonical `danger`.
+  def test_destructive_alias_renders_as_danger
     render_inline(UI::IndicatorComponent.new(variant: :destructive)) { "x" }
 
     assert_selector "span.bg-danger.text-text-on-interactive", visible: :all

--- a/test/test_components.rb
+++ b/test/test_components.rb
@@ -273,10 +273,12 @@ class TestAlertComponent < Minitest::Test
     assert_equal "Something happened.", c.instance_variable_get(:@description)
   end
 
-  def test_destructive_variant
+  # `destructive` is a non-breaking alias for the canonical `danger`, resolved in
+  # coerce_variant, so the stored variant is `:danger`.
+  def test_destructive_aliases_danger
     c = UI::AlertComponent.new(variant: :destructive)
 
-    assert_equal :destructive, c.instance_variable_get(:@variant)
+    assert_equal :danger, c.instance_variable_get(:@variant)
   end
 end
 
@@ -334,9 +336,16 @@ class TestBadgeComponent < Minitest::Test
   end
 
   def test_all_variants_exist
-    %i[default secondary destructive outline].each do |variant|
+    %i[default secondary info success warning danger outline ghost link].each do |variant|
       assert UI::BadgeComponent::VARIANTS.key?(variant), "Missing variant #{variant}"
     end
+  end
+
+  # `destructive` is a non-breaking alias for the canonical `danger`.
+  def test_destructive_aliases_danger
+    c = UI::BadgeComponent.new("Error", variant: :destructive)
+
+    assert_equal :danger, c.instance_variable_get(:@variant)
   end
 end
 
@@ -927,9 +936,16 @@ class TestIndicatorComponent < Minitest::Test
   end
 
   def test_all_variants_defined
-    %i[default destructive success warning].each do |v|
+    %i[default info success warning danger].each do |v|
       assert UI::IndicatorComponent::VARIANTS.key?(v), "Missing variant #{v}"
     end
+  end
+
+  # `destructive` is a non-breaking alias for the canonical `danger`.
+  def test_destructive_aliases_danger
+    c = UI::IndicatorComponent.new(variant: :destructive)
+
+    assert_equal :danger, c.instance_variable_get(:@variant)
   end
 
   def test_all_positions_defined


### PR DESCRIPTION
## What

Unifies the signal vocabulary to a canonical info·success·warning·danger ladder across alert/badge/button/indicator templates.

- destructive kept as a non-breaking alias for danger (resolved in coerce_variant)
- Alert gains all four tinted signal levels
- Badge signal levels: solid base-token fills → tinted chips (bg-*-surface + text-* + *-border)
- Indicator warning count text: non-adaptive text-text-heading → adaptive text-text-on-interactive

## Why

The signal base tokens (--color-warning etc.) are TEXT colors — dark in light mode for AAA-on-light readability. Used as solid fills they render as muddy dark chips (warning was a dark amber-900 brown). The tinted treatment is what the *-surface tokens are designed for, and is AAA-proven on the toast cards.

## Tests

- rake test green (443 + 271 runs, 0 failures)
- Structural tests: destructive now asserts as an alias of danger (not a VARIANTS key); badge/indicator variant lists updated to the four signal levels
- Render tests updated to the tinted classes

Pairs with the modelrails_base app PR (vendored components mirror these templates).
