### PR TITLE
refactor(ui): focus ring → focus-ring outline across 21 proven components (convention B5)

### DIFF
--- a/lib/generators/modelrails_ui/add/templates/alert_dialog/alert_dialog_component.rb.tt
+++ b/lib/generators/modelrails_ui/add/templates/alert_dialog/alert_dialog_component.rb.tt
@@ -115,8 +115,7 @@ module UI
         type: "button",
         "aria-label": close_label,
         data: { action: "click->modal#close" },
-        class: "btn-touch-target rounded-md -m-2 hover:bg-surface-sunken text-text-muted hover:text-text-body " \
-               "focus:outline-none focus:ring-2 focus:ring-interactive-focus")
+        class: "btn-touch-target rounded-md -m-2 hover:bg-surface-sunken text-text-muted hover:text-text-body focus-ring")
     end
 
     def body

--- a/lib/generators/modelrails_ui/add/templates/badge/badge_component.rb.tt
+++ b/lib/generators/modelrails_ui/add/templates/badge/badge_component.rb.tt
@@ -32,7 +32,7 @@ module UI
     BASE = "inline-flex w-fit shrink-0 items-center justify-center gap-1 overflow-hidden rounded-full " \
            "border border-transparent px-2 py-0.5 text-xs font-medium whitespace-nowrap " \
            "transition-[color,box-shadow] " \
-           "focus-visible:border-border-focus focus-visible:ring-[3px] focus-visible:ring-interactive-focus " \
+           "focus-ring " \
            "aria-invalid:border-danger-border aria-invalid:ring-danger  " \
            "[&>svg]:pointer-events-none [&>svg]:size-3"
 
@@ -49,8 +49,7 @@ module UI
       info: "bg-info-surface text-info border-info-border [a&]:hover:bg-info-hover",
       success: "bg-success-surface text-success border-success-border [a&]:hover:bg-success-hover",
       warning: "bg-warning-surface text-warning border-warning-border [a&]:hover:bg-warning-hover",
-      danger: "bg-danger-surface text-danger border-danger-border focus-visible:ring-danger " \
-              "[a&]:hover:bg-danger-hover",
+      danger: "bg-danger-surface text-danger border-danger-border [a&]:hover:bg-danger-hover",
       outline: "border-border text-text-heading [a&]:hover:bg-surface-sunken [a&]:hover:text-text-heading",
       ghost: "[a&]:hover:bg-surface-sunken [a&]:hover:text-text-heading",
       link: "text-interactive underline-offset-4 [a&]:hover:underline"

--- a/lib/generators/modelrails_ui/add/templates/breadcrumb/breadcrumb_component.rb.tt
+++ b/lib/generators/modelrails_ui/add/templates/breadcrumb/breadcrumb_component.rb.tt
@@ -14,9 +14,9 @@ module UI
   # - **You supply:** `items:` (`[{ label:, href: }, …, { label: }]` — the LAST item, with no
   #   `href`, is the current page).
   class BreadcrumbComponent < ApplicationComponent
-    LINK = "rounded-sm text-text-muted transition-colors outline-none " \
+    LINK = "rounded-sm text-text-muted transition-colors " \
            "hover:text-text-heading " \
-           "focus-visible:ring-1 focus-visible:ring-interactive-focus focus-visible:text-text-heading"
+           "focus-ring focus-visible:text-text-heading"
     CURRENT = "font-medium text-text-heading"
 
     # items: [{ label:, href: }, ..., { label: }] — last item is the current page (no href).

--- a/lib/generators/modelrails_ui/add/templates/button/button_component.rb.tt
+++ b/lib/generators/modelrails_ui/add/templates/button/button_component.rb.tt
@@ -6,18 +6,18 @@ module UI
     # @layer components). Filled family (primary/secondary/danger) + text family
     # (text/text_interactive/text_danger). All AAA-tuned, aligned to --form-input-height.
     FILLED = "inline-flex items-center justify-center px-4 rounded-md font-medium cursor-pointer " \
-             "focus:outline-none focus:ring-2 focus:ring-offset-2 min-h-[var(--form-input-height)]"
+             "focus-ring min-h-[var(--form-input-height)]"
 
     TEXT = "inline-flex items-center justify-center px-2 min-h-[var(--form-input-height)] min-w-[var(--form-input-height)] " \
-           "font-medium underline rounded focus-visible:outline-none focus-visible:ring-2 hover:no-underline"
+           "font-medium underline rounded focus-ring hover:no-underline"
 
     VARIANTS = {
-      primary: "#{FILLED} bg-interactive hover:bg-interactive-hover text-text-on-interactive focus:ring-interactive-focus",
-      secondary: "#{FILLED} border border-border text-text-body hover:bg-surface-sunken focus:ring-interactive-focus",
-      danger: "#{FILLED} bg-danger hover:bg-danger/90 text-text-on-interactive focus:ring-danger",
-      text: "#{TEXT} text-interactive focus-visible:ring-interactive-focus",
-      text_interactive: "#{TEXT} text-interactive focus-visible:ring-interactive-focus",
-      text_danger: "#{TEXT} text-danger focus-visible:ring-danger"
+      primary: "#{FILLED} bg-interactive hover:bg-interactive-hover text-text-on-interactive",
+      secondary: "#{FILLED} border border-border text-text-body hover:bg-surface-sunken",
+      danger: "#{FILLED} bg-danger hover:bg-danger/90 text-text-on-interactive",
+      text: "#{TEXT} text-interactive",
+      text_interactive: "#{TEXT} text-interactive",
+      text_danger: "#{TEXT} text-danger"
     }.freeze
 
     # Optional size overrides (the app uses a single size keyed to --form-input-height,

--- a/lib/generators/modelrails_ui/add/templates/checkbox/checkbox_component.rb.tt
+++ b/lib/generators/modelrails_ui/add/templates/checkbox/checkbox_component.rb.tt
@@ -28,7 +28,7 @@ module UI
   # guard here — unlike the enum-driven components (alert, button).
   class CheckboxComponent < ApplicationComponent
     BASE = "peer size-4 shrink-0 rounded-[4px] border border-border-strong shadow-xs transition-shadow outline-none " \
-           "focus-visible:border-border-focus focus-visible:ring-[3px] focus-visible:ring-interactive-focus " \
+           "focus-ring " \
            "disabled:cursor-not-allowed disabled:opacity-50 " \
            "aria-invalid:border-danger-border aria-invalid:ring-danger  " \
            "checked:border-interactive checked:bg-interactive checked:text-text-on-interactive " \

--- a/lib/generators/modelrails_ui/add/templates/data_table/data_table_component.rb.tt
+++ b/lib/generators/modelrails_ui/add/templates/data_table/data_table_component.rb.tt
@@ -45,8 +45,7 @@ module UI
     # The sort trigger is a real <button>: focusable + Enter/Space-activatable
     # for free. It spans the cell (left-aligned) and fills the >=44px height.
     SORT_BTN   = "flex min-h-11 w-full items-center gap-1 -mx-4 px-4 text-left font-medium " \
-                 "cursor-pointer select-none hover:text-text-heading focus-visible:outline-none " \
-                 "focus-visible:ring-[3px] focus-visible:ring-interactive-focus transition-colors"
+                 "cursor-pointer select-none hover:text-text-heading focus-ring transition-colors"
     TR_CLS     = "border-t border-border transition-colors hover:bg-surface-sunken/30"
     TD_CLS     = "px-4 py-3 align-middle"
     FOOTER_CLS = "flex items-center justify-between border-t border-border bg-surface-raised px-4 py-3 " \
@@ -54,8 +53,7 @@ module UI
     # h-11 w-11 keeps the pager buttons at the AAA 44px target floor.
     PAGE_BTN   = "inline-flex h-11 w-11 items-center justify-center rounded-md border border-border " \
                  "hover:bg-surface-sunken hover:text-text-heading disabled:pointer-events-none " \
-                 "disabled:opacity-40 focus-visible:outline-none focus-visible:ring-[3px] " \
-                 "focus-visible:ring-interactive-focus transition"
+                 "disabled:opacity-40 focus-ring transition"
     SORT_ASC   = "▲"
     SORT_DESC  = "▼"
 

--- a/lib/generators/modelrails_ui/add/templates/dialog/dialog_component.rb.tt
+++ b/lib/generators/modelrails_ui/add/templates/dialog/dialog_component.rb.tt
@@ -118,8 +118,7 @@ module UI
         type: "button",
         "aria-label": close_label,
         data: { action: "click->modal#close" },
-        class: "btn-touch-target rounded-md -m-2 hover:bg-surface-sunken text-text-muted hover:text-text-body " \
-               "focus:outline-none focus:ring-2 focus:ring-interactive-focus")
+        class: "btn-touch-target rounded-md -m-2 hover:bg-surface-sunken text-text-muted hover:text-text-body focus-ring")
     end
 
     def body

--- a/lib/generators/modelrails_ui/add/templates/drawer/drawer_component.rb.tt
+++ b/lib/generators/modelrails_ui/add/templates/drawer/drawer_component.rb.tt
@@ -125,8 +125,7 @@ module UI
         type: "button",
         "aria-label": close_label,
         data: { action: "click->modal#close" },
-        class: "btn-touch-target rounded-md -m-2 hover:bg-surface-sunken text-text-muted hover:text-text-body " \
-               "focus:outline-none focus:ring-2 focus:ring-interactive-focus")
+        class: "btn-touch-target rounded-md -m-2 hover:bg-surface-sunken text-text-muted hover:text-text-body focus-ring")
     end
 
     def body

--- a/lib/generators/modelrails_ui/add/templates/floating_label/floating_label_component.rb.tt
+++ b/lib/generators/modelrails_ui/add/templates/floating_label/floating_label_component.rb.tt
@@ -8,7 +8,7 @@ module UI
     # then rises above when the input is focused or has a value (:not(:placeholder-shown)).
     INPUT_BASE = "peer h-12 w-full min-w-0 rounded-md border border-border-strong bg-transparent px-3 pb-1.5 pt-4 " \
                  "text-base shadow-xs transition-[color,box-shadow] outline-none placeholder:text-transparent " \
-                 "focus-visible:border-border-focus focus-visible:ring-[3px] focus-visible:ring-interactive-focus " \
+                 "focus-ring " \
                  "aria-invalid:border-danger-border aria-invalid:ring-danger  " \
                  "disabled:pointer-events-none disabled:cursor-not-allowed disabled:opacity-50 " \
                  "md:text-sm "

--- a/lib/generators/modelrails_ui/add/templates/input/input_component.rb.tt
+++ b/lib/generators/modelrails_ui/add/templates/input/input_component.rb.tt
@@ -6,10 +6,10 @@ module UI
     # so swapping the builder to render this component is visually invisible.
     # (FIELD_BASE / FIELD_NORMAL / FIELD_ERROR in app/form_builders/tailwind_form_builder.rb)
     BASE   = "block w-full rounded-md border px-3 py-2 placeholder:text-text-muted " \
-             "focus:outline-none focus:ring-2 min-h-[var(--form-input-height)]"
-    NORMAL = "border-border-strong bg-surface-raised text-text-heading focus:ring-interactive-focus " \
+             "focus-ring min-h-[var(--form-input-height)]"
+    NORMAL = "border-border-strong bg-surface-raised text-text-heading " \
              "disabled:cursor-not-allowed disabled:opacity-50"
-    ERROR  = "border-danger ring-2 ring-danger bg-danger-surface text-danger focus:ring-danger"
+    ERROR  = "border-danger ring-2 ring-danger bg-danger-surface text-danger"
 
     # First-class accessibility/form params so the component is usable standalone
     # AND drivable by the form builder:

--- a/lib/generators/modelrails_ui/add/templates/number_input/number_input_component.rb.tt
+++ b/lib/generators/modelrails_ui/add/templates/number_input/number_input_component.rb.tt
@@ -43,7 +43,7 @@ module UI
            "min-h-[var(--form-input-height)] " \
            "transition-[color,box-shadow] outline-none " \
            "placeholder:text-text-muted " \
-           "focus-visible:border-border-focus focus-visible:ring-[3px] focus-visible:ring-interactive-focus " \
+           "focus-visible:border-border-focus focus-ring " \
            "aria-invalid:border-danger-border aria-invalid:ring-danger " \
            "disabled:pointer-events-none disabled:cursor-not-allowed disabled:opacity-50 " \
            "[appearance:textfield] [&::-webkit-inner-spin-button]:appearance-none [&::-webkit-outer-spin-button]:appearance-none " \

--- a/lib/generators/modelrails_ui/add/templates/radio_group/radio_group_component.rb.tt
+++ b/lib/generators/modelrails_ui/add/templates/radio_group/radio_group_component.rb.tt
@@ -82,7 +82,7 @@ module UI
     def radio_input(item, id)
       attrs = { type: "radio", name: @name, value: item[:value], id: id,
                 class: "h-4 w-4 border border-interactive text-interactive accent-interactive " \
-                       "focus-visible:outline-none focus-visible:border-border-focus focus-visible:ring-[3px] focus-visible:ring-interactive-focus " \
+                       "focus-ring " \
                        "disabled:cursor-not-allowed disabled:opacity-50" }
       attrs[:checked] = true if item[:checked]
       attrs[:disabled] = true if item[:disabled]

--- a/lib/generators/modelrails_ui/add/templates/range/range_component.rb.tt
+++ b/lib/generators/modelrails_ui/add/templates/range/range_component.rb.tt
@@ -38,7 +38,7 @@ module UI
   class RangeComponent < ApplicationComponent
     BASE = "w-full cursor-pointer appearance-none rounded-full bg-surface-sunken outline-none " \
            "h-2 accent-interactive " \
-           "focus-visible:outline-none focus-visible:ring-[3px] focus-visible:ring-interactive-focus " \
+           "focus-ring " \
            "aria-invalid:ring-danger " \
            "disabled:pointer-events-none disabled:opacity-50 " \
            "[&::-webkit-slider-thumb]:size-4 [&::-webkit-slider-thumb]:appearance-none " \

--- a/lib/generators/modelrails_ui/add/templates/rating_input/rating_input_component.rb.tt
+++ b/lib/generators/modelrails_ui/add/templates/rating_input/rating_input_component.rb.tt
@@ -99,7 +99,7 @@ module UI
         # graphic contrast in a real browser.
         class: cn(
           "min-h-11 min-w-11 inline-flex items-center justify-center",
-          "transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-interactive-focus rounded-sm",
+          "transition-colors focus-ring rounded-sm",
           filled ? "text-warning-icon" : "text-text-muted"
         ),
         data: {

--- a/lib/generators/modelrails_ui/add/templates/search_input/search_input_component.rb.tt
+++ b/lib/generators/modelrails_ui/add/templates/search_input/search_input_component.rb.tt
@@ -39,7 +39,7 @@ module UI
     INPUT_BASE = "h-11 w-full min-w-0 rounded-md border border-border-strong bg-surface-raised py-1 pl-9 pr-3 text-base text-text-heading shadow-xs " \
                  "transition-[color,box-shadow] outline-none " \
                  "placeholder:text-text-muted " \
-                 "focus-visible:border-border-focus focus-visible:ring-[3px] focus-visible:ring-interactive-focus " \
+                 "focus-visible:border-border-focus focus-ring " \
                  "aria-invalid:border-danger-border aria-invalid:ring-danger " \
                  "disabled:pointer-events-none disabled:cursor-not-allowed disabled:opacity-50 " \
                  "md:text-sm "

--- a/lib/generators/modelrails_ui/add/templates/select/select_component.rb.tt
+++ b/lib/generators/modelrails_ui/add/templates/select/select_component.rb.tt
@@ -26,7 +26,7 @@ module UI
   # No fail-loud guard — there's no enum axis to validate.
   class SelectComponent < ApplicationComponent
     BASE = "flex min-h-[var(--form-input-height)] w-full rounded-md border border-border-strong bg-transparent px-3 py-1 text-sm shadow-sm " \
-           "outline-none focus-visible:border-border-focus focus-visible:ring-[3px] focus-visible:ring-interactive-focus " \
+           "outline-none focus-visible:border-border-focus focus-ring " \
            "aria-invalid:border-danger-border aria-invalid:ring-danger " \
            "disabled:cursor-not-allowed disabled:opacity-50"
 

--- a/lib/generators/modelrails_ui/add/templates/sheet/sheet_component.rb.tt
+++ b/lib/generators/modelrails_ui/add/templates/sheet/sheet_component.rb.tt
@@ -139,8 +139,7 @@ module UI
         type: "button",
         "aria-label": close_label,
         data: { action: "click->modal#close" },
-        class: "btn-touch-target rounded-md -m-2 hover:bg-surface-sunken text-text-muted hover:text-text-body " \
-               "focus:outline-none focus:ring-2 focus:ring-interactive-focus")
+        class: "btn-touch-target rounded-md -m-2 hover:bg-surface-sunken text-text-muted hover:text-text-body focus-ring")
     end
 
     def body

--- a/lib/generators/modelrails_ui/add/templates/switch/switch_component.rb.tt
+++ b/lib/generators/modelrails_ui/add/templates/switch/switch_component.rb.tt
@@ -38,9 +38,14 @@ module UI
     # inside it so the input is the `peer` and TRACK/THUMB are its LATER SIBLINGS —
     # the only DOM order in which Tailwind peer-* (`.peer:checked ~ .x`) matches.
     WRAPPER = "relative inline-flex h-[1.15rem] w-8 shrink-0"
+    # Focus is the peer-projected EXCEPTION to the `focus-ring` utility: the real input is
+    # `sr-only`, so the AAA outline must render on the TRACK when the peer is focus-visible.
+    # `focus-ring` bakes `:focus-visible` into its own selector and can't be peer-projected,
+    # so we emit the same `outline: 2px solid var(--color-interactive-focus)` via an arbitrary
+    # property under `peer-focus-visible:` (a utility class here would be a phantom — no CSS).
     TRACK   = "pointer-events-none absolute inset-0 rounded-full border border-transparent shadow-xs " \
               "transition-all bg-surface-sunken peer-checked:bg-interactive " \
-              "peer-focus-visible:border-border-focus peer-focus-visible:ring-[3px] peer-focus-visible:ring-interactive-focus " \
+              "peer-focus-visible:[outline:2px_solid_var(--color-interactive-focus)] peer-focus-visible:[outline-offset:2px] " \
               "peer-aria-invalid:ring-2 peer-aria-invalid:ring-danger " \
               "peer-disabled:opacity-50"
     THUMB   = "pointer-events-none absolute inset-y-0 left-px my-auto z-10 block size-4 rounded-full " \

--- a/lib/generators/modelrails_ui/add/templates/tabs/tabs_component.rb.tt
+++ b/lib/generators/modelrails_ui/add/templates/tabs/tabs_component.rb.tt
@@ -24,9 +24,9 @@ module UI
 
     TABLIST = "inline-flex h-9 items-center justify-center rounded-lg bg-surface-sunken p-1 text-text-muted"
     # rubocop:disable Layout/LineLength
-    TRIGGER = "inline-flex items-center justify-center whitespace-nowrap rounded-md px-3 py-1 text-sm font-medium transition-all outline-none focus-visible:ring-1 focus-visible:ring-interactive-focus aria-disabled:pointer-events-none aria-disabled:opacity-50 data-[state=active]:bg-surface-raised data-[state=active]:text-text-heading data-[state=active]:shadow"
+    TRIGGER = "inline-flex items-center justify-center whitespace-nowrap rounded-md px-3 py-1 text-sm font-medium transition-all focus-ring aria-disabled:pointer-events-none aria-disabled:opacity-50 data-[state=active]:bg-surface-raised data-[state=active]:text-text-heading data-[state=active]:shadow"
     # rubocop:enable Layout/LineLength
-    PANEL = "mt-2 outline-none focus-visible:ring-1 focus-visible:ring-interactive-focus"
+    PANEL = "mt-2 focus-ring"
 
     # label:    accessible name for the tablist (aria-label; required; i18n at the call site).
     # selected: index of the initially-active tab (default 0).

--- a/lib/generators/modelrails_ui/add/templates/textarea/textarea_component.rb.tt
+++ b/lib/generators/modelrails_ui/add/templates/textarea/textarea_component.rb.tt
@@ -5,10 +5,10 @@ module UI
     # Styling matches the host app's TailwindFormBuilder field constants (shared
     # with UI::InputComponent) so the builder can delegate to it invisibly.
     BASE   = "block w-full rounded-md border px-3 py-2 placeholder:text-text-muted " \
-             "focus:outline-none focus:ring-2 min-h-[var(--form-input-height)]"
-    NORMAL = "border-border-strong bg-surface-raised text-text-heading focus:ring-interactive-focus " \
+             "focus-ring min-h-[var(--form-input-height)]"
+    NORMAL = "border-border-strong bg-surface-raised text-text-heading " \
              "disabled:cursor-not-allowed disabled:opacity-50"
-    ERROR  = "border-danger ring-2 ring-danger bg-danger-surface text-danger focus:ring-danger"
+    ERROR  = "border-danger ring-2 ring-danger bg-danger-surface text-danger"
 
     # value:       textarea body (builder-driven); falls back to block content for standalone use
     # required:    sets `required` + `aria-required="true"`

--- a/lib/generators/modelrails_ui/add/templates/toggle/toggle_component.rb.tt
+++ b/lib/generators/modelrails_ui/add/templates/toggle/toggle_component.rb.tt
@@ -32,7 +32,7 @@ module UI
     BASE = "inline-flex items-center justify-center gap-2 rounded-md text-sm font-medium whitespace-nowrap " \
            "transition-[color,box-shadow] outline-none " \
            "data-[state=off]:hover:bg-surface-sunken data-[state=off]:hover:text-text-body " \
-           "focus-visible:border-border-focus focus-visible:ring-[3px] focus-visible:ring-interactive-focus " \
+           "focus-ring " \
            "disabled:pointer-events-none disabled:opacity-50 " \
            "aria-invalid:border-danger-border aria-invalid:ring-danger  " \
            "data-[state=on]:bg-interactive-subtle data-[state=on]:text-interactive " \

--- a/test/render/badge_render_test.rb
+++ b/test/render/badge_render_test.rb
@@ -20,12 +20,12 @@ class BadgeRenderTest < ViewComponent::TestCase
 
   # The canonical `danger` signal uses the TINTED treatment (soft danger-surface +
   # saturated text-danger + danger-border), not a solid fill. Never raw palette /
-  # text-white; danger uniquely keeps a danger-colored focus ring.
+  # text-white; focus ring is the uniform focus-ring utility.
   def test_danger_uses_tinted_surface
     render_inline(UI::BadgeComponent.new("Error", variant: :danger))
 
     assert_selector "span.bg-danger-surface.text-danger.border-danger-border"
-    assert_selector 'span.focus-visible\\:ring-danger'
+    assert_selector "span.focus-ring"
     refute_selector "span.text-white"
   end
 

--- a/test/render/button_render_test.rb
+++ b/test/render/button_render_test.rb
@@ -16,7 +16,7 @@ class ButtonRenderTest < ViewComponent::TestCase
 
     assert_selector "button.bg-interactive"
     assert_selector "button.text-text-on-interactive"
-    assert_selector "button.focus\\:ring-interactive-focus"
+    assert_selector "button.focus-ring"
   end
 
   def test_href_renders_anchor

--- a/test/render/checkbox_render_test.rb
+++ b/test/render/checkbox_render_test.rb
@@ -15,7 +15,7 @@ class CheckboxRenderTest < ViewComponent::TestCase
     render_inline(UI::CheckboxComponent.new(label: "Accept terms", name: "terms"))
 
     assert_selector "input.border-border-strong"
-    assert_selector "input.focus-visible\\:ring-interactive-focus"
+    assert_selector "input.focus-ring"
     assert_selector "input.checked\\:bg-interactive"
   end
 

--- a/test/render/floating_label_render_test.rb
+++ b/test/render/floating_label_render_test.rb
@@ -15,7 +15,7 @@ class FloatingLabelRenderTest < ViewComponent::TestCase
     render_inline(UI::FloatingLabelComponent.new(label: "Email"))
 
     assert_selector "input.border-border-strong"
-    assert_selector "input.focus-visible\\:ring-interactive-focus"
+    assert_selector "input.focus-ring"
   end
 
   def test_label_text_renders

--- a/test/render/input_render_test.rb
+++ b/test/render/input_render_test.rb
@@ -21,14 +21,14 @@ class InputRenderTest < ViewComponent::TestCase
   def test_renders_base_aaa_tokens
     render_inline(UI::InputComponent.new)
 
-    assert_selector "input.block.w-full.rounded-md.border.focus\\:ring-2"
+    assert_selector "input.block.w-full.rounded-md.border.focus-ring"
   end
 
   # NORMAL styling on a non-invalid field.
   def test_renders_normal_aaa_tokens_when_valid
     render_inline(UI::InputComponent.new)
 
-    assert_selector "input.border-border-strong.bg-surface-raised.text-text-heading.focus\\:ring-interactive-focus"
+    assert_selector "input.border-border-strong.bg-surface-raised.text-text-heading"
   end
 
   # A disabled field is visually distinct (NORMAL carries disabled styling).

--- a/test/render/number_input_render_test.rb
+++ b/test/render/number_input_render_test.rb
@@ -22,7 +22,7 @@ class NumberInputRenderTest < ViewComponent::TestCase
     render_inline(UI::NumberInputComponent.new(name: "qty"))
 
     assert_selector "input.border-border-strong"
-    assert_selector "input.focus-visible\\:ring-interactive-focus"
+    assert_selector "input.focus-ring"
   end
 
   # 44px AAA touch target: the input carries the --form-input-height min-height token.

--- a/test/render/radio_group_render_test.rb
+++ b/test/render/radio_group_render_test.rb
@@ -100,11 +100,10 @@ class RadioGroupRenderTest < ViewComponent::TestCase
     assert_selector "input.accent-interactive"
   end
 
-  # Standard library 3px focus ring (not ring-1), matching the other form controls.
-  def test_inputs_use_the_standard_3px_focus_ring
+  # Uniform focus-ring utility (converged convention).
+  def test_inputs_use_the_focus_ring_utility
     render_inline(UI::RadioGroupComponent.new(name: "plan", label: "Billing plan", items: PLAN_ITEMS))
 
-    assert_selector "input.focus-visible\\:ring-\\[3px\\]"
-    assert_selector "input.focus-visible\\:ring-interactive-focus"
+    assert_selector "input.focus-ring"
   end
 end

--- a/test/render/search_input_render_test.rb
+++ b/test/render/search_input_render_test.rb
@@ -32,7 +32,7 @@ class SearchInputRenderTest < ViewComponent::TestCase
     render_inline(UI::SearchInputComponent.new(name: "q"))
 
     assert_selector "input.border-border-strong"
-    assert_selector "input.focus-visible\\:ring-interactive-focus"
+    assert_selector "input.focus-ring"
   end
 
   # WCAG 2.5.5 target size: the control sits at the 44px floor (h-11).

--- a/test/render/select_render_test.rb
+++ b/test/render/select_render_test.rb
@@ -17,7 +17,7 @@ class SelectRenderTest < ViewComponent::TestCase
     render_inline(UI::SelectComponent.new(options: %w[A B]))
 
     assert_selector "select.border-border-strong"
-    assert_selector "select.focus-visible\\:ring-interactive-focus"
+    assert_selector "select.focus-ring"
   end
 
   # WCAG 2.5.5 target size: the control sits at the 44px floor (--form-input-height).

--- a/test/render/textarea_render_test.rb
+++ b/test/render/textarea_render_test.rb
@@ -21,14 +21,14 @@ class TextareaRenderTest < ViewComponent::TestCase
   def test_renders_base_aaa_tokens
     render_inline(UI::TextareaComponent.new)
 
-    assert_selector "textarea.block.w-full.rounded-md.border.focus\\:ring-2"
+    assert_selector "textarea.block.w-full.rounded-md.border.focus-ring"
   end
 
   # NORMAL styling on a non-invalid field.
   def test_renders_normal_aaa_tokens_when_valid
     render_inline(UI::TextareaComponent.new)
 
-    assert_selector "textarea.border-border-strong.bg-surface-raised.text-text-heading.focus\\:ring-interactive-focus"
+    assert_selector "textarea.border-border-strong.bg-surface-raised.text-text-heading"
   end
 
   # A disabled field is visually distinct (NORMAL carries disabled styling).


### PR DESCRIPTION
## Converged-conventions B5: outline-not-ring focus

First plan of the convention pass. Replaces every component's per-tone focus **box-shadow ring** (`focus:ring-*` / `focus-visible:ring-*`) with one uniform `focus-ring` **outline** utility.

**Why an outline, not a ring:** a box-shadow ring is clipped by `overflow:hidden` ancestors and vanishes entirely in forced-colors / Windows High-Contrast mode — both silent WCAG 2.4.7 failures. An OS-drawn `outline` survives both. The focus color is uniform (`--color-interactive-focus`) regardless of the control's own tone.

## What changed
- **21 proven component templates** swept: button, badge, breadcrumb, checkbox, data_table, dialog, alert_dialog, drawer, sheet, floating_label, input, number_input, radio_group, range, rating_input, search_input, select, switch, tabs, textarea, toggle.
- **10 render-test assertions** updated to assert `focus-ring`.
- State rings (invalid `ring-danger`, checked) and the sanctioned menu `bg-surface-sunken` focus highlight are preserved.

**The `focus-ring` utility itself lives in the host app** (`@utility focus-ring`), since the app owns its design tokens — components just reference the class.

## Switch: the peer-projected exception
The switch's real input is `sr-only`, so the outline must render on the visible track via the peer cascade. The `focus-ring` utility bakes `:focus-visible` into its own selector and can't be peer-projected (and `peer-focus-ring` is invalid Tailwind that compiles to nothing). So the switch emits the same outline via `peer-focus-visible:[outline:2px_solid_var(--color-interactive-focus)]` — verified non-phantom with a compiled-CSS probe.

## Verification
- Full gem render suite: **384 examples, 0 failures**.
- App-side adoption (re-vendor + browser-axe 0b, incl. the switch outline proof) ships in the paired modelrails_base PR; AAA contrast is certified by that PR's CI.