### PR TITLE
feat(tooltip,hover_card): playground centering + corner placements

### DIFF
--- a/lib/generators/modelrails_ui/add/templates/hover_card/hover_card_component.rb.tt
+++ b/lib/generators/modelrails_ui/add/templates/hover_card/hover_card_component.rb.tt
@@ -29,46 +29,26 @@ module UI
                 "invisible opacity-0 transition-opacity duration-200 " \
                 "group-data-[state=open]:visible group-data-[state=open]:opacity-100"
 
-    # Anchor positioning (modern, gated by `supports-`): `fixed` so the viewport is the
-    # containing block, `position-area` to place it, `position-try-fallbacks` to keep it on
-    # screen. Pre-Baseline fallback (`not-supports-`): `absolute` offsets vs the wrapper.
+    # Placement on the `position-area` grid — 4 edges + 4 corners. Each value carries the
+    # gap margin, the modern path (gated by `supports-[position-area]`: `fixed` + a
+    # `position-area` value + `position-try-fallbacks` to keep it on-screen), and the
+    # pre-Baseline `absolute` fallback offsets (`not-supports-`). A Tailwind class table —
+    # one line per placement keeps it scannable.
+    # rubocop:disable Layout/LineLength
     POSITIONS = {
-      bottom: "mt-2 " \
-              "supports-[position-area:bottom]:fixed " \
-              "supports-[position-area:bottom]:[position-area:bottom_center] " \
-              "supports-[position-area:bottom]:[position-try-fallbacks:flip-block] " \
-              "not-supports-[position-area:bottom]:absolute " \
-              "not-supports-[position-area:bottom]:top-full " \
-              "not-supports-[position-area:bottom]:left-1/2 " \
-              "not-supports-[position-area:bottom]:-translate-x-1/2",
-      top:    "mb-2 " \
-              "supports-[position-area:bottom]:fixed " \
-              "supports-[position-area:bottom]:[position-area:top_center] " \
-              "supports-[position-area:bottom]:[position-try-fallbacks:flip-block] " \
-              "not-supports-[position-area:bottom]:absolute " \
-              "not-supports-[position-area:bottom]:bottom-full " \
-              "not-supports-[position-area:bottom]:left-1/2 " \
-              "not-supports-[position-area:bottom]:-translate-x-1/2",
-      left:   "mr-2 " \
-              "supports-[position-area:bottom]:fixed " \
-              "supports-[position-area:bottom]:[position-area:center_left] " \
-              "supports-[position-area:bottom]:[position-try-fallbacks:flip-inline] " \
-              "not-supports-[position-area:bottom]:absolute " \
-              "not-supports-[position-area:bottom]:right-full " \
-              "not-supports-[position-area:bottom]:top-1/2 " \
-              "not-supports-[position-area:bottom]:-translate-y-1/2",
-      right:  "ml-2 " \
-              "supports-[position-area:bottom]:fixed " \
-              "supports-[position-area:bottom]:[position-area:center_right] " \
-              "supports-[position-area:bottom]:[position-try-fallbacks:flip-inline] " \
-              "not-supports-[position-area:bottom]:absolute " \
-              "not-supports-[position-area:bottom]:left-full " \
-              "not-supports-[position-area:bottom]:top-1/2 " \
-              "not-supports-[position-area:bottom]:-translate-y-1/2"
+      bottom:       "mt-2 supports-[position-area:bottom]:fixed supports-[position-area:bottom]:[position-area:bottom_center] supports-[position-area:bottom]:[position-try-fallbacks:flip-block] not-supports-[position-area:bottom]:absolute not-supports-[position-area:bottom]:top-full not-supports-[position-area:bottom]:left-1/2 not-supports-[position-area:bottom]:-translate-x-1/2",
+      top:          "mb-2 supports-[position-area:bottom]:fixed supports-[position-area:bottom]:[position-area:top_center] supports-[position-area:bottom]:[position-try-fallbacks:flip-block] not-supports-[position-area:bottom]:absolute not-supports-[position-area:bottom]:bottom-full not-supports-[position-area:bottom]:left-1/2 not-supports-[position-area:bottom]:-translate-x-1/2",
+      left:         "mr-2 supports-[position-area:bottom]:fixed supports-[position-area:bottom]:[position-area:center_left] supports-[position-area:bottom]:[position-try-fallbacks:flip-inline] not-supports-[position-area:bottom]:absolute not-supports-[position-area:bottom]:right-full not-supports-[position-area:bottom]:top-1/2 not-supports-[position-area:bottom]:-translate-y-1/2",
+      right:        "ml-2 supports-[position-area:bottom]:fixed supports-[position-area:bottom]:[position-area:center_right] supports-[position-area:bottom]:[position-try-fallbacks:flip-inline] not-supports-[position-area:bottom]:absolute not-supports-[position-area:bottom]:left-full not-supports-[position-area:bottom]:top-1/2 not-supports-[position-area:bottom]:-translate-y-1/2",
+      top_left:     "mb-2 supports-[position-area:bottom]:fixed supports-[position-area:bottom]:[position-area:top_left] supports-[position-area:bottom]:[position-try-fallbacks:flip-block] not-supports-[position-area:bottom]:absolute not-supports-[position-area:bottom]:bottom-full not-supports-[position-area:bottom]:left-0",
+      top_right:    "mb-2 supports-[position-area:bottom]:fixed supports-[position-area:bottom]:[position-area:top_right] supports-[position-area:bottom]:[position-try-fallbacks:flip-block] not-supports-[position-area:bottom]:absolute not-supports-[position-area:bottom]:bottom-full not-supports-[position-area:bottom]:right-0",
+      bottom_left:  "mt-2 supports-[position-area:bottom]:fixed supports-[position-area:bottom]:[position-area:bottom_left] supports-[position-area:bottom]:[position-try-fallbacks:flip-block] not-supports-[position-area:bottom]:absolute not-supports-[position-area:bottom]:top-full not-supports-[position-area:bottom]:left-0",
+      bottom_right: "mt-2 supports-[position-area:bottom]:fixed supports-[position-area:bottom]:[position-area:bottom_right] supports-[position-area:bottom]:[position-try-fallbacks:flip-block] not-supports-[position-area:bottom]:absolute not-supports-[position-area:bottom]:top-full not-supports-[position-area:bottom]:right-0"
     }.freeze
+    # rubocop:enable Layout/LineLength
 
     # id: card id; label: optional accessible name (→ role=group + aria-label);
-    # side: :bottom | :top | :left | :right
+    # side: edge :bottom | :top | :left | :right, or corner :top_left | :top_right | :bottom_left | :bottom_right
     def initialize(id: nil, label: nil, side: :bottom, **html_attrs)
       @id          = id || "hovercard-#{SecureRandom.hex(4)}"
       @label       = label

--- a/lib/generators/modelrails_ui/add/templates/tooltip/tooltip_component.rb.tt
+++ b/lib/generators/modelrails_ui/add/templates/tooltip/tooltip_component.rb.tt
@@ -34,47 +34,28 @@ module UI
                   "group-hover:opacity-100 group-focus-within:opacity-100 " \
                   "group-data-[dismissed]:opacity-0!"
 
-    # Each side carries: an always-on gap margin; the modern anchor-positioning path
-    # (gated behind `supports-[position-area]`) — `fixed` so the viewport is the containing
-    # block, `position-area` to place it, `position-try-fallbacks` to auto-flip on overflow;
-    # and the pre-Baseline fallback (`not-supports-`) — `absolute` offsets vs the wrapper.
+    # Placement on the `position-area` grid — 4 edges + 4 corners. Each value carries the
+    # gap margin, the modern path (gated by `supports-[position-area]`: `fixed` + a
+    # `position-area` value + `position-try-fallbacks` to keep it on-screen), and the
+    # pre-Baseline `absolute` fallback offsets (`not-supports-`). Corners fall back to a
+    # corner-aligned edge on browsers without anchor positioning. A Tailwind class table —
+    # one line per placement keeps it scannable.
+    # rubocop:disable Layout/LineLength
     POSITIONS = {
-      top:    "mb-2 " \
-              "supports-[position-area:bottom]:fixed " \
-              "supports-[position-area:bottom]:[position-area:top_center] " \
-              "supports-[position-area:bottom]:[position-try-fallbacks:flip-block] " \
-              "not-supports-[position-area:bottom]:absolute " \
-              "not-supports-[position-area:bottom]:bottom-full " \
-              "not-supports-[position-area:bottom]:left-1/2 " \
-              "not-supports-[position-area:bottom]:-translate-x-1/2",
-      bottom: "mt-2 " \
-              "supports-[position-area:bottom]:fixed " \
-              "supports-[position-area:bottom]:[position-area:bottom_center] " \
-              "supports-[position-area:bottom]:[position-try-fallbacks:flip-block] " \
-              "not-supports-[position-area:bottom]:absolute " \
-              "not-supports-[position-area:bottom]:top-full " \
-              "not-supports-[position-area:bottom]:left-1/2 " \
-              "not-supports-[position-area:bottom]:-translate-x-1/2",
-      left:   "mr-2 " \
-              "supports-[position-area:bottom]:fixed " \
-              "supports-[position-area:bottom]:[position-area:center_left] " \
-              "supports-[position-area:bottom]:[position-try-fallbacks:flip-inline] " \
-              "not-supports-[position-area:bottom]:absolute " \
-              "not-supports-[position-area:bottom]:right-full " \
-              "not-supports-[position-area:bottom]:top-1/2 " \
-              "not-supports-[position-area:bottom]:-translate-y-1/2",
-      right:  "ml-2 " \
-              "supports-[position-area:bottom]:fixed " \
-              "supports-[position-area:bottom]:[position-area:center_right] " \
-              "supports-[position-area:bottom]:[position-try-fallbacks:flip-inline] " \
-              "not-supports-[position-area:bottom]:absolute " \
-              "not-supports-[position-area:bottom]:left-full " \
-              "not-supports-[position-area:bottom]:top-1/2 " \
-              "not-supports-[position-area:bottom]:-translate-y-1/2"
+      top:          "mb-2 supports-[position-area:bottom]:fixed supports-[position-area:bottom]:[position-area:top_center] supports-[position-area:bottom]:[position-try-fallbacks:flip-block] not-supports-[position-area:bottom]:absolute not-supports-[position-area:bottom]:bottom-full not-supports-[position-area:bottom]:left-1/2 not-supports-[position-area:bottom]:-translate-x-1/2",
+      bottom:       "mt-2 supports-[position-area:bottom]:fixed supports-[position-area:bottom]:[position-area:bottom_center] supports-[position-area:bottom]:[position-try-fallbacks:flip-block] not-supports-[position-area:bottom]:absolute not-supports-[position-area:bottom]:top-full not-supports-[position-area:bottom]:left-1/2 not-supports-[position-area:bottom]:-translate-x-1/2",
+      left:         "mr-2 supports-[position-area:bottom]:fixed supports-[position-area:bottom]:[position-area:center_left] supports-[position-area:bottom]:[position-try-fallbacks:flip-inline] not-supports-[position-area:bottom]:absolute not-supports-[position-area:bottom]:right-full not-supports-[position-area:bottom]:top-1/2 not-supports-[position-area:bottom]:-translate-y-1/2",
+      right:        "ml-2 supports-[position-area:bottom]:fixed supports-[position-area:bottom]:[position-area:center_right] supports-[position-area:bottom]:[position-try-fallbacks:flip-inline] not-supports-[position-area:bottom]:absolute not-supports-[position-area:bottom]:left-full not-supports-[position-area:bottom]:top-1/2 not-supports-[position-area:bottom]:-translate-y-1/2",
+      top_left:     "mb-2 supports-[position-area:bottom]:fixed supports-[position-area:bottom]:[position-area:top_left] supports-[position-area:bottom]:[position-try-fallbacks:flip-block] not-supports-[position-area:bottom]:absolute not-supports-[position-area:bottom]:bottom-full not-supports-[position-area:bottom]:left-0",
+      top_right:    "mb-2 supports-[position-area:bottom]:fixed supports-[position-area:bottom]:[position-area:top_right] supports-[position-area:bottom]:[position-try-fallbacks:flip-block] not-supports-[position-area:bottom]:absolute not-supports-[position-area:bottom]:bottom-full not-supports-[position-area:bottom]:right-0",
+      bottom_left:  "mt-2 supports-[position-area:bottom]:fixed supports-[position-area:bottom]:[position-area:bottom_left] supports-[position-area:bottom]:[position-try-fallbacks:flip-block] not-supports-[position-area:bottom]:absolute not-supports-[position-area:bottom]:top-full not-supports-[position-area:bottom]:left-0",
+      bottom_right: "mt-2 supports-[position-area:bottom]:fixed supports-[position-area:bottom]:[position-area:bottom_right] supports-[position-area:bottom]:[position-try-fallbacks:flip-block] not-supports-[position-area:bottom]:absolute not-supports-[position-area:bottom]:top-full not-supports-[position-area:bottom]:right-0"
     }.freeze
+    # rubocop:enable Layout/LineLength
 
     # text: the hint (the bubble's content); id: bubble id (→ aria-describedby + anchor);
-    # side: :top | :bottom | :left | :right
+    # side: edge :top | :bottom | :left | :right, or corner :top_left | :top_right |
+    #       :bottom_left | :bottom_right
     def initialize(text:, id: nil, side: :top, **html_attrs)
       @text        = text
       @id          = id || "tooltip-#{SecureRandom.hex(4)}"

--- a/lib/generators/modelrails_ui/lookbook/templates/previews/ui/hover_card_component_preview.rb
+++ b/lib/generators/modelrails_ui/lookbook/templates/previews/ui/hover_card_component_preview.rb
@@ -20,7 +20,7 @@ module UI
 
     # Edit `side` and `label` live.
     # @param label text
-    # @param side select [bottom, top, left, right]
+    # @param side select [bottom, top, left, right, top_left, top_right, bottom_left, bottom_right]
     def playground(label: "User card", side: :bottom)
       render_with_template(locals: {label: label, side: side.to_sym})
     end

--- a/lib/generators/modelrails_ui/lookbook/templates/previews/ui/hover_card_component_preview.rb
+++ b/lib/generators/modelrails_ui/lookbook/templates/previews/ui/hover_card_component_preview.rb
@@ -22,10 +22,7 @@ module UI
     # @param label text
     # @param side select [bottom, top, left, right]
     def playground(label: "User card", side: :bottom)
-      ui(:hover_card, label: label, side: side.to_sym) do |c|
-        c.with_trigger { "@dave" }
-        "Profile preview content."
-      end
+      render_with_template(locals: {label: label, side: side.to_sym})
     end
   end
 end

--- a/lib/generators/modelrails_ui/lookbook/templates/previews/ui/hover_card_component_preview/playground.html.erb
+++ b/lib/generators/modelrails_ui/lookbook/templates/previews/ui/hover_card_component_preview/playground.html.erb
@@ -1,0 +1,6 @@
+<div class="flex min-h-64 items-center justify-center p-12">
+  <%= render(UI::HoverCardComponent.new(label: label, side: side)) do |c| %>
+    <% c.with_trigger { "@dave" } %>
+    Profile preview content.
+  <% end %>
+</div>

--- a/lib/generators/modelrails_ui/lookbook/templates/previews/ui/tooltip_component_preview.rb
+++ b/lib/generators/modelrails_ui/lookbook/templates/previews/ui/tooltip_component_preview.rb
@@ -20,7 +20,7 @@ module UI
 
     # Edit `text` and `side` live to explore placement.
     # @param text text
-    # @param side select [top, bottom, left, right]
+    # @param side select [top, bottom, left, right, top_left, top_right, bottom_left, bottom_right]
     def playground(text: "Saved to your library", side: :top)
       render_with_template(locals: {text: text, side: side.to_sym})
     end

--- a/lib/generators/modelrails_ui/lookbook/templates/previews/ui/tooltip_component_preview.rb
+++ b/lib/generators/modelrails_ui/lookbook/templates/previews/ui/tooltip_component_preview.rb
@@ -22,7 +22,7 @@ module UI
     # @param text text
     # @param side select [top, bottom, left, right]
     def playground(text: "Saved to your library", side: :top)
-      ui(:tooltip, text: text, side: side.to_sym) { "Hover or focus me" }
+      render_with_template(locals: {text: text, side: side.to_sym})
     end
   end
 end

--- a/lib/generators/modelrails_ui/lookbook/templates/previews/ui/tooltip_component_preview/playground.html.erb
+++ b/lib/generators/modelrails_ui/lookbook/templates/previews/ui/tooltip_component_preview/playground.html.erb
@@ -1,0 +1,5 @@
+<div class="flex min-h-64 items-center justify-center p-12">
+  <%= render(UI::TooltipComponent.new(text: text, side: side)) do %>
+    Hover or focus me
+  <% end %>
+</div>

--- a/test/render/hover_card_render_test.rb
+++ b/test/render/hover_card_render_test.rb
@@ -57,6 +57,13 @@ class HoverCardRenderTest < ViewComponent::TestCase
     assert_match(/with_trigger/, error.message)
   end
 
+  def test_corner_placement_maps_to_a_position_area_corner
+    render_card(side: :top_right)
+
+    assert_selector "[data-floating-target='panel']",
+      class: ["supports-[position-area:bottom]:[position-area:top_right]"], visible: :all
+  end
+
   def test_fail_loud_on_unknown_side
     assert_raises(ArgumentError) { UI::HoverCardComponent.new(side: :diagonal) }
   end

--- a/test/render/tooltip_render_test.rb
+++ b/test/render/tooltip_render_test.rb
@@ -37,6 +37,13 @@ class TooltipRenderTest < ViewComponent::TestCase
     assert_selector "[role='tooltip'].group-data-\\[dismissed\\]\\:opacity-0\\!", visible: :all
   end
 
+  def test_corner_placement_maps_to_a_position_area_corner
+    render_tooltip(side: :top_right)
+
+    assert_selector "[role='tooltip']",
+      class: ["supports-[position-area:bottom]:[position-area:top_right]"], visible: :all
+  end
+
   def test_fail_loud_on_unknown_side
     error = assert_raises(ArgumentError) { UI::TooltipComponent.new(text: "x", side: :sideways) }
     assert_match(/unknown side/, error.message)


### PR DESCRIPTION
Floating-band positioning polish (fast-follow to Wave 5b #21), addressing two playground/UX gaps.

## Corner placements

`side` on tooltip + hover_card now accepts 4 corners in addition to the 4 edges: `:top_left` / `:top_right` / `:bottom_left` / `:bottom_right`, mapping to CSS `position-area` corner tiles (`top right`, etc.). Non-breaking — the 4 edges are unchanged. Exposed in the `@param` playgrounds.

## Playground centering

The `@param` playgrounds now render via `render_with_template` (the param-driven preview pattern) wrapped in a centered container, so left/top/corner placements are actually visible in Lookbook (previously the trigger sat top-left and those placements rendered off-screen).

## Verification

- Gem suite green (render + structural + rubocop).
- Render tests assert `side: :top_right` → the `position-area: top right` class for both components.
- **Browser-verified (Playwright/Chromium):** the `top_right` corner computes `position-area: right top` and places the bubble above + right-aligned to the trigger's right edge; playgrounds render centered.

## Notes

- Corner fallbacks (pre-Baseline browsers without `position-area`) degrade to a corner-aligned `absolute` offset.
- The `POSITIONS` maps use a scoped `rubocop:disable Layout/LineLength` — they're Tailwind class lookup tables, one line per placement for scannability.