### PR TITLE
feat(ui): button/badge/alert two-axis variant×tone API + shim (B2/A8)

### DIFF
--- a/lib/generators/modelrails_ui/add/templates/alert/alert_component.rb.tt
+++ b/lib/generators/modelrails_ui/add/templates/alert/alert_component.rb.tt
@@ -16,14 +16,16 @@ module UI
   #
   # ## Accessibility contract
   # - **Guarantees:** a live region matched to urgency — `role="status"`/`aria-live="polite"`
-  #   for the neutral `default` (and `info`/`success`/`warning`), `role="alert"`/
+  #   for the neutral tone (and `info`/`success`/`warning`), `role="alert"`/
   #   `aria-live="assertive"` for `danger` — and AAA-contrast text on the banner surface.
   # - **You supply:** a title and/or description (kwargs or the `alert_title` /
-  #   `alert_description` slots) and a valid `variant` (an unknown one raises in development).
+  #   `alert_description` slots) and a valid `tone` (an unknown one raises in development).
   #
-  # ## Variants
-  # `default` · `info` · `success` · `warning` · `danger`
-  # (`destructive` is a non-breaking alias for `danger`.)
+  # ## Tone
+  # An alert is always a filled banner — it has no shape axis, only a tone:
+  # `neutral` · `info` · `success` · `warning` · `danger`
+  # (`variant:` is accepted as a deprecated alias for `tone:` — `default`→`neutral`,
+  # `destructive`→`danger`, the rest 1:1.)
   class AlertComponent < ApplicationComponent
     OUTER_CLASSES = "relative grid w-full grid-cols-[0_1fr] items-start gap-y-0.5 rounded-lg border " \
                     "px-4 py-3 text-sm has-[>svg]:grid-cols-[calc(var(--spacing)*4)_1fr] " \
@@ -34,21 +36,21 @@ module UI
     # reads its severity the same way a toast does. `text-<level>` (no `/90` opacity
     # modifier — that would lower contrast below the AAA 7:1 floor on the description).
     VARIANTS = {
-      default: "bg-surface-raised text-text-body",
+      neutral: "bg-surface-raised text-text-body",
       info:    "bg-info-surface border-info-border text-info [&>svg]:text-current *:data-[slot=alert-description]:text-info",
       success: "bg-success-surface border-success-border text-success [&>svg]:text-current *:data-[slot=alert-description]:text-success",
       warning: "bg-warning-surface border-warning-border text-warning [&>svg]:text-current *:data-[slot=alert-description]:text-warning",
       danger:  "bg-danger-surface border-danger-border text-danger [&>svg]:text-current *:data-[slot=alert-description]:text-danger"
     }.freeze
 
-    # `destructive` is a non-breaking alias for the canonical `danger` (matching the
-    # signal tokens). Resolved in coerce_variant before lookup.
-    VARIANT_ALIASES = { destructive: :danger }.freeze
+    # Deprecated `variant:` alias → `tone:`. The old flat `variant` enum maps 1:1 onto
+    # tone except `default`→`neutral` and `destructive`→`danger`. Resolved in coerce_tone.
+    VARIANT_ALIASES = { default: :neutral, destructive: :danger }.freeze
 
     # Live-region semantics by urgency: only `danger` is urgent (assertive); the
-    # neutral default and info/success/warning announce politely.
-    ROLES = { default: "status", info: "status", success: "status", warning: "status", danger: "alert" }.freeze
-    LIVE  = { default: "polite", info: "polite", success: "polite", warning: "polite", danger: "assertive" }.freeze
+    # neutral tone and info/success/warning announce politely.
+    ROLES = { neutral: "status", info: "status", success: "status", warning: "status", danger: "alert" }.freeze
+    LIVE  = { neutral: "polite", info: "polite", success: "polite", warning: "polite", danger: "assertive" }.freeze
 
     renders_one :alert_title, "UI::AlertComponent::TitleComponent"
     renders_one :alert_description, "UI::AlertComponent::DescriptionComponent"
@@ -56,8 +58,8 @@ module UI
     # title: and description: are kwarg shorthands for plain-text content.
     # Use slots (with_alert_title / with_alert_description) for rich HTML.
     # Slots take precedence over kwargs when both are provided.
-    def initialize(variant: :default, title: nil, description: nil, **html_attrs)
-      @variant = coerce_variant(variant.to_sym)
+    def initialize(tone: :neutral, variant: nil, title: nil, description: nil, **html_attrs)
+      @tone = coerce_tone(tone, variant)
       @title = title
       @description = description
       @extra_class = html_attrs.delete(:class)
@@ -67,9 +69,9 @@ module UI
     def call
       content_tag(:div, safe_join([resolved_title, resolved_description].compact),
         **@html_attrs,
-        role: ROLES.fetch(@variant),
-        "aria-live": LIVE.fetch(@variant),
-        class: cn(OUTER_CLASSES, VARIANTS.fetch(@variant), @extra_class))
+        role: ROLES.fetch(@tone),
+        "aria-live": LIVE.fetch(@tone),
+        class: cn(OUTER_CLASSES, VARIANTS.fetch(@tone), @extra_class))
     end
 
     class TitleComponent < ApplicationComponent
@@ -90,22 +92,28 @@ module UI
 
     private
 
-    # Fail loud on an unknown variant in development/test so misuse is caught
-    # immediately; fall back to :default in production so a bad variant never
-    # 500s a page. The Rails.respond_to?(:env) guard stays correct even when the Rails
-    # module is defined but Rails.env isn't booted (the gem's Rails-less tests load
-    # rails/generators, which defines Rails without Rails.env).
-    def coerce_variant(variant)
-      variant = VARIANT_ALIASES.fetch(variant, variant)
-      return variant if VARIANTS.key?(variant)
+    # Resolve the tone, accepting the deprecated `variant:` alias. When `variant:` is
+    # passed (non-nil) it wins (legacy call sites) and is mapped onto a tone via
+    # VARIANT_ALIASES (default→neutral, destructive→danger, the rest 1:1); otherwise
+    # the new `tone:` axis is used.
+    #
+    # Fail loud on an unknown tone in development/test so misuse is caught immediately;
+    # fall back to :neutral in production so a bad tone never 500s a page. The
+    # Rails.respond_to?(:env) guard stays correct even when the Rails module is defined
+    # but Rails.env isn't booted (the gem's Rails-less tests load rails/generators,
+    # which defines Rails without Rails.env).
+    def coerce_tone(tone, variant)
+      tone = variant.nil? ? tone.to_sym : VARIANT_ALIASES.fetch(variant.to_sym, variant.to_sym)
+      return tone if VARIANTS.key?(tone)
 
       unless defined?(Rails) && Rails.respond_to?(:env) && Rails.env.production?
         raise ArgumentError,
-          "UI::AlertComponent: unknown variant #{variant.inspect}. " \
-          "Expected one of: #{VARIANTS.keys.join(", ")} (alias: destructive→danger)."
+          "UI::AlertComponent: unknown tone #{tone.inspect}. " \
+          "Expected one of: #{VARIANTS.keys.join(", ")} " \
+          "(deprecated variant: alias — default→neutral, destructive→danger)."
       end
 
-      :default
+      :neutral
     end
 
     def resolved_title

--- a/lib/generators/modelrails_ui/add/templates/badge/badge_component.rb.tt
+++ b/lib/generators/modelrails_ui/add/templates/badge/badge_component.rb.tt
@@ -16,18 +16,29 @@ module UI
   #   A badge is presentational; `href:` is for navigation/filtering, not actions.
   #
   # ## Accessibility contract
-  # - **Guarantees:** AAA-contrast text on every variant's surface, including the
+  # - **Guarantees:** AAA-contrast text on every shipped cell's surface, including the
   #   adaptive signal treatments (`danger`/`success`/`info`/`warning`) which stay
   #   legible in dark mode.
   # - **You supply:** if the badge conveys status that isn't already in the
   #   surrounding text (e.g. a color-coded "danger" pill), give it an accessible
-  #   name so screen-reader users get the same signal. A valid `variant` is required —
-  #   an unknown one raises in development.
+  #   name so screen-reader users get the same signal. A valid `(variant, tone)`
+  #   cell is required — an unproven one raises in development.
   #
-  # ## Variants
-  # Signal levels: `info` · `success` · `warning` · `danger` (tinted chips).
-  # Style levels: `default` · `secondary` · `outline` · `ghost` · `link`.
-  # (`destructive` is a non-breaking alias for `danger`.)
+  # ## Axes (converged-conventions B2)
+  # Two axes: `variant:` (shape) × `tone:` (signal).
+  # - `variant: :solid | :soft | :outline | :ghost | :link` (default `:solid`)
+  # - `tone: :primary | :neutral | :info | :success | :warning | :danger` (default `:primary`)
+  #
+  # Only the 9 AAA-proven cells ship (see `COMBOS`). Every signal lives on the SOFT
+  # variant as a TINTED chip — note `[:soft, :danger]` is the badge "danger" (there is
+  # NO solid-danger badge fill; `variant: :solid, tone: :danger` is unproven and raises).
+  #
+  # ## Legacy shim (deprecated flat `variant:` → `[variant, tone]`)
+  # The historical flat values still work, byte-identically, via `SHIM`:
+  # `default`→`[solid,primary]`, `secondary`→`[soft,primary]`, `info`→`[soft,info]`,
+  # `success`→`[soft,success]`, `warning`→`[soft,warning]`, `danger`→`[soft,danger]`,
+  # `destructive`→`[soft,danger]`, `outline`→`[outline,neutral]`, `ghost`→`[ghost,neutral]`,
+  # `link`→`[link,primary]`. (`danger`/`destructive` map to the SOFT chip — NOT solid.)
   class BadgeComponent < ApplicationComponent
     BASE = "inline-flex w-fit shrink-0 items-center justify-center gap-1 overflow-hidden rounded-full " \
            "border border-transparent px-2 py-0.5 text-xs font-medium whitespace-nowrap " \
@@ -36,34 +47,44 @@ module UI
            "aria-invalid:border-danger-border aria-invalid:ring-danger  " \
            "[&>svg]:pointer-events-none [&>svg]:size-3"
 
-    # Signal levels use the TINTED treatment (soft `*-surface` background + saturated
-    # `text-<level>` + `*-border`), matching the alert + toast cards. The `--color-<level>`
-    # base tokens are TEXT colors (dark in light mode for AAA-on-light readability), so
-    # using them as solid fills produces dark, muddy chips — e.g. `bg-warning` is amber-900
-    # (a dark brown), which reads nothing like "warning." The tinted pairing is what the
-    # `*-surface` tokens are for, and `text-<level>` on `bg-<level>-surface` is AAA-proven
-    # on the toast cards. (info/success on their tinted surfaces: CI-verify.)
-    VARIANTS = {
-      default: "bg-interactive text-text-on-interactive [a&]:hover:bg-interactive-hover",
-      secondary: "bg-interactive-subtle text-interactive [a&]:hover:bg-interactive-subtle",
-      info: "bg-info-surface text-info border-info-border [a&]:hover:bg-info-hover",
-      success: "bg-success-surface text-success border-success-border [a&]:hover:bg-success-hover",
-      warning: "bg-warning-surface text-warning border-warning-border [a&]:hover:bg-warning-hover",
-      danger: "bg-danger-surface text-danger border-danger-border [a&]:hover:bg-danger-hover",
-      outline: "border-border text-text-heading [a&]:hover:bg-surface-sunken [a&]:hover:text-text-heading",
-      ghost: "[a&]:hover:bg-surface-sunken [a&]:hover:text-text-heading",
-      link: "text-interactive underline-offset-4 [a&]:hover:underline"
+    # The 9 AAA-proven cells, keyed `[variant, tone]`. Signal tones use the TINTED
+    # treatment (soft `*-surface` background + saturated `text-<level>` + `*-border`),
+    # matching the alert + toast cards. The `--color-<level>` base tokens are TEXT
+    # colors (dark in light mode for AAA-on-light readability), so using them as solid
+    # fills produces dark, muddy chips — e.g. `bg-warning` is amber-900 (a dark brown),
+    # which reads nothing like "warning." The tinted pairing is what the `*-surface`
+    # tokens are for, and `text-<level>` on `bg-<level>-surface` is AAA-proven on the
+    # toast cards. (info/success on their tinted surfaces: CI-verify.)
+    COMBOS = {
+      [:solid, :primary] => "bg-interactive text-text-on-interactive [a&]:hover:bg-interactive-hover",
+      [:soft, :primary] => "bg-interactive-subtle text-interactive [a&]:hover:bg-interactive-subtle",
+      [:soft, :info] => "bg-info-surface text-info border-info-border [a&]:hover:bg-info-hover",
+      [:soft, :success] => "bg-success-surface text-success border-success-border [a&]:hover:bg-success-hover",
+      [:soft, :warning] => "bg-warning-surface text-warning border-warning-border [a&]:hover:bg-warning-hover",
+      [:soft, :danger] => "bg-danger-surface text-danger border-danger-border [a&]:hover:bg-danger-hover",
+      [:outline, :neutral] => "border-border text-text-heading [a&]:hover:bg-surface-sunken [a&]:hover:text-text-heading",
+      [:ghost, :neutral] => "[a&]:hover:bg-surface-sunken [a&]:hover:text-text-heading",
+      [:link, :primary] => "text-interactive underline-offset-4 [a&]:hover:underline"
     }.freeze
 
-    # `destructive` is a non-breaking alias for the canonical `danger`. Resolved in
-    # coerce_variant before lookup.
-    VARIANT_ALIASES = { destructive: :danger }.freeze
+    # Legacy flat `variant:` values → `[variant, tone]`. Per-component (badge `danger`
+    # is the SOFT chip, so `danger`/`destructive`→`[soft,danger]` — NOT solid, unlike
+    # button). When a caller passes one of these in `variant:`, the shim wins and the
+    # passed `tone:` is ignored.
+    SHIM = {
+      default: [:solid, :primary], secondary: [:soft, :primary], info: [:soft, :info],
+      success: [:soft, :success], warning: [:soft, :warning], danger: [:soft, :danger],
+      destructive: [:soft, :danger], outline: [:outline, :neutral], ghost: [:ghost, :neutral],
+      link: [:link, :primary]
+    }.freeze
 
-    # label — positional or keyword shorthand for plain-text badges without a block.
-    # href  — renders an <a> tag (a clickable tag/filter link); sets tag: :a automatically.
-    def initialize(label = nil, variant: :default, href: nil, **html_attrs)
+    # label   — positional or keyword shorthand for plain-text badges without a block.
+    # variant — shape axis (see COMBOS); also accepts a legacy flat value via SHIM.
+    # tone    — signal axis (see COMBOS); ignored when `variant:` is a legacy flat value.
+    # href    — renders an <a> tag (a clickable tag/filter link); sets tag: :a automatically.
+    def initialize(label = nil, variant: :solid, tone: :primary, href: nil, **html_attrs)
       @label = label || html_attrs.delete(:label)
-      @variant = coerce_variant(variant.to_sym)
+      coerce_axes(variant, tone)
       @tag = html_attrs.delete(:tag)
       @extra_class = html_attrs.delete(:class)
       @html_attrs = html_attrs
@@ -76,28 +97,36 @@ module UI
 
     def call
       content_tag(@tag || :span, content.presence || @label,
-        class: cn(BASE, VARIANTS.fetch(@variant), @extra_class),
+        class: cn(BASE, COMBOS.fetch([@variant, @tone], COMBOS[[:solid, :primary]]), @extra_class),
         **@html_attrs)
     end
 
     private
 
-    # Fail loud on an unknown variant in development/test so misuse is caught
-    # immediately; fall back to :default in production so a bad variant never
-    # 500s a page. The Rails.respond_to?(:env) guard stays correct even when the Rails
-    # module is defined but Rails.env isn't booted (the gem's Rails-less tests load
-    # rails/generators, which defines Rails without Rails.env).
-    def coerce_variant(variant)
-      variant = VARIANT_ALIASES.fetch(variant, variant)
-      return variant if VARIANTS.key?(variant)
+    # Resolve the (variant, tone) cell. A legacy flat value in `variant:` is translated
+    # through SHIM (passed `tone:` ignored); otherwise the two axes are used directly.
+    # Fail loud on an unproven cell in development/test so misuse is caught immediately;
+    # fall back to [:solid, :primary] in production so a bad cell never 500s a page. The
+    # Rails.respond_to?(:env) guard stays correct even when the Rails module is defined
+    # but Rails.env isn't booted (the gem's Rails-less tests load rails/generators, which
+    # defines Rails without Rails.env).
+    def coerce_axes(variant, tone)
+      variant = variant.to_sym
+      if SHIM.key?(variant)
+        @variant, @tone = SHIM[variant]
+      else
+        @variant, @tone = variant, tone.to_sym
+      end
+      return if COMBOS.key?([@variant, @tone])
 
       unless defined?(Rails) && Rails.respond_to?(:env) && Rails.env.production?
         raise ArgumentError,
-          "UI::BadgeComponent: unknown variant #{variant.inspect}. " \
-          "Expected one of: #{VARIANTS.keys.join(", ")} (alias: destructive→danger)."
+          "UI::BadgeComponent: unproven cell [#{@variant.inspect}, #{@tone.inspect}]. " \
+          "Expected one of: #{COMBOS.keys.map(&:inspect).join(", ")} " \
+          "(legacy flat aliases: #{SHIM.keys.join(", ")})."
       end
 
-      :default
+      @variant, @tone = :solid, :primary
     end
   end
 end

--- a/lib/generators/modelrails_ui/add/templates/button/button_component.rb.tt
+++ b/lib/generators/modelrails_ui/add/templates/button/button_component.rb.tt
@@ -3,36 +3,63 @@
 module UI
   class ButtonComponent < ApplicationComponent
     # Reproduces the host app's .btn-* button system (app/assets/tailwind/application.css
-    # @layer components). Filled family (primary/secondary/danger) + text family
-    # (text/text_interactive/text_danger). All AAA-tuned, aligned to --form-input-height.
+    # @layer components). Two-axis API (converged-conventions B2):
+    #
+    #   variant: :solid | :outline | :text   (shape, default :solid)
+    #   tone:    :primary | :neutral | :danger  (signal, default :primary)
+    #
+    # Only AAA-proven (variant, tone) cells exist (COMBOS) — an unproven cell raises
+    # in dev/test and falls back to [:solid, :primary] in prod (the combo-guard: a new
+    # fill is an untested text-on-* pairing). The proven cells:
+    #
+    #   [:solid,   :primary]  filled brand
+    #   [:solid,   :danger]   filled danger
+    #   [:outline, :neutral]  bordered neutral
+    #   [:text,    :primary]  text/link brand
+    #   [:text,    :danger]   text/link danger
+    #
+    # Legacy flat `variant:` values are still accepted via SHIM (back-compat,
+    # byte-identical output): primary, secondary, danger, destructive, text,
+    # text_interactive, text_danger. When a legacy value is passed, `tone:` is ignored.
+    #
+    # size: :default | :icon — :icon (A8) is a 44×44 square (WCAG 2.5.5): adds min-w
+    # and drops horizontal padding (min-h is already carried by FILLED/TEXT).
     FILLED = "inline-flex items-center justify-center px-4 rounded-md font-medium cursor-pointer " \
              "focus-ring min-h-[var(--form-input-height)]"
 
     TEXT = "inline-flex items-center justify-center px-2 min-h-[var(--form-input-height)] min-w-[var(--form-input-height)] " \
            "font-medium underline rounded focus-ring hover:no-underline"
 
-    VARIANTS = {
-      primary: "#{FILLED} bg-interactive hover:bg-interactive-hover text-text-on-interactive",
-      secondary: "#{FILLED} border border-border text-text-body hover:bg-surface-sunken",
-      danger: "#{FILLED} bg-danger hover:bg-danger/90 text-text-on-interactive",
-      text: "#{TEXT} text-interactive",
-      text_interactive: "#{TEXT} text-interactive",
-      text_danger: "#{TEXT} text-danger"
+    # The proven (variant, tone) cells. Keys are [variant, tone]; values are the AAA
+    # treatments (byte-identical to the former flat VARIANTS values).
+    COMBOS = {
+      [:solid, :primary] => "#{FILLED} bg-interactive hover:bg-interactive-hover text-text-on-interactive",
+      [:solid, :danger] => "#{FILLED} bg-danger hover:bg-danger/90 text-text-on-interactive",
+      [:outline, :neutral] => "#{FILLED} border border-border text-text-body hover:bg-surface-sunken",
+      [:text, :primary] => "#{TEXT} text-interactive",
+      [:text, :danger] => "#{TEXT} text-danger"
     }.freeze
 
-    # Optional size overrides (the app uses a single size keyed to --form-input-height,
-    # so default is empty; kept for API symmetry / future use).
-    SIZES = {default: ""}.freeze
+    # Legacy flat `variant:` → [variant, tone]. Lets every existing call site keep
+    # working unchanged (the new two-axis API is the canonical form).
+    SHIM = {
+      primary: [:solid, :primary],
+      secondary: [:outline, :neutral],
+      danger: [:solid, :danger],
+      destructive: [:solid, :danger],
+      text: [:text, :primary],
+      text_interactive: [:text, :primary],
+      text_danger: [:text, :danger]
+    }.freeze
 
-    # `destructive` is a non-breaking alias for the canonical `danger`, so the whole
-    # UI vocabulary speaks one severity ladder. Resolved in coerce_variant before lookup.
-    VARIANT_ALIASES = {destructive: :danger}.freeze
+    # A8: :default keeps the standard horizontal padding; :icon is a 44×44 square.
+    SIZES = {default: "", icon: "px-0 min-w-[var(--form-input-height)]"}.freeze
 
     # label — positional or keyword shorthand for plain-text buttons without a block.
     # href  — renders an <a> tag; sets tag: :a automatically.
-    def initialize(label = nil, variant: :primary, size: :default, href: nil, **html_attrs)
+    def initialize(label = nil, variant: :solid, tone: :primary, size: :default, href: nil, **html_attrs)
       @label = label || html_attrs.delete(:label)
-      @variant = coerce_variant(variant.to_sym)
+      coerce_axes(variant, tone)
       @size = size.to_sym
       @tag = html_attrs.delete(:tag)
       @extra_class = html_attrs.delete(:class)
@@ -54,26 +81,37 @@ module UI
 
     private
 
-    # Fail loud on an unknown variant in development/test so misuse is caught
-    # immediately; fall back to :primary in production so a bad variant never
-    # 500s a page. The Rails.respond_to?(:env) guard stays correct even when the Rails
-    # module is defined but Rails.env isn't booted (the gem's Rails-less tests load
-    # rails/generators, which defines Rails without Rails.env).
-    def coerce_variant(variant)
-      variant = VARIANT_ALIASES.fetch(variant, variant)
-      return variant if VARIANTS.key?(variant)
+    # Resolve the (variant, tone) axes into @variant/@tone. An explicit proven cell
+    # ([variant, tone] already in COMBOS) is used directly — this lets the new
+    # `variant: :text, tone: :danger` form work even though `:text` also names a legacy
+    # flat value. Otherwise, a legacy flat value in `variant:` is translated via SHIM
+    # (ignoring the passed tone). Fail loud on an unproven cell in development/test so
+    # misuse is caught immediately; fall back to [:solid, :primary] in production so a
+    # bad combo never 500s a page. The Rails.respond_to?(:env) guard stays correct even
+    # when the Rails module is defined but Rails.env isn't booted (the gem's Rails-less
+    # tests load rails/generators, which defines Rails without Rails.env).
+    def coerce_axes(variant, tone)
+      variant = variant.to_sym
+      @variant, @tone = variant, tone.to_sym
+      return if COMBOS.key?([@variant, @tone])
+
+      if SHIM.key?(variant)
+        @variant, @tone = SHIM[variant]
+        return
+      end
 
       unless defined?(Rails) && Rails.respond_to?(:env) && Rails.env.production?
         raise ArgumentError,
-          "UI::ButtonComponent: unknown variant #{variant.inspect}. " \
-          "Expected one of: #{VARIANTS.keys.join(", ")} (alias: destructive→danger)."
+          "UI::ButtonComponent: unproven cell [#{@variant.inspect}, #{@tone.inspect}]. " \
+          "Proven cells: #{COMBOS.keys.map(&:inspect).join(", ")}. " \
+          "Legacy flat variant values are also accepted: #{SHIM.keys.join(", ")}."
       end
 
-      :primary
+      @variant, @tone = :solid, :primary
     end
 
     def component_classes
-      cn(VARIANTS.fetch(@variant, VARIANTS[:primary]), SIZES.fetch(@size, SIZES[:default]), @extra_class)
+      cn(COMBOS.fetch([@variant, @tone], COMBOS[[:solid, :primary]]), SIZES.fetch(@size, ""), @extra_class)
     end
   end
 end

--- a/test/render/alert_render_test.rb
+++ b/test/render/alert_render_test.rb
@@ -69,4 +69,62 @@ class AlertRenderTest < ViewComponent::TestCase
 
     assert_selector "div.mt-4.bg-surface-raised"
   end
+
+  # --- B2: 1-axis tone rename (deprecated `variant:` alias must stay byte-identical) ---
+
+  # The DEPRECATED `variant:` alias path. Each legacy value must render the exact
+  # same surface class + role + aria-live as before the tone rename.
+  LEGACY_VARIANT_BACK_COMPAT = {
+    default: {surface: "bg-surface-raised", role: "status", live: "polite"},
+    info: {surface: "bg-info-surface", role: "status", live: "polite"},
+    success: {surface: "bg-success-surface", role: "status", live: "polite"},
+    warning: {surface: "bg-warning-surface", role: "status", live: "polite"},
+    danger: {surface: "bg-danger-surface", role: "alert", live: "assertive"},
+    destructive: {surface: "bg-danger-surface", role: "alert", live: "assertive"}
+  }.freeze
+
+  LEGACY_VARIANT_BACK_COMPAT.each do |legacy, expected|
+    define_method("test_legacy_variant_#{legacy}_renders_byte_identical") do
+      render_inline(UI::AlertComponent.new(variant: legacy, title: "X"))
+
+      assert_selector "div[role='#{expected[:role]}'][aria-live='#{expected[:live]}'].#{expected[:surface]}"
+    end
+  end
+
+  # The NEW `tone:` axis. `tone: :neutral` is the renamed `default` — identical output.
+  def test_tone_neutral_matches_legacy_default
+    render_inline(UI::AlertComponent.new(tone: :neutral, title: "X"))
+
+    assert_selector "div[role='status'][aria-live='polite'].bg-surface-raised"
+    assert_selector "div.text-text-body"
+  end
+
+  def test_tone_warning_is_a_polite_status_on_the_warning_surface
+    render_inline(UI::AlertComponent.new(tone: :warning, title: "Heads up"))
+
+    assert_selector "div[role='status'][aria-live='polite'].bg-warning-surface", text: "Heads up"
+  end
+
+  def test_tone_danger_is_an_assertive_alert_on_the_danger_surface
+    render_inline(UI::AlertComponent.new(tone: :danger, title: "Couldn't save"))
+
+    assert_selector "div[role='alert'][aria-live='assertive'].bg-danger-surface", text: "Couldn't save"
+  end
+
+  # The legacy `variant:` alias and the new `tone:` axis must resolve identically.
+  def test_legacy_default_variant_and_tone_neutral_render_identically
+    render_inline(UI::AlertComponent.new(variant: :default, title: "X"))
+    legacy = page.native.to_html
+
+    render_inline(UI::AlertComponent.new(tone: :neutral, title: "X"))
+    new_axis = page.native.to_html
+
+    assert_equal legacy, new_axis
+  end
+
+  def test_unknown_tone_raises
+    assert_raises(ArgumentError) do
+      render_inline(UI::AlertComponent.new(tone: :bogus))
+    end
+  end
 end

--- a/test/render/badge_render_test.rb
+++ b/test/render/badge_render_test.rb
@@ -18,6 +18,28 @@ class BadgeRenderTest < ViewComponent::TestCase
     assert_selector "span.text-text-on-interactive"
   end
 
+  # Back-compat lock: every legacy flat `variant:` value must keep rendering its
+  # exact marker class (byte-identical output through the deprecation shim). The
+  # 9 historical variants + `destructive` alias.
+  {
+    default: "bg-interactive",
+    secondary: "bg-interactive-subtle",
+    info: "bg-info-surface",
+    success: "bg-success-surface",
+    warning: "bg-warning-surface",
+    danger: "bg-danger-surface",
+    destructive: "bg-danger-surface",
+    outline: "border-border",
+    ghost: "[a&]:hover:bg-surface-sunken",
+    link: "underline-offset-4"
+  }.each do |legacy, marker|
+    define_method("test_legacy_variant_#{legacy}_still_renders") do
+      render_inline(UI::BadgeComponent.new("X", variant: legacy))
+
+      assert_selector "span.#{marker.gsub(/[\[\]()&:]/) { |c| "\\#{c}" }}"
+    end
+  end
+
   # The canonical `danger` signal uses the TINTED treatment (soft danger-surface +
   # saturated text-danger + danger-border), not a solid fill. Never raw palette /
   # text-white; focus ring is the uniform focus-ring utility.
@@ -29,7 +51,8 @@ class BadgeRenderTest < ViewComponent::TestCase
     refute_selector "span.text-white"
   end
 
-  # `destructive` is a non-breaking alias for the canonical `danger` — identical fill.
+  # `destructive` is a non-breaking alias for the canonical `danger` — identical fill
+  # (the SOFT chip, NOT a solid fill).
   def test_destructive_alias_renders_as_danger
     render_inline(UI::BadgeComponent.new("Error", variant: :destructive))
 
@@ -59,6 +82,28 @@ class BadgeRenderTest < ViewComponent::TestCase
 
     assert_selector "span.bg-warning-surface.text-warning.border-warning-border"
     refute_selector "span.text-text-heading"
+  end
+
+  # New two-axis API: variant: (shape) × tone: (signal).
+  def test_two_axis_soft_info_renders_info_chip
+    render_inline(UI::BadgeComponent.new("Note", variant: :soft, tone: :info))
+
+    assert_selector "span.bg-info-surface.text-info.border-info-border"
+  end
+
+  def test_two_axis_ghost_neutral_renders_ghost
+    render_inline(UI::BadgeComponent.new("Quiet", variant: :ghost, tone: :neutral))
+
+    assert_selector "span.\\[a\\&\\]\\:hover\\:bg-surface-sunken"
+    assert_selector "span.\\[a\\&\\]\\:hover\\:text-text-heading"
+  end
+
+  # UNPROVEN cell for badge: there's no solid-danger chip (badge danger is the soft
+  # tinted treatment). The AAA combo-guard must raise in dev for an untested pairing.
+  def test_solid_danger_unproven_raises
+    assert_raises(ArgumentError) do
+      render_inline(UI::BadgeComponent.new("X", variant: :solid, tone: :danger))
+    end
   end
 
   def test_href_renders_anchor

--- a/test/render/button_render_test.rb
+++ b/test/render/button_render_test.rb
@@ -42,6 +42,61 @@ class ButtonRenderTest < ViewComponent::TestCase
     end
   end
 
+  # --- B2 two-axis (variant × tone) + A8 :icon size ---------------------------
+
+  # Back-compat: every legacy flat `variant:` value still renders its marker class
+  # (the shim translates the old enum to a (variant, tone) cell — byte-identical output).
+  {
+    primary: "bg-interactive",
+    secondary: "border-border",
+    danger: "bg-danger",
+    destructive: "bg-danger",
+    text: "text-interactive",
+    text_interactive: "text-interactive",
+    text_danger: "text-danger"
+  }.each do |legacy, marker|
+    define_method("test_legacy_variant_#{legacy}_still_renders") do
+      render_inline(UI::ButtonComponent.new("Go", variant: legacy))
+
+      assert_selector "button.#{marker.tr(" ", ".")}"
+    end
+  end
+
+  def test_two_axis_solid_primary_matches_legacy_primary
+    render_inline(UI::ButtonComponent.new("Go", variant: :solid, tone: :primary))
+
+    assert_selector "button.bg-interactive.text-text-on-interactive"
+  end
+
+  def test_two_axis_text_danger
+    render_inline(UI::ButtonComponent.new("Go", variant: :text, tone: :danger))
+
+    assert_selector "button.text-danger"
+  end
+
+  def test_two_axis_outline_neutral_matches_legacy_secondary
+    render_inline(UI::ButtonComponent.new("Go", variant: :outline, tone: :neutral))
+
+    assert_selector "button.border-border"
+  end
+
+  # Unproven (variant, tone) cell — raises in dev/test (the AAA combo-guard:
+  # a new fill is an untested text-on-* pairing).
+  def test_unproven_cell_raises_in_dev
+    assert_raises(ArgumentError) do
+      render_inline(UI::ButtonComponent.new("Go", variant: :solid, tone: :neutral))
+    end
+  end
+
+  # A8: `size: :icon` is a 44×44 square (drop horizontal padding, add min-w; min-h
+  # is already carried by the FILLED base).
+  def test_size_icon_is_a_44px_square
+    render_inline(UI::ButtonComponent.new(variant: :solid, tone: :primary, size: :icon))
+
+    assert_selector "button.px-0"
+    assert_selector 'button.min-w-\\[var\\(--form-input-height\\)\\]'
+  end
+
   # Behavioral proof of the tailwind_merge-backed `cn`: a `class:` passthrough
   # must OVERRIDE a conflicting base utility. The filled base is `rounded-md`;
   # passing `class: "rounded-full"` must win, and `rounded-md` must be dropped.

--- a/test/test_components.rb
+++ b/test/test_components.rb
@@ -142,16 +142,20 @@ class TestButtonComponent < Minitest::Test
     assert_equal "Save", c.instance_variable_get(:@label)
   end
 
-  def test_default_variant
+  def test_default_axes
     c = UI::ButtonComponent.new
 
-    assert_equal :primary, c.instance_variable_get(:@variant)
+    assert_equal :solid, c.instance_variable_get(:@variant)
+    assert_equal :primary, c.instance_variable_get(:@tone)
   end
 
-  def test_variant_stored_as_symbol
+  # A legacy flat `variant:` (here the string "danger") coerces through SHIM to the
+  # two-axis form: [:solid, :danger]. Back-compat for every existing call site.
+  def test_legacy_variant_coerced_to_axes
     c = UI::ButtonComponent.new(variant: "danger")
 
-    assert_equal :danger, c.instance_variable_get(:@variant)
+    assert_equal :solid, c.instance_variable_get(:@variant)
+    assert_equal :danger, c.instance_variable_get(:@tone)
   end
 
   def test_default_size
@@ -255,10 +259,10 @@ class TestButtonComponent < Minitest::Test
 end
 
 class TestAlertComponent < Minitest::Test
-  def test_default_variant
+  def test_default_tone
     c = UI::AlertComponent.new
 
-    assert_equal :default, c.instance_variable_get(:@variant)
+    assert_equal :neutral, c.instance_variable_get(:@tone)
   end
 
   def test_title_kwarg_stored
@@ -273,12 +277,12 @@ class TestAlertComponent < Minitest::Test
     assert_equal "Something happened.", c.instance_variable_get(:@description)
   end
 
-  # `destructive` is a non-breaking alias for the canonical `danger`, resolved in
-  # coerce_variant, so the stored variant is `:danger`.
+  # `destructive` is a non-breaking alias for the canonical `danger` tone, resolved via
+  # the deprecated `variant:` path in coerce_tone, so the stored tone is `:danger`.
   def test_destructive_aliases_danger
     c = UI::AlertComponent.new(variant: :destructive)
 
-    assert_equal :danger, c.instance_variable_get(:@variant)
+    assert_equal :danger, c.instance_variable_get(:@tone)
   end
 end
 
@@ -329,23 +333,30 @@ class TestBadgeComponent < Minitest::Test
     assert_equal "New", c.instance_variable_get(:@label)
   end
 
-  def test_default_variant
+  # Two-axis default (converged-conventions B2): variant: :solid × tone: :primary.
+  def test_default_axes
     c = UI::BadgeComponent.new
 
-    assert_equal :default, c.instance_variable_get(:@variant)
+    assert_equal :solid, c.instance_variable_get(:@variant)
+    assert_equal :primary, c.instance_variable_get(:@tone)
   end
 
-  def test_all_variants_exist
-    %i[default secondary info success warning danger outline ghost link].each do |variant|
-      assert UI::BadgeComponent::VARIANTS.key?(variant), "Missing variant #{variant}"
+  # Every shipped (variant, tone) cell is an AAA-proven treatment in COMBOS.
+  def test_all_combos_exist
+    [%i[solid primary], %i[soft primary], %i[soft info], %i[soft success],
+      %i[soft warning], %i[soft danger], %i[outline neutral], %i[ghost neutral],
+      %i[link primary]].each do |cell|
+      assert UI::BadgeComponent::COMBOS.key?(cell), "Missing cell #{cell.inspect}"
     end
   end
 
-  # `destructive` is a non-breaking alias for the canonical `danger`.
-  def test_destructive_aliases_danger
+  # `destructive` is a non-breaking alias for the canonical `danger`, which on badge
+  # is the SOFT tinted chip — so it resolves to the [:soft, :danger] cell (NOT solid).
+  def test_destructive_aliases_soft_danger
     c = UI::BadgeComponent.new("Error", variant: :destructive)
 
-    assert_equal :danger, c.instance_variable_get(:@variant)
+    assert_equal :soft, c.instance_variable_get(:@variant)
+    assert_equal :danger, c.instance_variable_get(:@tone)
   end
 end
 


### PR DESCRIPTION
## Converged-conventions B2 + A8 (convention pass, Plan 2)

Factor the flat one-axis `variant:` enum into **`variant:` (shape) × `tone:` (signal)** across button, badge, and alert, with a per-component **deprecation shim** so every existing call site keeps working byte-identically. Ships only the **AAA-proven `(variant,tone)` cells** (each an existing treatment); unproven cells **raise in dev / fall back in prod** — a new fill is an untested `text-on-*` pairing.

### Per surface
- **button** — `variant: :solid|:outline|:text` × `tone: :primary|:neutral|:danger`. `coerce_axes` checks the proven cell **first**, then the legacy shim (so the new `variant: :text, tone: :danger` resolves even though `text` is also a legacy flat value). **A8:** restores the `:icon` size (44×44 square, WCAG 2.5.5).
- **badge** — `variant: :solid|:soft|:outline|:ghost|:link` × `tone: :primary|:neutral|:info|:success|:warning|:danger`. Note `danger`/`destructive` → `[soft, danger]` (the tinted chip), **not** a solid fill — per-component shim tables, deliberately not shared.
- **alert** — genuinely **1-axis** (`tone:` only; it's always a banner, no shape axis — forcing one would be the Catalyst-palette over-engineering B2 warns against). `variant:` kept as a deprecated alias. Live-region `role`/`aria-live` preserved (only `danger` is assertive).

### Back-compat
Every currently-valid value (7 button + 10 badge + 6 alert incl. `destructive`) renders **byte-identical** classes — locked by render tests. Base/focus constants untouched.

### Verification
Full gem suite **470/0 + 420/0**. App adoption + browser-axe 0b ships in the paired modelrails_base PR (AAA certified by that PR's CI). No new color cell shipped, so the existing 0b rows already cover every shipped (variant,tone).