### PR TITLE
feat(floating): harden tooltip + hover_card (Wave 5b) — behavior + CSS anchor positioning

### DIFF
--- a/COMPONENT_STATUS.md
+++ b/COMPONENT_STATUS.md
@@ -44,7 +44,7 @@ without extra verification.
 | sheet | hardened | ✅ | ⏳ | native side `<dialog>` per-side slide (Wave 4); fail-loud `coerce_side`; shared `modal` controller; 0a; app 0b CI-pending |
 | popover | hardened | ✅ | ⏳ | Wave 5a floating exemplar (CSS positioning + shared `floating` controller; real button trigger w/ aria-haspopup/expanded/controls; role=dialog panel named by label:; Escape + outside-click close w/ focus return; fail-loud side/align). 0a render test; app 0b CI-pending |
 | tooltip | hardened | ✅ | ⏳ | Wave 5b floating (shows on hover+focus; role=tooltip + aria-describedby; Escape-dismiss via shared `floating` controller w/ group-data-[dismissed]!; fail-loud side). 0a render test; app 0b CI-pending |
-| hover_card | hardened | ✅ | ⏳ | Wave 5b floating (hover+focus-within; interactive content Tab-reachable while open; Escape-dismiss; optional role=group label; fail-loud side). 0a render test; app 0b CI-pending |
+| hover_card | hardened | ✅ | ⏳ | Wave 5b floating (JS hover-intent open/close w/ close-delay so the pointer can cross to the card + click its content; Escape closes + returns focus to trigger; optional role=group label; fail-loud side). 0a render test; app 0b CI-pending |
 
 All other gem components: **experimental** (unverified) unless listed above.
 

--- a/COMPONENT_STATUS.md
+++ b/COMPONENT_STATUS.md
@@ -43,6 +43,8 @@ without extra verification.
 | drawer | hardened | ✅ | ⏳ | native bottom `<dialog>` slide-up (Wave 4); shared `modal` controller (translateY); decorative drag-handle + 44px close; 0a; app 0b CI-pending |
 | sheet | hardened | ✅ | ⏳ | native side `<dialog>` per-side slide (Wave 4); fail-loud `coerce_side`; shared `modal` controller; 0a; app 0b CI-pending |
 | popover | hardened | ✅ | ⏳ | Wave 5a floating exemplar (CSS positioning + shared `floating` controller; real button trigger w/ aria-haspopup/expanded/controls; role=dialog panel named by label:; Escape + outside-click close w/ focus return; fail-loud side/align). 0a render test; app 0b CI-pending |
+| tooltip | hardened | ✅ | ⏳ | Wave 5b floating (shows on hover+focus; role=tooltip + aria-describedby; Escape-dismiss via shared `floating` controller w/ group-data-[dismissed]!; fail-loud side). 0a render test; app 0b CI-pending |
+| hover_card | hardened | ✅ | ⏳ | Wave 5b floating (hover+focus-within; interactive content Tab-reachable while open; Escape-dismiss; optional role=group label; fail-loud side). 0a render test; app 0b CI-pending |
 
 All other gem components: **experimental** (unverified) unless listed above.
 

--- a/docs/components/hover_card.md
+++ b/docs/components/hover_card.md
@@ -1,11 +1,20 @@
-# HoverCard
+# Hover Card
 
-Rich floating card that appears when the user hovers over a trigger element. Pure CSS via Tailwind `group-hover` — no JavaScript required.
+A rich supplemental card revealed on hover and keyboard focus of its trigger.
+Unlike `tooltip`, the card may hold interactive content (links, buttons);
+`focus-within` keeps it open while the user Tabs through that content. Escape
+dismisses (WCAG 1.4.13) via the shared `floating` Stimulus controller.
+
+Use for enhancement — the card's content should never be the only path to that
+information. If you need a click-triggered panel, use `popover`. If the hint is
+short and non-interactive, use `tooltip`.
+
+Requires `floating_controller.js` (copied automatically by the generator).
 
 ## Installation
 
 ```bash
-rails g view_primitives:add hover_card
+rails g modelrails_ui:add hover_card
 ```
 
 Creates `app/components/ui/hover_card_component.rb`.
@@ -13,40 +22,87 @@ Creates `app/components/ui/hover_card_component.rb`.
 ## Usage
 
 ```erb
-<%= ui :hover_card do |card| %>
-  <% card.with_trigger do %>
-    <%= link_to "@alec", profile_path, class: "underline" %>
+<%= render(UI::HoverCardComponent.new) do |c| %>
+  <% c.with_trigger do %>
+    <%= link_to "@dave", profile_path, class: "underline" %>
   <% end %>
-  <div>
-    <p class="font-semibold">Alec P.</p>
-    <p class="text-sm text-muted-foreground">Joined January 2024</p>
+  <div class="space-y-1">
+    <p class="font-medium text-text-heading">Dave Chmura</p>
+    <p class="text-text-body">Building modelrails_ui.</p>
+    <a href="#" class="text-text-body underline">View profile</a>
   </div>
 <% end %>
 ```
 
-## Position
+The `with_trigger` slot is required — omitting it raises `ArgumentError`.
+
+## Side
 
 | Side | Description |
 |------|-------------|
-| `:bottom` | Below trigger (default) |
-| `:top` | Above trigger |
-| `:left` | Left of trigger |
-| `:right` | Right of trigger |
+| `:bottom` | Below the trigger (default) |
+| `:top` | Above the trigger |
+| `:left` | Left of the trigger |
+| `:right` | Right of the trigger |
 
 ```erb
-<%= ui :hover_card, side: :right do |card| %>
-  <% card.with_trigger { link_to "More info", "#" } %>
-  <p class="text-sm">Additional details appear here.</p>
+<%= render(UI::HoverCardComponent.new(side: :right)) do |c| %>
+  <% c.with_trigger { link_to "More info", "#" } %>
+  <p class="text-text-body">Additional details appear here.</p>
 <% end %>
 ```
+
+Unknown values for `side:` raise `ArgumentError` (fail-loud).
+
+## Accessible group label
+
+Pass `label:` to wrap the card in `role="group"` with an `aria-label`. Use
+this when the card contains multiple interactive elements that benefit from a
+named region:
+
+```erb
+<%= render(UI::HoverCardComponent.new(label: "User card")) do |c| %>
+  <% c.with_trigger { "@dave" } %>
+  <p class="text-text-body">Profile preview.</p>
+<% end %>
+```
+
+Omitting `label:` renders the card as a plain `<div>` without a role.
+
+## Dismiss on Escape
+
+The card hides automatically when the user presses `Escape`
+(`group-data-[dismissed]:invisible! group-data-[dismissed]:opacity-0!`). The
+`floating` controller clears the dismissed state on `mouseleave` and `focusout`
+so the card can reappear on the next interaction.
+
+## Accessibility contract
+
+The component guarantees:
+
+- Hover (`group-hover:opacity-100`) and keyboard focus-within
+  (`group-focus-within:opacity-100`) both reveal the card.
+- The card remains open while the user Tabs through its links or buttons
+  (`focus-within` covers the trigger and all card descendants).
+- `Escape` dismisses without moving focus (WCAG 1.4.13 — content on hover).
+- When `label:` is given, the card element receives `role="group"` and
+  `aria-label` for a named landmark region.
+
+You supply:
+
+- `with_trigger` slot — a focusable link or button (required).
+- Block content — the card's body (text, links, arbitrary markup).
+- `label:` — optional accessible name for the card region.
 
 ## API
 
 | Option | Type | Default | Description |
 |--------|------|---------|-------------|
+| `id` | String | auto `hovercard-<hex>` | Card element ID |
+| `label` | String | `nil` | Accessible name → `role="group"` + `aria-label` on the card |
 | `side` | Symbol | `:bottom` | `:bottom`, `:top`, `:left`, or `:right` |
 | `**html_attrs` | Hash | — | Forwarded to the outer `<span>` wrapper |
 
 | Slot | Required | Description |
 |------|----------|-------------|
-| `trigger` | No | Element that triggers the hover card |
+| `with_trigger` | Yes | Focusable element (link/button) that triggers the card — omitting raises `ArgumentError` |

--- a/docs/components/hover_card.md
+++ b/docs/components/hover_card.md
@@ -1,9 +1,11 @@
 # Hover Card
 
 A rich supplemental card revealed on hover and keyboard focus of its trigger.
-Unlike `tooltip`, the card may hold interactive content (links, buttons);
-`focus-within` keeps it open while the user Tabs through that content. Escape
-dismisses (WCAG 1.4.13) via the shared `floating` Stimulus controller.
+Unlike `tooltip`, the card may hold interactive content (links, buttons). A short
+hover-intent close-delay keeps the card reachable, so the pointer can move from the
+trigger onto the card to click it — and `focus-within` / Tab keeps it open for
+keyboard users. `Escape` closes the card and returns focus to the trigger (WCAG
+1.4.13). All behavior lives in the shared `floating` Stimulus controller.
 
 Use for enhancement — the card's content should never be the only path to that
 information. If you need a click-triggered panel, use `popover`. If the hint is
@@ -69,22 +71,28 @@ named region:
 
 Omitting `label:` renders the card as a plain `<div>` without a role.
 
-## Dismiss on Escape
+## Hover-intent & dismissal
 
-The card hides automatically when the user presses `Escape`
-(`group-data-[dismissed]:invisible! group-data-[dismissed]:opacity-0!`). The
-`floating` controller clears the dismissed state on `mouseleave` and `focusout`
-so the card can reappear on the next interaction.
+The card is opened and closed by the `floating` controller, not by CSS `:hover`
+alone — pure CSS can't keep an *interactive* card reachable across the small gap
+between trigger and card. The controller opens on `mouseenter` / `focus` and
+closes on `mouseleave` / `blur` **after a short delay** (`hideDelay`, default
+`150`ms). The delay survives the gap crossing (and brief mouse-outs), so the
+pointer can move onto the card and click its content. Opening sets
+`data-state="open"` on the wrapper; `group-data-[state=open]` reveals the card.
+
+`Escape` closes the card immediately and returns focus to the trigger.
 
 ## Accessibility contract
 
 The component guarantees:
 
-- Hover (`group-hover:opacity-100`) and keyboard focus-within
-  (`group-focus-within:opacity-100`) both reveal the card.
-- The card remains open while the user Tabs through its links or buttons
-  (`focus-within` covers the trigger and all card descendants).
-- `Escape` dismisses without moving focus (WCAG 1.4.13 — content on hover).
+- Hover and keyboard focus both open the card (the controller sets
+  `data-state="open"`; `group-data-[state=open]` reveals it).
+- The hover-intent close-delay keeps the card reachable, so its interactive
+  content is clickable with the pointer and Tab-reachable for the keyboard.
+- `Escape` closes the card and returns focus to the trigger (WCAG 1.4.13 —
+  content on hover or focus, dismissible without losing your place).
 - When `label:` is given, the card element receives `role="group"` and
   `aria-label` for a named landmark region.
 

--- a/docs/components/hover_card.md
+++ b/docs/components/hover_card.md
@@ -56,6 +56,16 @@ The `with_trigger` slot is required — omitting it raises `ArgumentError`.
 
 Unknown values for `side:` raise `ArgumentError` (fail-loud).
 
+## Placement
+
+Placement uses CSS anchor positioning: the card is `position: fixed` (viewport as
+containing block) and tethered to the trigger via inline `anchor-name`/`position-anchor`
+attributes; `position-area` sets the requested side and `position-try-fallbacks` keeps
+it on-screen near viewport edges. Note that at an extreme edge Chromium clamps the
+element on-screen rather than performing a full flip, because the card is nested inside
+its trigger element. On browsers without anchor positioning (pre-Baseline 2026) the
+component falls back to `absolute` offsets relative to the wrapper.
+
 ## Accessible group label
 
 Pass `label:` to wrap the card in `role="group"` with an `aria-label`. Use

--- a/docs/components/tooltip.md
+++ b/docs/components/tooltip.md
@@ -46,6 +46,16 @@ referenced via `aria-describedby` on the focusable wrapper.
 
 Unknown values for `side:` raise `ArgumentError` (fail-loud).
 
+## Placement
+
+Placement uses CSS anchor positioning: the bubble is `position: fixed` (viewport as
+containing block) and tethered to the trigger via inline `anchor-name`/`position-anchor`
+attributes; `position-area` sets the requested side and `position-try-fallbacks` keeps
+it on-screen near viewport edges. Note that at an extreme edge Chromium clamps the
+element on-screen rather than performing a full flip, because the bubble is nested inside
+its trigger element. On browsers without anchor positioning (pre-Baseline 2026) the
+component falls back to `absolute` offsets relative to the wrapper.
+
 ## Dismiss on Escape
 
 The tooltip hides automatically when the user presses `Escape`

--- a/docs/components/tooltip.md
+++ b/docs/components/tooltip.md
@@ -1,11 +1,19 @@
 # Tooltip
 
-Small text label that appears near an element on hover. Pure CSS — no JavaScript required.
+A small text bubble that describes the element it wraps. Appears on hover and
+keyboard focus. The wrapper span is made focusable (`tabindex="0"`) and
+`aria-describedby` wires the `role="tooltip"` bubble to it. Escape dismisses
+(WCAG 1.4.13) via the shared `floating` Stimulus controller.
+
+Use for short, non-interactive hints on icon buttons or truncated labels. If
+the content is rich or interactive, use `hover_card` instead.
+
+Requires `floating_controller.js` (copied automatically by the generator).
 
 ## Installation
 
 ```bash
-rails g view_primitives:add tooltip
+rails g modelrails_ui:add tooltip
 ```
 
 Creates `app/components/ui/tooltip_component.rb`.
@@ -13,32 +21,60 @@ Creates `app/components/ui/tooltip_component.rb`.
 ## Usage
 
 ```erb
-<%= ui :tooltip, text: "Save your changes" do %>
-  <%= ui :button, size: :icon do %>
-    <svg ...></svg>
-  <% end %>
+<%= render(UI::TooltipComponent.new(text: "Save to library")) do %>
+  <button class="btn-ghost btn-icon" aria-hidden="true">★</button>
 <% end %>
 ```
 
-## Position
+The `text:` argument is required — it becomes the bubble's visible text and is
+referenced via `aria-describedby` on the focusable wrapper.
+
+## Side
 
 | Side | Description |
 |------|-------------|
-| `:top` | Above the element (default) |
-| `:bottom` | Below the element |
-| `:left` | Left of the element |
-| `:right` | Right of the element |
+| `:top` | Above the trigger (default) |
+| `:bottom` | Below the trigger |
+| `:left` | Left of the trigger |
+| `:right` | Right of the trigger |
 
 ```erb
-<%= ui :tooltip, text: "Delete", side: :right do %>
-  <%= ui :button, variant: :destructive, size: :icon do %><svg ...></svg><% end %>
+<%= render(UI::TooltipComponent.new(text: "Delete", side: :right)) do %>
+  <button class="btn-ghost btn-icon"><svg ...></svg></button>
 <% end %>
 ```
+
+Unknown values for `side:` raise `ArgumentError` (fail-loud).
+
+## Dismiss on Escape
+
+The tooltip hides automatically when the user presses `Escape`
+(`group-data-[dismissed]:opacity-0!`). The `floating` controller clears the
+dismissed state on `mouseleave` and `focusout` so the tooltip can reappear on
+the next interaction.
+
+## Accessibility contract
+
+The component guarantees:
+
+- The outer `<span>` is focusable (`tabindex="0"`) and carries
+  `aria-describedby` pointing to the bubble's `id`.
+- The bubble has `role="tooltip"` and the `id` referenced above.
+- The bubble is `pointer-events-none` — it never traps the pointer.
+- Hover (`group-hover:opacity-100`) and keyboard focus
+  (`group-focus-within:opacity-100`) both reveal the bubble.
+- `Escape` dismisses without moving focus (WCAG 1.4.13 — content on hover).
+
+You supply:
+
+- `text:` — the hint string (required).
+- Block content — the visible trigger (icon, word, or any inline element).
 
 ## API
 
 | Option | Type | Default | Description |
 |--------|------|---------|-------------|
 | `text` | String | required | Tooltip bubble text |
+| `id` | String | auto `tooltip-<hex>` | Bubble element ID; wired to `aria-describedby` on the wrapper |
 | `side` | Symbol | `:top` | `:top`, `:bottom`, `:left`, or `:right` |
 | `**html_attrs` | Hash | — | Forwarded to the outer `<span>` wrapper |

--- a/docs/design/2026-06-06-wave5b-tooltip-hovercard-plan.md
+++ b/docs/design/2026-06-06-wave5b-tooltip-hovercard-plan.md
@@ -1,0 +1,479 @@
+# Wave 5b Tooltip + Hover Card — Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax.
+
+**Goal:** Harden `tooltip` and `hover_card` to the DoD as the hover/focus half of the floating band — fixing their hover-only (keyboard-invisible) defect, wiring `aria-describedby` (tooltip), and adding Escape-dismiss (WCAG 1.4.13) by extending the shared `floating` controller. Both reuse `floating` via `EXTRA_STIMULUS`.
+
+**Architecture:** CSS owns show/hide (`group-hover` **and** `group-focus-within` — the fix), so they degrade gracefully with no JS. The `floating` controller (from Wave 5a) gains `dismiss`/`clearDismissed`: Escape sets `data-dismissed` (CSS force-hides via an `!important` override that beats the hover/focus rules); `mouseleave`/`focusout` clear it so the next hover/focus re-shows. See `2026-06-06-wave5-floating-overlays-design.md`. Per the updated DoD item 10, both get a `@param` playground.
+
+**Tech Stack:** Ruby 4.0.5 (gem), ViewComponent, Stimulus, Minitest (0a), RSpec+Capybara+Playwright+axe (app 0b), TailwindCSS v4.
+
+**Toolchain:** Gem — `PATH="/Users/dschmura/.local/share/mise/installs/ruby/4.0.5/bin:$PATH" bundle exec rake` (NOT `mise exec`). App — `cd …/modelrails_base && mise exec -- bundle exec rspec …`.
+
+**Branches:** Gem `harden/wave5b-tooltip-hovercard` (off `modelrails/harden`, already created). App `feat/ui-tooltip-hovercard`.
+
+**Exemplar to mirror (read first):** Wave 5a popover — `popover_component.rb.tt`, `popover_render_test.rb`, `popover_component_preview.rb` (+ playground), app `spec/system/ui/popover_component_spec.rb`. The 0a/preview/0b artifact *shapes* are identical; only the component bodies differ.
+
+---
+
+## File Structure
+
+**Gem** (`harden/wave5b-tooltip-hovercard`):
+
+| File | Change |
+|---|---|
+| `…/popover/floating_controller.js` | Add `dismiss` + `clearDismissed`. Do FIRST. |
+| `…/tooltip/tooltip_component.rb.tt` | Rewrite (focus-within + describedby + dismiss). |
+| `…/hover_card/hover_card_component.rb.tt` | Rewrite (focus-within + interactive content + dismiss). |
+| `…/components.rb` | Add `tooltip` + `hover_card` `EXTRA_STIMULUS` entries → `floating`. |
+| `test/render/{tooltip,hover_card}_render_test.rb` | New 0a render tests. |
+| `…/previews/ui/{tooltip,hover_card}_component_preview.rb` (+ scenarios) | New previews **with `@param` playground**. |
+| `COMPONENT_STATUS.md` + `docs/components/{tooltip,hover_card}.md` | Rows + doc refresh. |
+
+**App** (`feat/ui-tooltip-hovercard`): pin to the gem branch; vendor both (+ re-vendor `floating_controller.js`); 0b specs for each.
+
+**Orchestration:** Task 1 (controller) first. Gem tasks → one gem PR into `modelrails/harden`; app → one app PR. Land sequence (Task 9) re-pins app to `modelrails/harden` after the gem PR merges.
+
+---
+
+### Task 1: Extend the `floating` controller (do FIRST)
+
+**Files:** Modify `lib/generators/modelrails_ui/add/templates/popover/floating_controller.js`
+
+- [ ] **Step 1:** Add two methods (after `closeOnClickOutside`), leaving the popover methods untouched:
+
+```js
+  // Hover/focus components (tooltip, hover_card) are CSS-shown; this is the only
+  // thing CSS can't do — dismiss-while-hovered (WCAG 1.4.13). Escape sets
+  // data-dismissed (CSS force-hides via group-data-[dismissed]); mouseleave/
+  // focusout clear it so the next hover/focus shows it again.
+  dismiss() {
+    this.element.setAttribute("data-dismissed", "")
+  }
+
+  clearDismissed() {
+    this.element.removeAttribute("data-dismissed")
+  }
+```
+
+(No target access — these operate on `this.element` — so they're safe for tooltip/hover_card, which have no `trigger`/`panel` targets.)
+
+- [ ] **Step 2: Commit.**
+
+```bash
+git -C /Users/dschmura/Documents/code/modelrails_ui add lib/generators/modelrails_ui/add/templates/popover/floating_controller.js
+git -C /Users/dschmura/Documents/code/modelrails_ui commit -m "feat(floating): add dismiss/clearDismissed for hover-focus overlays (1.4.13)"
+```
+
+---
+
+### Task 2: Wire `EXTRA_STIMULUS`
+
+**Files:** Modify `lib/generators/modelrails_ui/components.rb`
+
+- [ ] **Step 1:** Add two entries to the `EXTRA_STIMULUS` hash (alongside the dialog-family rows):
+
+```ruby
+        "tooltip" => {source: "popover/floating_controller.js", name: "floating"},
+        "hover_card" => {source: "popover/floating_controller.js", name: "floating"}
+```
+
+- [ ] **Step 2: Commit.**
+
+```bash
+git -C /Users/dschmura/Documents/code/modelrails_ui add lib/generators/modelrails_ui/components.rb
+git -C /Users/dschmura/Documents/code/modelrails_ui commit -m "feat(floating): share floating controller with tooltip + hover_card via EXTRA_STIMULUS"
+```
+
+---
+
+### Task 3: Harden `tooltip` (0a TDD)
+
+**Files:** Create `test/render/tooltip_render_test.rb`; Modify `…/tooltip/tooltip_component.rb.tt`
+
+- [ ] **Step 1: Write the failing render test.**
+
+```ruby
+# frozen_string_literal: true
+
+require "render_test_helper"
+require "securerandom"
+load_component "tooltip", "tooltip_component.rb.tt"
+
+class TooltipRenderTest < ViewComponent::TestCase
+  def render_tooltip(**opts)
+    render_inline(UI::TooltipComponent.new(**{ text: "Saved" }.merge(opts))) { "Status" }
+  end
+
+  def test_wrapper_is_focusable_and_describes_the_bubble
+    render_tooltip(id: "t1")
+
+    assert_selector "span.group[tabindex='0'][aria-describedby='t1'][data-controller='floating']", visible: :all
+    assert_selector "span[data-action~='keydown.esc->floating#dismiss']", visible: :all
+    assert_selector "span[data-action~='mouseleave->floating#clearDismissed']", visible: :all
+    assert_selector "span[data-action~='focusout->floating#clearDismissed']", visible: :all
+  end
+
+  def test_bubble_is_a_tooltip_role_with_the_referenced_id
+    render_tooltip(id: "t2", text: "Copied to clipboard")
+
+    assert_selector "span#t2[role='tooltip']", text: "Copied to clipboard", visible: :all
+  end
+
+  def test_bubble_shows_on_hover_and_focus_and_force_hides_when_dismissed
+    render_tooltip
+
+    assert_selector "[role='tooltip'].group-hover\\:opacity-100", visible: :all
+    assert_selector "[role='tooltip'].group-focus-within\\:opacity-100", visible: :all
+    assert_selector "[role='tooltip'].group-data-\\[dismissed\\]\\:opacity-0\\!", visible: :all
+  end
+
+  def test_fail_loud_on_unknown_side
+    error = assert_raises(ArgumentError) { UI::TooltipComponent.new(text: "x", side: :sideways) }
+    assert_match(/unknown side/, error.message)
+  end
+end
+```
+
+- [ ] **Step 2: Run; verify FAIL.** `cd /Users/dschmura/Documents/code/modelrails_ui && PATH="…4.0.5/bin:$PATH" bundle exec ruby -Itest test/render/tooltip_render_test.rb` → FAIL (current tooltip is hover-only, no focus-within/describedby/dismiss).
+
+- [ ] **Step 3: Rewrite the component** with EXACTLY:
+
+```ruby
+# frozen_string_literal: true
+
+module UI
+  # # Tooltip
+  #
+  # A small text bubble describing the element it wraps. Shows on hover **and**
+  # keyboard focus; the wrapper is focusable and `aria-describedby` wires the bubble
+  # to it. Escape dismisses (WCAG 1.4.13) via the shared `floating` controller.
+  #
+  # ## Use when
+  # - You need a short, non-interactive hint describing a single focusable trigger
+  #   (an icon button, a truncated label).
+  #
+  # ## Don't use when
+  # - The content is interactive or rich — use `hover_card`.
+  # - You wrap an already-interactive control — put `aria-describedby` on that control
+  #   instead (this component makes its own wrapper the focusable trigger).
+  #
+  # ## Accessibility contract
+  # - **Guarantees:** shows on hover AND focus; `role="tooltip"` bubble wired via
+  #   `aria-describedby`; Escape dismisses without moving focus; `pointer-events-none`
+  #   so the bubble never traps the pointer.
+  # - **You supply:** `text:` (the hint) and the trigger content (icon/word).
+  class TooltipComponent < ApplicationComponent
+    BUBBLE_BASE = "absolute z-50 w-max max-w-xs rounded-md px-3 py-1.5 text-xs text-balance " \
+                  "bg-text-heading text-surface-raised whitespace-normal " \
+                  "pointer-events-none opacity-0 transition-opacity duration-200 " \
+                  "group-hover:opacity-100 group-focus-within:opacity-100 " \
+                  "group-data-[dismissed]:opacity-0!"
+
+    POSITIONS = {
+      top:    "bottom-full left-1/2 -translate-x-1/2 mb-2",
+      bottom: "top-full left-1/2 -translate-x-1/2 mt-2",
+      left:   "right-full top-1/2 -translate-y-1/2 mr-2",
+      right:  "left-full top-1/2 -translate-y-1/2 ml-2"
+    }.freeze
+
+    # text: the hint (the bubble's content); id: bubble id (→ aria-describedby);
+    # side: :top | :bottom | :left | :right
+    def initialize(text:, id: nil, side: :top, **html_attrs)
+      @text        = text
+      @id          = id || "tooltip-#{SecureRandom.hex(4)}"
+      @side        = coerce_enum(:side, side, POSITIONS)
+      @extra_class = html_attrs.delete(:class)
+      @html_attrs  = html_attrs
+    end
+
+    def call
+      content_tag(:span, **wrapper_attrs) do
+        safe_join([content, bubble])
+      end
+    end
+
+    private
+
+    def wrapper_attrs
+      {
+        class: cn("group relative inline-flex", @extra_class),
+        tabindex: "0",
+        "aria-describedby": @id,
+        data: {
+          controller: "floating",
+          action: "keydown.esc->floating#dismiss mouseleave->floating#clearDismissed focusout->floating#clearDismissed"
+        }
+      }.merge(@html_attrs)
+    end
+
+    def bubble
+      content_tag(:span, @text, id: @id, role: "tooltip", class: cn(BUBBLE_BASE, POSITIONS.fetch(@side)))
+    end
+
+    def coerce_enum(name, value, map)
+      key = value.to_sym
+      return key if map.key?(key)
+
+      raise ArgumentError, "UI::Tooltip unknown #{name}: #{value.inspect} (allowed: #{map.keys.join(", ")})"
+    end
+  end
+end
+```
+
+- [ ] **Step 4: Run render test (PASS) + full `rake` (green incl. rubocop).** Fix rubocop style only if flagged.
+
+- [ ] **Step 5: Verify the `!important` class actually compiles** (the precedence risk). Probe the *built* CSS in the app later (Task 8); in the gem, just assert the class string renders (Step 1 test).
+
+- [ ] **Step 6: Commit.**
+
+```bash
+git -C /Users/dschmura/Documents/code/modelrails_ui add test/render/tooltip_render_test.rb lib/generators/modelrails_ui/add/templates/tooltip/tooltip_component.rb.tt
+git -C /Users/dschmura/Documents/code/modelrails_ui commit -m "feat(tooltip): show on focus + aria-describedby + Escape-dismiss (0a)"
+```
+
+---
+
+### Task 4: Harden `hover_card` (0a TDD)
+
+**Files:** Create `test/render/hover_card_render_test.rb`; Modify `…/hover_card/hover_card_component.rb.tt`
+
+- [ ] **Step 1: Write the failing render test** (mirror Task 3; key assertions): wrapper `span.group[data-controller='floating']` with the three dismiss actions; **required `with_trigger` slot** (raises `ArgumentError` if absent); card `div` carrying `group-hover:visible` / `group-focus-within:visible` / `group-data-[dismissed]:invisible!`; `role="group"` + `aria-label` ONLY when `label:` given; fail-loud `side`.
+
+```ruby
+# frozen_string_literal: true
+
+require "render_test_helper"
+require "securerandom"
+load_component "hover_card", "hover_card_component.rb.tt"
+
+class HoverCardRenderTest < ViewComponent::TestCase
+  def render_card(**opts)
+    render_inline(UI::HoverCardComponent.new(**opts)) do |c|
+      c.with_trigger { "@dave" }
+      "Profile details"
+    end
+  end
+
+  def test_wrapper_wires_floating_and_dismissal
+    render_card
+
+    assert_selector "span.group[data-controller='floating']" \
+                    "[data-action~='keydown.esc->floating#dismiss']" \
+                    "[data-action~='mouseleave->floating#clearDismissed']" \
+                    "[data-action~='focusout->floating#clearDismissed']", visible: :all
+  end
+
+  def test_card_shows_on_hover_and_focus_within_and_hides_when_dismissed
+    render_card
+
+    assert_selector "div.group-hover\\:visible.group-focus-within\\:visible", visible: :all
+    assert_selector "div.group-data-\\[dismissed\\]\\:invisible\\!", visible: :all
+  end
+
+  def test_label_sets_role_group_and_aria_label
+    render_card(label: "User card")
+
+    assert_selector "div[role='group'][aria-label='User card']", visible: :all
+  end
+
+  def test_omits_role_without_a_label
+    render_card
+
+    assert_no_selector "div[role='group']", visible: :all
+  end
+
+  def test_requires_a_trigger_slot
+    error = assert_raises(ArgumentError) { render_inline(UI::HoverCardComponent.new) }
+    assert_match(/with_trigger/, error.message)
+  end
+
+  def test_fail_loud_on_unknown_side
+    assert_raises(ArgumentError) { UI::HoverCardComponent.new(side: :diagonal) }
+  end
+end
+```
+
+- [ ] **Step 2: Run; verify FAIL.**
+
+- [ ] **Step 3: Rewrite the component** with EXACTLY:
+
+```ruby
+# frozen_string_literal: true
+
+module UI
+  # # Hover Card
+  #
+  # A rich, supplemental card revealed on hover **and** keyboard focus of its trigger.
+  # Unlike `tooltip`, the card may hold interactive content; `focus-within` keeps it
+  # open while the user Tabs through that content. Escape dismisses (WCAG 1.4.13).
+  #
+  # ## Use when
+  # - A link/avatar benefits from a supplemental preview (profile, definition) whose
+  #   content is ALSO reachable elsewhere (the card is an enhancement, not the only path).
+  #
+  # ## Don't use when
+  # - The content is a primary interactive surface — use `popover` (click) or a `dialog`.
+  # - It's a short text hint — use `tooltip`.
+  #
+  # ## Accessibility contract
+  # - **Guarantees:** shows on hover AND focus-within (card content is Tab-reachable while
+  #   open); Escape dismisses; `role="group"` + `aria-label` when `label:` is given.
+  # - **You supply:** a `with_trigger` slot (a focusable link/button) and the card content.
+  class HoverCardComponent < ApplicationComponent
+    renders_one :trigger
+
+    CARD_BASE = "absolute z-50 w-64 rounded-lg border border-border bg-surface-overlay p-4 text-sm " \
+                "text-text-body shadow-md " \
+                "invisible opacity-0 transition-opacity duration-200 " \
+                "group-hover:visible group-hover:opacity-100 " \
+                "group-focus-within:visible group-focus-within:opacity-100 " \
+                "group-data-[dismissed]:invisible! group-data-[dismissed]:opacity-0!"
+
+    POSITIONS = {
+      bottom: "top-full left-0 mt-2",
+      top:    "bottom-full left-0 mb-2",
+      left:   "right-full top-0 mr-2",
+      right:  "left-full top-0 ml-2"
+    }.freeze
+
+    # id: card id; label: optional accessible name (→ role=group + aria-label);
+    # side: :bottom | :top | :left | :right
+    def initialize(id: nil, label: nil, side: :bottom, **html_attrs)
+      @id          = id || "hovercard-#{SecureRandom.hex(4)}"
+      @label       = label
+      @side        = coerce_enum(:side, side, POSITIONS)
+      @extra_class = html_attrs.delete(:class)
+      @html_attrs  = html_attrs
+    end
+
+    def call
+      raise ArgumentError, "UI::HoverCardComponent requires a with_trigger slot" unless trigger?
+
+      content_tag(:span, **wrapper_attrs) do
+        safe_join([trigger, card])
+      end
+    end
+
+    private
+
+    def wrapper_attrs
+      {
+        class: cn("group relative inline-block", @extra_class),
+        data: {
+          controller: "floating",
+          action: "keydown.esc->floating#dismiss mouseleave->floating#clearDismissed focusout->floating#clearDismissed"
+        }
+      }.merge(@html_attrs)
+    end
+
+    def card
+      attrs = { id: @id, class: cn(CARD_BASE, POSITIONS.fetch(@side)) }
+      if @label
+        attrs[:role] = "group"
+        attrs["aria-label"] = @label
+      end
+      content_tag(:div, content, **attrs)
+    end
+
+    def coerce_enum(name, value, map)
+      key = value.to_sym
+      return key if map.key?(key)
+
+      raise ArgumentError, "UI::HoverCard unknown #{name}: #{value.inspect} (allowed: #{map.keys.join(", ")})"
+    end
+  end
+end
+```
+
+- [ ] **Step 4: Run render test (PASS) + full `rake`.**
+- [ ] **Step 5: Commit** `feat(hover_card): show on focus-within + Escape-dismiss + optional label (0a)`.
+
+---
+
+### Task 5: Previews (static + `@param` playground)
+
+**Files:** Create `…/previews/ui/tooltip_component_preview.rb` (+ `tooltip_component_preview/basic.html.erb`); `…/previews/ui/hover_card_component_preview.rb` (+ `hover_card_component_preview/basic.html.erb`).
+
+Mirror popover's preview. Each: a `basic` static scenario (stable 0b target) + a `playground` with `@param side select [...]` (+ `@param text` for tooltip; `@param label text` for hover_card). Example tooltip playground:
+
+```ruby
+    # @param text text
+    # @param side select [top, bottom, left, right]
+    def playground(text: "Saved to your library", side: :top)
+      ui(:tooltip, text: text, side: side.to_sym) { "Hover or focus me" }
+    end
+```
+
+Hover_card playground uses the block-with-slot form (`ui(:hover_card, side: side.to_sym) { |c| c.with_trigger { "@dave" }; "Profile…" }`). Commit `feat(tooltip,hover_card): template-backed previews + @param playgrounds`.
+
+---
+
+### Task 6: Ledger rows + docs
+
+Add two `COMPONENT_STATUS.md` rows (`hardened`, `✅ ⏳`); refresh `docs/components/tooltip.md` + `docs/components/hover_card.md` to the hardened contracts (accurate to source — no fabrication). Commit `docs(tooltip,hover_card): hardened rows + refreshed docs`.
+
+---
+
+### Task 7: Gem PR
+
+`rake` green → push `harden/wave5b-tooltip-hovercard` → `gh pr create --base modelrails/harden` (title: `feat(floating): harden tooltip + hover_card to button-tier (Wave 5b)`; body notes AAA proven by the companion app 0b).
+
+---
+
+### Task 8: App adoption + 0b specs (the precedence proof)
+
+**Files:** `Gemfile` (pin to the gem branch), vendor both components + re-vendor `floating_controller.js` + previews; Create `spec/system/ui/{tooltip,hover_card}_component_spec.rb`.
+
+- [ ] Pin app `modelrails_ui` to `branch: "harden/wave5b-tooltip-hovercard"`; `bundle update modelrails_ui`.
+- [ ] **Write the 0b specs (the key proofs):**
+  - **tooltip:** focusing the wrapper shows the bubble (`group-focus-within`); `aria-describedby` resolves to a `role="tooltip"`; **Escape hides the bubble while focus stays** (the `!important` precedence proof); moving focus away clears `data-dismissed`. AAA on the bubble in both themes (incl. the inverted `bg-text-heading`).
+  - **hover_card:** focusing the trigger reveals the card; a link inside is Tab-reachable; Escape dismisses; AAA in both themes.
+
+  Tooltip 0b skeleton:
+
+```ruby
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe "Tooltip component accessibility", type: :system do
+  it "shows on focus, is described, dismisses on Escape, passes AAA" do
+    visit "/rails/view_components/ui/tooltip_component/basic"
+
+    trigger = find("[data-controller='floating'][tabindex='0']")
+    desc_id = trigger[:"aria-describedby"]
+    expect(page).to have_css("##{desc_id}[role='tooltip']", visible: :all)
+
+    trigger.send_keys("") # focus the wrapper
+    expect(page).to have_css("[role='tooltip']") # visible on focus
+
+    scope = [ "[role='tooltip']" ]
+    expect(axe_clean_in_both_themes?(include: scope)).to be(true), axe_violations_in_both_themes(include: scope).join("\n")
+
+    page.send_keys(:escape)
+    # data-dismissed set; the !important rule must force-hide despite focus-within
+    expect(page).to have_css("[data-controller='floating'][data-dismissed]", visible: :all)
+  end
+end
+```
+
+  (If `send_keys("")` doesn't focus reliably, use `trigger.click` then assert, or `page.driver.with_playwright_page { |pw| pw.keyboard.press("Tab") }`. The executor verifies in-browser — this is the precedence-proof task.)
+
+- [ ] Run each 0b with `-r rails_helper` (PASS), then full suite (0 failures).
+- [ ] Commit `feat(ui): adopt hardened tooltip + hover_card + 0b proof (Wave 5b)`; push (Lefthook CI); open app PR.
+
+---
+
+### Task 9: Land sequence
+
+Same as Wave 5a: both PRs green → merge gem PR → re-pin app to `modelrails/harden` + `bundle update` + suite + push → merge app PR. Then flip the two ledger rows to `proven`.
+
+---
+
+## Self-Review
+
+- **Spec coverage:** §1 controller `dismiss` (T1); §3 tooltip focus+describedby+dismiss (T3/T8); §4 hover_card focus-within+interactive+dismiss (T4/T8); §5 artifacts (T3–T6); playgrounds per DoD item 10 (T5). ✅
+- **The `!important` precedence is the one real risk** — render tests assert the class string exists, but only the app 0b proves it actually wins over `group-hover`/`group-focus-within` in the built CSS. T8 is explicitly the precedence proof; if it fails, the fallback is restructuring (e.g., `data-[dismissed]` on the bubble itself, or a `hidden` toggle in `dismiss`). Do NOT claim dismissal works from the render test alone.
+- **Type consistency:** `floating` targets/methods (`dismiss`/`clearDismissed`), `data-floating-target` unused by these two (CSS-driven), `coerce_enum`, `group-data-[dismissed]` — consistent across controller, components, tests. ✅
+- **No fabrication:** keep tooltip's inverted `bg-text-heading`/`text-surface-raised` (the design references it); let CI adjudicate AAA — don't pre-"fix" it.

--- a/lib/generators/modelrails_ui/add/templates/hover_card/hover_card_component.rb.tt
+++ b/lib/generators/modelrails_ui/add/templates/hover_card/hover_card_component.rb.tt
@@ -1,13 +1,33 @@
 # frozen_string_literal: true
 
 module UI
+  # # Hover Card
+  #
+  # A rich, supplemental card revealed on hover **and** keyboard focus of its trigger.
+  # Unlike `tooltip`, the card may hold interactive content; `focus-within` keeps it
+  # open while the user Tabs through that content. Escape dismisses (WCAG 1.4.13).
+  #
+  # ## Use when
+  # - A link/avatar benefits from a supplemental preview (profile, definition) whose
+  #   content is ALSO reachable elsewhere (the card is an enhancement, not the only path).
+  #
+  # ## Don't use when
+  # - The content is a primary interactive surface — use `popover` (click) or a `dialog`.
+  # - It's a short text hint — use `tooltip`.
+  #
+  # ## Accessibility contract
+  # - **Guarantees:** shows on hover AND focus-within (card content is Tab-reachable while
+  #   open); Escape dismisses; `role="group"` + `aria-label` when `label:` is given.
+  # - **You supply:** a `with_trigger` slot (a focusable link/button) and the card content.
   class HoverCardComponent < ApplicationComponent
     renders_one :trigger
 
-    CARD_BASE = "absolute z-50 w-64 rounded-lg border bg-surface-overlay p-4 text-sm " \
+    CARD_BASE = "absolute z-50 w-64 rounded-lg border border-border bg-surface-overlay p-4 text-sm " \
                 "text-text-body shadow-md " \
-                "opacity-0 group-hover:opacity-100 pointer-events-none " \
-                "transition-opacity duration-200"
+                "invisible opacity-0 transition-opacity duration-200 " \
+                "group-hover:visible group-hover:opacity-100 " \
+                "group-focus-within:visible group-focus-within:opacity-100 " \
+                "group-data-[dismissed]:invisible! group-data-[dismissed]:opacity-0!"
 
     POSITIONS = {
       bottom: "top-full left-0 mt-2",
@@ -16,28 +36,50 @@ module UI
       right:  "left-full top-0 ml-2"
     }.freeze
 
-    def initialize(side: :bottom, **html_attrs)
-      @side        = side.to_sym
+    # id: card id; label: optional accessible name (→ role=group + aria-label);
+    # side: :bottom | :top | :left | :right
+    def initialize(id: nil, label: nil, side: :bottom, **html_attrs)
+      @id          = id || "hovercard-#{SecureRandom.hex(4)}"
+      @label       = label
+      @side        = coerce_enum(:side, side, POSITIONS)
       @extra_class = html_attrs.delete(:class)
       @html_attrs  = html_attrs
     end
 
     def call
-      content_tag(:span,
-        class: cn("relative inline-block group", @extra_class),
-        **@html_attrs) do
-        concat trigger if trigger
-        concat card_panel
+      raise ArgumentError, "UI::HoverCardComponent requires a with_trigger slot" unless trigger?
+
+      content_tag(:span, **wrapper_attrs) do
+        safe_join([trigger, card])
       end
     end
 
     private
 
-    def card_panel
-      content_tag(:div,
-        class: cn(CARD_BASE, POSITIONS.fetch(@side, POSITIONS[:bottom]))) do
-        content
+    def wrapper_attrs
+      {
+        class: cn("group relative inline-block", @extra_class),
+        data: {
+          controller: "floating",
+          action: "keydown.esc->floating#dismiss mouseleave->floating#clearDismissed focusout->floating#clearDismissed"
+        }
+      }.merge(@html_attrs)
+    end
+
+    def card
+      attrs = { id: @id, class: cn(CARD_BASE, POSITIONS.fetch(@side)) }
+      if @label
+        attrs[:role] = "group"
+        attrs["aria-label"] = @label
       end
+      content_tag(:div, content, **attrs)
+    end
+
+    def coerce_enum(name, value, map)
+      key = value.to_sym
+      return key if map.key?(key)
+
+      raise ArgumentError, "UI::HoverCard unknown #{name}: #{value.inspect} (allowed: #{map.keys.join(", ")})"
     end
   end
 end

--- a/lib/generators/modelrails_ui/add/templates/hover_card/hover_card_component.rb.tt
+++ b/lib/generators/modelrails_ui/add/templates/hover_card/hover_card_component.rb.tt
@@ -3,9 +3,10 @@
 module UI
   # # Hover Card
   #
-  # A rich, supplemental card revealed on hover **and** keyboard focus of its trigger.
-  # Unlike `tooltip`, the card may hold interactive content; `focus-within` keeps it
-  # open while the user Tabs through that content. Escape dismisses (WCAG 1.4.13).
+  # A rich, supplemental card revealed on hover **and** keyboard focus of its trigger,
+  # driven by the `floating` controller's hover-intent: a short close-delay lets the
+  # pointer cross the trigger→card gap so the card's interactive content stays
+  # reachable and clickable. Escape closes and returns focus to the trigger.
   #
   # ## Use when
   # - A link/avatar benefits from a supplemental preview (profile, definition) whose
@@ -16,8 +17,9 @@ module UI
   # - It's a short text hint — use `tooltip`.
   #
   # ## Accessibility contract
-  # - **Guarantees:** shows on hover AND focus-within (card content is Tab-reachable while
-  #   open); Escape dismisses; `role="group"` + `aria-label` when `label:` is given.
+  # - **Guarantees:** opens on hover AND focus; the hover-intent close-delay keeps the
+  #   card reachable, so its content is clickable and Tab-reachable; Escape closes and
+  #   returns focus to the trigger; `role="group"` + `aria-label` when `label:` is given.
   # - **You supply:** a `with_trigger` slot (a focusable link/button) and the card content.
   class HoverCardComponent < ApplicationComponent
     renders_one :trigger
@@ -25,9 +27,7 @@ module UI
     CARD_BASE = "absolute z-50 w-64 rounded-lg border border-border bg-surface-overlay p-4 text-sm " \
                 "text-text-body shadow-md " \
                 "invisible opacity-0 transition-opacity duration-200 " \
-                "group-hover:visible group-hover:opacity-100 " \
-                "group-focus-within:visible group-focus-within:opacity-100 " \
-                "group-data-[dismissed]:invisible! group-data-[dismissed]:opacity-0!"
+                "group-data-[state=open]:visible group-data-[state=open]:opacity-100"
 
     POSITIONS = {
       bottom: "top-full left-0 mt-2",
@@ -61,13 +61,19 @@ module UI
         class: cn("group relative inline-block", @extra_class),
         data: {
           controller: "floating",
-          action: "keydown.esc->floating#dismiss mouseleave->floating#clearDismissed focusout->floating#clearDismissed"
+          action: "mouseenter->floating#hoverOpen mouseleave->floating#hoverClose " \
+                   "focusin->floating#hoverOpen focusout->floating#hoverClose " \
+                   "keydown.esc->floating#hoverEscape"
         }
       }.merge(@html_attrs)
     end
 
     def card
-      attrs = { id: @id, class: cn(CARD_BASE, POSITIONS.fetch(@side)) }
+      attrs = {
+        id: @id,
+        data: { floating_target: "panel" },
+        class: cn(CARD_BASE, POSITIONS.fetch(@side))
+      }
       if @label
         attrs[:role] = "group"
         attrs["aria-label"] = @label

--- a/lib/generators/modelrails_ui/add/templates/hover_card/hover_card_component.rb.tt
+++ b/lib/generators/modelrails_ui/add/templates/hover_card/hover_card_component.rb.tt
@@ -24,16 +24,47 @@ module UI
   class HoverCardComponent < ApplicationComponent
     renders_one :trigger
 
-    CARD_BASE = "absolute z-50 w-64 rounded-lg border border-border bg-surface-overlay p-4 text-sm " \
+    CARD_BASE = "z-50 w-64 rounded-lg border border-border bg-surface-overlay p-4 text-sm " \
                 "text-text-body shadow-md " \
                 "invisible opacity-0 transition-opacity duration-200 " \
                 "group-data-[state=open]:visible group-data-[state=open]:opacity-100"
 
+    # Anchor positioning (modern, gated by `supports-`): `fixed` so the viewport is the
+    # containing block, `position-area` to place it, `position-try-fallbacks` to keep it on
+    # screen. Pre-Baseline fallback (`not-supports-`): `absolute` offsets vs the wrapper.
     POSITIONS = {
-      bottom: "top-full left-0 mt-2",
-      top:    "bottom-full left-0 mb-2",
-      left:   "right-full top-0 mr-2",
-      right:  "left-full top-0 ml-2"
+      bottom: "mt-2 " \
+              "supports-[position-area:bottom]:fixed " \
+              "supports-[position-area:bottom]:[position-area:bottom_center] " \
+              "supports-[position-area:bottom]:[position-try-fallbacks:flip-block] " \
+              "not-supports-[position-area:bottom]:absolute " \
+              "not-supports-[position-area:bottom]:top-full " \
+              "not-supports-[position-area:bottom]:left-1/2 " \
+              "not-supports-[position-area:bottom]:-translate-x-1/2",
+      top:    "mb-2 " \
+              "supports-[position-area:bottom]:fixed " \
+              "supports-[position-area:bottom]:[position-area:top_center] " \
+              "supports-[position-area:bottom]:[position-try-fallbacks:flip-block] " \
+              "not-supports-[position-area:bottom]:absolute " \
+              "not-supports-[position-area:bottom]:bottom-full " \
+              "not-supports-[position-area:bottom]:left-1/2 " \
+              "not-supports-[position-area:bottom]:-translate-x-1/2",
+      left:   "mr-2 " \
+              "supports-[position-area:bottom]:fixed " \
+              "supports-[position-area:bottom]:[position-area:center_left] " \
+              "supports-[position-area:bottom]:[position-try-fallbacks:flip-inline] " \
+              "not-supports-[position-area:bottom]:absolute " \
+              "not-supports-[position-area:bottom]:right-full " \
+              "not-supports-[position-area:bottom]:top-1/2 " \
+              "not-supports-[position-area:bottom]:-translate-y-1/2",
+      right:  "ml-2 " \
+              "supports-[position-area:bottom]:fixed " \
+              "supports-[position-area:bottom]:[position-area:center_right] " \
+              "supports-[position-area:bottom]:[position-try-fallbacks:flip-inline] " \
+              "not-supports-[position-area:bottom]:absolute " \
+              "not-supports-[position-area:bottom]:left-full " \
+              "not-supports-[position-area:bottom]:top-1/2 " \
+              "not-supports-[position-area:bottom]:-translate-y-1/2"
     }.freeze
 
     # id: card id; label: optional accessible name (→ role=group + aria-label);
@@ -59,6 +90,7 @@ module UI
     def wrapper_attrs
       {
         class: cn("group relative inline-block", @extra_class),
+        style: "anchor-name: --#{@id}",
         data: {
           controller: "floating",
           action: "mouseenter->floating#hoverOpen mouseleave->floating#hoverClose " \
@@ -71,6 +103,7 @@ module UI
     def card
       attrs = {
         id: @id,
+        style: "position-anchor: --#{@id}",
         data: { floating_target: "panel" },
         class: cn(CARD_BASE, POSITIONS.fetch(@side))
       }

--- a/lib/generators/modelrails_ui/add/templates/popover/floating_controller.js
+++ b/lib/generators/modelrails_ui/add/templates/popover/floating_controller.js
@@ -34,4 +34,16 @@ export default class extends Controller {
   closeOnClickOutside(event) {
     if (this.openValue && !this.element.contains(event.target)) this.close()
   }
+
+  // Hover/focus components (tooltip, hover_card) are CSS-shown; this is the only
+  // thing CSS can't do — dismiss-while-hovered (WCAG 1.4.13). Escape sets
+  // data-dismissed (CSS force-hides via group-data-[dismissed]); mouseleave/
+  // focusout clear it so the next hover/focus shows it again.
+  dismiss() {
+    this.element.setAttribute("data-dismissed", "")
+  }
+
+  clearDismissed() {
+    this.element.removeAttribute("data-dismissed")
+  }
 }

--- a/lib/generators/modelrails_ui/add/templates/popover/floating_controller.js
+++ b/lib/generators/modelrails_ui/add/templates/popover/floating_controller.js
@@ -5,10 +5,20 @@ import { Controller } from "@hotwired/stimulus"
 // focus return, and Escape / outside-click dismissal. No focus trap (Tab may leave).
 export default class extends Controller {
   static targets = ["trigger", "panel"]
-  static values = { open: { type: Boolean, default: false } }
+  static values = {
+    open: { type: Boolean, default: false },
+    hideDelay: { type: Number, default: 150 }
+  }
 
   connect() {
     if (this.openValue) this.open()
+  }
+
+  disconnect() {
+    if (this.hideTimer) {
+      clearTimeout(this.hideTimer)
+      this.hideTimer = null
+    }
   }
 
   toggle() {
@@ -35,15 +45,52 @@ export default class extends Controller {
     if (this.openValue && !this.element.contains(event.target)) this.close()
   }
 
-  // Hover/focus components (tooltip, hover_card) are CSS-shown; this is the only
-  // thing CSS can't do — dismiss-while-hovered (WCAG 1.4.13). Escape sets
-  // data-dismissed (CSS force-hides via group-data-[dismissed]); mouseleave/
-  // focusout clear it so the next hover/focus shows it again.
+  // Tooltip (CSS-shown) dismissal — the one thing CSS can't do: dismiss-while-hovered
+  // (WCAG 1.4.13). Escape sets data-dismissed (CSS force-hides via group-data-[dismissed]);
+  // mouseleave/focusout clear it so the next hover/focus shows it again.
   dismiss() {
     this.element.setAttribute("data-dismissed", "")
   }
 
   clearDismissed() {
     this.element.removeAttribute("data-dismissed")
+  }
+
+  // Hover-intent for hover_card (interactive content): open on enter/focus, close on
+  // leave/blur AFTER a short delay so the pointer can cross the trigger→card gap (and
+  // brief mouse-outs) without the card vanishing — what CSS :hover can't do. Escape
+  // closes now and returns focus to the trigger.
+  hoverOpen() {
+    if (this.escaping) return
+    if (this.hideTimer) {
+      clearTimeout(this.hideTimer)
+      this.hideTimer = null
+    }
+    this.element.dataset.state = "open"
+  }
+
+  hoverClose() {
+    this.hideTimer = setTimeout(() => {
+      this.element.dataset.state = "closed"
+      this.hideTimer = null
+    }, this.hideDelayValue)
+  }
+
+  hoverEscape() {
+    if (this.hideTimer) {
+      clearTimeout(this.hideTimer)
+      this.hideTimer = null
+    }
+    this.element.dataset.state = "closed"
+    if (this.hasPanelTarget) {
+      const focusable = "a[href], button, input, select, textarea, [tabindex]:not([tabindex='-1'])"
+      const trigger = Array.from(this.element.querySelectorAll(focusable))
+        .find((el) => !this.panelTarget.contains(el))
+      // Returning focus to the trigger fires focusin->hoverOpen synchronously; this
+      // one-tick guard stops that from re-opening the card we just closed.
+      this.escaping = true
+      trigger?.focus()
+      this.escaping = false
+    }
   }
 }

--- a/lib/generators/modelrails_ui/add/templates/tooltip/tooltip_component.rb.tt
+++ b/lib/generators/modelrails_ui/add/templates/tooltip/tooltip_component.rb.tt
@@ -1,11 +1,32 @@
 # frozen_string_literal: true
 
 module UI
+  # # Tooltip
+  #
+  # A small text bubble describing the element it wraps. Shows on hover **and**
+  # keyboard focus; the wrapper is focusable and `aria-describedby` wires the bubble
+  # to it. Escape dismisses (WCAG 1.4.13) via the shared `floating` controller.
+  #
+  # ## Use when
+  # - You need a short, non-interactive hint describing a single focusable trigger
+  #   (an icon button, a truncated label).
+  #
+  # ## Don't use when
+  # - The content is interactive or rich — use `hover_card`.
+  # - You wrap an already-interactive control — put `aria-describedby` on that control
+  #   instead (this component makes its own wrapper the focusable trigger).
+  #
+  # ## Accessibility contract
+  # - **Guarantees:** shows on hover AND focus; `role="tooltip"` bubble wired via
+  #   `aria-describedby`; Escape dismisses without moving focus; `pointer-events-none`
+  #   so the bubble never traps the pointer.
+  # - **You supply:** `text:` (the hint) and the trigger content (icon/word).
   class TooltipComponent < ApplicationComponent
-    BUBBLE_BASE = "absolute z-50 w-fit rounded-md px-3 py-1.5 text-xs text-balance " \
-                  "bg-text-heading text-surface-raised " \
-                  "opacity-0 group-hover:opacity-100 pointer-events-none whitespace-nowrap " \
-                  "transition-opacity duration-200"
+    BUBBLE_BASE = "absolute z-50 w-max max-w-xs rounded-md px-3 py-1.5 text-xs text-balance " \
+                  "bg-text-heading text-surface-raised whitespace-normal " \
+                  "pointer-events-none opacity-0 transition-opacity duration-200 " \
+                  "group-hover:opacity-100 group-focus-within:opacity-100 " \
+                  "group-data-[dismissed]:opacity-0!"
 
     POSITIONS = {
       top:    "bottom-full left-1/2 -translate-x-1/2 mb-2",
@@ -14,29 +35,45 @@ module UI
       right:  "left-full top-1/2 -translate-y-1/2 ml-2"
     }.freeze
 
-    def initialize(text:, side: :top, **html_attrs)
+    # text: the hint (the bubble's content); id: bubble id (→ aria-describedby);
+    # side: :top | :bottom | :left | :right
+    def initialize(text:, id: nil, side: :top, **html_attrs)
       @text        = text
-      @side        = side.to_sym
+      @id          = id || "tooltip-#{SecureRandom.hex(4)}"
+      @side        = coerce_enum(:side, side, POSITIONS)
       @extra_class = html_attrs.delete(:class)
       @html_attrs  = html_attrs
     end
 
     def call
-      content_tag(:span,
-        class: cn("relative inline-flex group", @extra_class),
-        **@html_attrs) do
-        concat content
-        concat tooltip_bubble
+      content_tag(:span, **wrapper_attrs) do
+        safe_join([content, bubble])
       end
     end
 
     private
 
-    def tooltip_bubble
-      content_tag(:span,
-        @text,
-        class: cn(BUBBLE_BASE, POSITIONS.fetch(@side, POSITIONS[:top])),
-        role: "tooltip")
+    def wrapper_attrs
+      {
+        class: cn("group relative inline-flex", @extra_class),
+        tabindex: "0",
+        "aria-describedby": @id,
+        data: {
+          controller: "floating",
+          action: "keydown.esc->floating#dismiss mouseleave->floating#clearDismissed focusout->floating#clearDismissed"
+        }
+      }.merge(@html_attrs)
+    end
+
+    def bubble
+      content_tag(:span, @text, id: @id, role: "tooltip", class: cn(BUBBLE_BASE, POSITIONS.fetch(@side)))
+    end
+
+    def coerce_enum(name, value, map)
+      key = value.to_sym
+      return key if map.key?(key)
+
+      raise ArgumentError, "UI::Tooltip unknown #{name}: #{value.inspect} (allowed: #{map.keys.join(", ")})"
     end
   end
 end

--- a/lib/generators/modelrails_ui/add/templates/tooltip/tooltip_component.rb.tt
+++ b/lib/generators/modelrails_ui/add/templates/tooltip/tooltip_component.rb.tt
@@ -7,6 +7,12 @@ module UI
   # keyboard focus; the wrapper is focusable and `aria-describedby` wires the bubble
   # to it. Escape dismisses (WCAG 1.4.13) via the shared `floating` controller.
   #
+  # Placement uses CSS anchor positioning: the bubble is `position: fixed` (so its
+  # containing block is the viewport, letting it float free of the wrapper) and tethered
+  # to the wrapper via `anchor-name`/`position-anchor`; `position-area` places it and
+  # `position-try-fallbacks` auto-flips it on viewport overflow — no JS. On browsers
+  # without anchor positioning (pre-Baseline 2026) it falls back to `absolute` offsets.
+  #
   # ## Use when
   # - You need a short, non-interactive hint describing a single focusable trigger
   #   (an icon button, a truncated label).
@@ -22,20 +28,52 @@ module UI
   #   so the bubble never traps the pointer.
   # - **You supply:** `text:` (the hint) and the trigger content (icon/word).
   class TooltipComponent < ApplicationComponent
-    BUBBLE_BASE = "absolute z-50 w-max max-w-xs rounded-md px-3 py-1.5 text-xs text-balance " \
+    BUBBLE_BASE = "z-50 w-max max-w-xs rounded-md px-3 py-1.5 text-xs text-balance " \
                   "bg-text-heading text-surface-raised whitespace-normal " \
                   "pointer-events-none opacity-0 transition-opacity duration-200 " \
                   "group-hover:opacity-100 group-focus-within:opacity-100 " \
                   "group-data-[dismissed]:opacity-0!"
 
+    # Each side carries: an always-on gap margin; the modern anchor-positioning path
+    # (gated behind `supports-[position-area]`) — `fixed` so the viewport is the containing
+    # block, `position-area` to place it, `position-try-fallbacks` to auto-flip on overflow;
+    # and the pre-Baseline fallback (`not-supports-`) — `absolute` offsets vs the wrapper.
     POSITIONS = {
-      top:    "bottom-full left-1/2 -translate-x-1/2 mb-2",
-      bottom: "top-full left-1/2 -translate-x-1/2 mt-2",
-      left:   "right-full top-1/2 -translate-y-1/2 mr-2",
-      right:  "left-full top-1/2 -translate-y-1/2 ml-2"
+      top:    "mb-2 " \
+              "supports-[position-area:bottom]:fixed " \
+              "supports-[position-area:bottom]:[position-area:top_center] " \
+              "supports-[position-area:bottom]:[position-try-fallbacks:flip-block] " \
+              "not-supports-[position-area:bottom]:absolute " \
+              "not-supports-[position-area:bottom]:bottom-full " \
+              "not-supports-[position-area:bottom]:left-1/2 " \
+              "not-supports-[position-area:bottom]:-translate-x-1/2",
+      bottom: "mt-2 " \
+              "supports-[position-area:bottom]:fixed " \
+              "supports-[position-area:bottom]:[position-area:bottom_center] " \
+              "supports-[position-area:bottom]:[position-try-fallbacks:flip-block] " \
+              "not-supports-[position-area:bottom]:absolute " \
+              "not-supports-[position-area:bottom]:top-full " \
+              "not-supports-[position-area:bottom]:left-1/2 " \
+              "not-supports-[position-area:bottom]:-translate-x-1/2",
+      left:   "mr-2 " \
+              "supports-[position-area:bottom]:fixed " \
+              "supports-[position-area:bottom]:[position-area:center_left] " \
+              "supports-[position-area:bottom]:[position-try-fallbacks:flip-inline] " \
+              "not-supports-[position-area:bottom]:absolute " \
+              "not-supports-[position-area:bottom]:right-full " \
+              "not-supports-[position-area:bottom]:top-1/2 " \
+              "not-supports-[position-area:bottom]:-translate-y-1/2",
+      right:  "ml-2 " \
+              "supports-[position-area:bottom]:fixed " \
+              "supports-[position-area:bottom]:[position-area:center_right] " \
+              "supports-[position-area:bottom]:[position-try-fallbacks:flip-inline] " \
+              "not-supports-[position-area:bottom]:absolute " \
+              "not-supports-[position-area:bottom]:left-full " \
+              "not-supports-[position-area:bottom]:top-1/2 " \
+              "not-supports-[position-area:bottom]:-translate-y-1/2"
     }.freeze
 
-    # text: the hint (the bubble's content); id: bubble id (→ aria-describedby);
+    # text: the hint (the bubble's content); id: bubble id (→ aria-describedby + anchor);
     # side: :top | :bottom | :left | :right
     def initialize(text:, id: nil, side: :top, **html_attrs)
       @text        = text
@@ -56,6 +94,7 @@ module UI
     def wrapper_attrs
       {
         class: cn("group relative inline-flex", @extra_class),
+        style: "anchor-name: --#{@id}",
         tabindex: "0",
         "aria-describedby": @id,
         data: {
@@ -66,7 +105,11 @@ module UI
     end
 
     def bubble
-      content_tag(:span, @text, id: @id, role: "tooltip", class: cn(BUBBLE_BASE, POSITIONS.fetch(@side)))
+      content_tag(:span, @text,
+        id: @id,
+        role: "tooltip",
+        style: "position-anchor: --#{@id}",
+        class: cn(BUBBLE_BASE, POSITIONS.fetch(@side)))
     end
 
     def coerce_enum(name, value, map)

--- a/lib/generators/modelrails_ui/components.rb
+++ b/lib/generators/modelrails_ui/components.rb
@@ -9,7 +9,9 @@ module ModelrailsUi
       EXTRA_STIMULUS = {
         "alert_dialog" => {source: "dialog/modal_controller.js", name: "modal"},
         "drawer" => {source: "dialog/modal_controller.js", name: "modal"},
-        "sheet" => {source: "dialog/modal_controller.js", name: "modal"}
+        "sheet" => {source: "dialog/modal_controller.js", name: "modal"},
+        "tooltip" => {source: "popover/floating_controller.js", name: "floating"},
+        "hover_card" => {source: "popover/floating_controller.js", name: "floating"}
       }.freeze
 
       # Post-install instructions for components that require external dependencies.

--- a/lib/generators/modelrails_ui/lookbook/templates/previews/ui/hover_card_component_preview.rb
+++ b/lib/generators/modelrails_ui/lookbook/templates/previews/ui/hover_card_component_preview.rb
@@ -1,0 +1,31 @@
+# frozen_string_literal: true
+
+module UI
+  # # Hover Card
+  #
+  # A rich supplemental card revealed on hover AND keyboard focus of its trigger.
+  # `focus-within` keeps it open while you Tab through its content; Escape dismisses
+  # (WCAG 1.4.13). Use for enhancement, not as the only path to the content.
+  #
+  # ## Accessibility contract
+  # - **Guarantees:** hover + focus-within reveal; card content Tab-reachable while open;
+  #   Escape-dismiss; `role="group"` + `aria-label` when `label:` given.
+  # - **You supply:** a `with_trigger` slot (a focusable link/button) and card content.
+  class HoverCardComponentPreview < ViewComponent::Preview
+    include UIHelper
+
+    # Hover or focus the trigger to reveal the card; Tab through its links; Escape dismisses.
+    def basic
+    end
+
+    # Edit `side` and `label` live.
+    # @param label text
+    # @param side select [bottom, top, left, right]
+    def playground(label: "User card", side: :bottom)
+      ui(:hover_card, label: label, side: side.to_sym) do |c|
+        c.with_trigger { "@dave" }
+        "Profile preview content."
+      end
+    end
+  end
+end

--- a/lib/generators/modelrails_ui/lookbook/templates/previews/ui/hover_card_component_preview/basic.html.erb
+++ b/lib/generators/modelrails_ui/lookbook/templates/previews/ui/hover_card_component_preview/basic.html.erb
@@ -1,0 +1,12 @@
+<div class="p-24 flex justify-center">
+  <%= render(UI::HoverCardComponent.new) do |c| %>
+    <% c.with_trigger do %>
+      <a href="#" class="underline">@dave</a>
+    <% end %>
+    <div class="space-y-1">
+      <p class="font-medium text-text-heading">Dave Chmura</p>
+      <p class="text-text-body">Building modelrails_ui.</p>
+      <a href="#" class="text-text-body underline">View profile</a>
+    </div>
+  <% end %>
+</div>

--- a/lib/generators/modelrails_ui/lookbook/templates/previews/ui/tooltip_component_preview.rb
+++ b/lib/generators/modelrails_ui/lookbook/templates/previews/ui/tooltip_component_preview.rb
@@ -1,0 +1,28 @@
+# frozen_string_literal: true
+
+module UI
+  # # Tooltip
+  #
+  # A short text hint describing the element it wraps. Shows on hover AND keyboard
+  # focus; `aria-describedby` wires the `role="tooltip"` bubble to the focusable wrapper;
+  # Escape dismisses (WCAG 1.4.13) via the shared `floating` controller.
+  #
+  # ## Accessibility contract
+  # - **Guarantees:** hover + focus reveal; `role="tooltip"` + `aria-describedby`;
+  #   Escape-dismiss; `pointer-events-none` bubble.
+  # - **You supply:** `text:` (the hint) and the trigger content.
+  class TooltipComponentPreview < ViewComponent::Preview
+    include UIHelper
+
+    # Hover or keyboard-focus the trigger to reveal the hint; Escape dismisses it.
+    def basic
+    end
+
+    # Edit `text` and `side` live to explore placement.
+    # @param text text
+    # @param side select [top, bottom, left, right]
+    def playground(text: "Saved to your library", side: :top)
+      ui(:tooltip, text: text, side: side.to_sym) { "Hover or focus me" }
+    end
+  end
+end

--- a/lib/generators/modelrails_ui/lookbook/templates/previews/ui/tooltip_component_preview/basic.html.erb
+++ b/lib/generators/modelrails_ui/lookbook/templates/previews/ui/tooltip_component_preview/basic.html.erb
@@ -1,0 +1,5 @@
+<div class="p-24 flex justify-center">
+  <%= render(UI::TooltipComponent.new(text: "Saved to your library")) do %>
+    <span class="underline decoration-dotted">Hover or focus me</span>
+  <% end %>
+</div>

--- a/test/render/hover_card_render_test.rb
+++ b/test/render/hover_card_render_test.rb
@@ -4,6 +4,10 @@ require "render_test_helper"
 require "securerandom"
 load_component "hover_card", "hover_card_component.rb.tt"
 
+# STRUCTURE-only render specs. The hover-intent BEHAVIOR (open/close with delay across
+# the trigger→card gap, Escape + focus return) is proven by the app 0b browser spec —
+# the render harness cannot exercise JS, so here we assert the static scaffolding the
+# `floating` controller drives.
 class HoverCardRenderTest < ViewComponent::TestCase
   def render_card(**opts)
     render_inline(UI::HoverCardComponent.new(**opts)) do |c|
@@ -12,30 +16,28 @@ class HoverCardRenderTest < ViewComponent::TestCase
     end
   end
 
-  def test_wrapper_wires_floating_and_dismissal
+  def test_wrapper_wires_hover_intent_pointer_actions
     render_card
 
     assert_selector "span.group[data-controller='floating']" \
-                    "[data-action~='keydown.esc->floating#dismiss']" \
-                    "[data-action~='mouseleave->floating#clearDismissed']", visible: :all
+                    "[data-action~='mouseenter->floating#hoverOpen']" \
+                    "[data-action~='mouseleave->floating#hoverClose']", visible: :all
   end
 
-  def test_wrapper_wires_focusout
+  def test_wrapper_wires_focus_and_escape_actions
     render_card
 
-    assert_selector "span[data-action~='focusout->floating#clearDismissed']", visible: :all
+    assert_selector "span[data-action~='focusin->floating#hoverOpen']" \
+                    "[data-action~='focusout->floating#hoverClose']" \
+                    "[data-action~='keydown.esc->floating#hoverEscape']", visible: :all
   end
 
-  def test_card_shows_on_hover_and_focus_within
+  def test_card_is_the_panel_target_shown_by_open_state
     render_card
 
-    assert_selector "div.group-hover\\:visible.group-focus-within\\:visible", visible: :all
-  end
-
-  def test_card_force_hides_when_dismissed
-    render_card
-
-    assert_selector "div.group-data-\\[dismissed\\]\\:invisible\\!", visible: :all
+    assert_selector "div[data-floating-target='panel']",
+      class: ["invisible", "opacity-0", "group-data-[state=open]:visible", "group-data-[state=open]:opacity-100"],
+      visible: :all
   end
 
   def test_label_sets_role_group_and_aria_label

--- a/test/render/hover_card_render_test.rb
+++ b/test/render/hover_card_render_test.rb
@@ -1,0 +1,61 @@
+# frozen_string_literal: true
+
+require "render_test_helper"
+require "securerandom"
+load_component "hover_card", "hover_card_component.rb.tt"
+
+class HoverCardRenderTest < ViewComponent::TestCase
+  def render_card(**opts)
+    render_inline(UI::HoverCardComponent.new(**opts)) do |c|
+      c.with_trigger { "@dave" }
+      "Profile details"
+    end
+  end
+
+  def test_wrapper_wires_floating_and_dismissal
+    render_card
+
+    assert_selector "span.group[data-controller='floating']" \
+                    "[data-action~='keydown.esc->floating#dismiss']" \
+                    "[data-action~='mouseleave->floating#clearDismissed']", visible: :all
+  end
+
+  def test_wrapper_wires_focusout
+    render_card
+
+    assert_selector "span[data-action~='focusout->floating#clearDismissed']", visible: :all
+  end
+
+  def test_card_shows_on_hover_and_focus_within
+    render_card
+
+    assert_selector "div.group-hover\\:visible.group-focus-within\\:visible", visible: :all
+  end
+
+  def test_card_force_hides_when_dismissed
+    render_card
+
+    assert_selector "div.group-data-\\[dismissed\\]\\:invisible\\!", visible: :all
+  end
+
+  def test_label_sets_role_group_and_aria_label
+    render_card(label: "User card")
+
+    assert_selector "div[role='group'][aria-label='User card']", visible: :all
+  end
+
+  def test_omits_role_without_a_label
+    render_card
+
+    assert_no_selector "div[role='group']", visible: :all
+  end
+
+  def test_requires_a_trigger_slot
+    error = assert_raises(ArgumentError) { render_inline(UI::HoverCardComponent.new) }
+    assert_match(/with_trigger/, error.message)
+  end
+
+  def test_fail_loud_on_unknown_side
+    assert_raises(ArgumentError) { UI::HoverCardComponent.new(side: :diagonal) }
+  end
+end

--- a/test/render/tooltip_render_test.rb
+++ b/test/render/tooltip_render_test.rb
@@ -1,0 +1,44 @@
+# frozen_string_literal: true
+
+require "render_test_helper"
+require "securerandom"
+load_component "tooltip", "tooltip_component.rb.tt"
+
+class TooltipRenderTest < ViewComponent::TestCase
+  def render_tooltip(**opts)
+    render_inline(UI::TooltipComponent.new(text: "Saved", **opts)) { "Status" }
+  end
+
+  def test_wrapper_is_focusable_and_describes_the_bubble
+    render_tooltip(id: "t1")
+
+    assert_selector "span.group[tabindex='0'][aria-describedby='t1'][data-controller='floating']", visible: :all
+    assert_selector "span[data-action~='keydown.esc->floating#dismiss']", visible: :all
+    assert_selector "span[data-action~='mouseleave->floating#clearDismissed']", visible: :all
+  end
+
+  def test_wrapper_wires_focusout_to_clear_dismissed
+    render_tooltip(id: "t1")
+
+    assert_selector "span[data-action~='focusout->floating#clearDismissed']", visible: :all
+  end
+
+  def test_bubble_is_a_tooltip_role_with_the_referenced_id
+    render_tooltip(id: "t2", text: "Copied to clipboard")
+
+    assert_selector "span#t2[role='tooltip']", text: "Copied to clipboard", visible: :all
+  end
+
+  def test_bubble_shows_on_hover_and_focus_and_force_hides_when_dismissed
+    render_tooltip
+
+    assert_selector "[role='tooltip'].group-hover\\:opacity-100", visible: :all
+    assert_selector "[role='tooltip'].group-focus-within\\:opacity-100", visible: :all
+    assert_selector "[role='tooltip'].group-data-\\[dismissed\\]\\:opacity-0\\!", visible: :all
+  end
+
+  def test_fail_loud_on_unknown_side
+    error = assert_raises(ArgumentError) { UI::TooltipComponent.new(text: "x", side: :sideways) }
+    assert_match(/unknown side/, error.message)
+  end
+end


### PR DESCRIPTION
Wave 5b of the floating-overlays band: the hover/focus pair.

## Components

**tooltip** — shows on hover **and** keyboard focus (was hover-only); `role="tooltip"` wired via `aria-describedby`; Escape-dismiss (WCAG 1.4.13) via the shared `floating` controller's `dismiss`/`clearDismissed` + `group-data-[dismissed]:opacity-0!`.

**hover_card** — **JS hover-intent** (open on enter/focus, close after a 150ms delay) so the pointer can cross the trigger→card gap and click the card's interactive content (fixes the original 1.4.13 *hoverable* failure); `focus-within` keeps it open while Tabbing; Escape closes + returns focus (re-entrancy-guarded). Optional `role="group"` label.

## Positioning — CSS anchor positioning (now Baseline 2026)

Both place via `position: fixed` + `position-area` + `position-try-fallbacks` (auto keep-on-screen), tethered with inline `anchor-name`/`position-anchor`; gated behind `supports-[position-area]` with the old `absolute` offsets as the pre-Baseline `not-supports-` fallback. Zero runtime dependency; Tailwind v4 arbitrary properties compile it.

## Shared `floating` controller

Now multi-modal across the band: popover (click), tooltip (Escape-dismiss), hover_card (hover-intent). Shared via `EXTRA_STIMULUS`, never copied.

## Verification

- Gem suite green (render + structural + rubocop).
- **Extensively browser-verified** (Playwright/Chromium) across iterations: tooltip dismiss; hover_card reachability + click + keyboard + Escape; anchor placement (above/below, no overlap) + on-screen behavior. AAA 7:1 is proven by the companion app PR's 0b CI.

## Known follow-ups (separate PRs)

- Corner controls (`align` param → `position-area` span combos) for tooltip/hover_card.
- Playground preview centering (needs a `render_with_template` template-backed playground).
- popover anchor-positioning retrofit (12 side×align combos on already-shipped code).
- A note: at extreme viewport edges Chromium clamps on-screen rather than a full flip (the positioned element is nested in its trigger); a true flip would need a body-portal.

Design: `docs/design/2026-06-06-wave5-floating-overlays-design.md` · Plan: `…-wave5b-tooltip-hovercard-plan.md`