### PR TITLE
feat(ui): repair FormFieldComponent — bound label/ids/aria wiring (B1)

### DIFF
--- a/lib/generators/modelrails_ui/add/templates/form_field/form_field_component.rb.tt
+++ b/lib/generators/modelrails_ui/add/templates/form_field/form_field_component.rb.tt
@@ -1,51 +1,89 @@
 # frozen_string_literal: true
 
 module UI
-  # Wraps a label + input + optional hint and error message into a consistent field layout.
+  # # Form Field
   #
-  # Usage:
-  #   <%= ui :form_field, label: "Email", error: @user.errors[:email].first do %>
-  #     <%= ui :input, type: "email", name: "user[email]", id: "user_email" %>
+  # Wraps a caption + control + optional hint and error into one AAA-correct field:
+  # it binds the `<label for>` to the control, gives the hint/error real ids that the
+  # control references via `aria-describedby`, and injects `invalid`/`required` into
+  # the control. The control arrives as a block, so the component yields its field
+  # context (`input_attrs`) and the caller spreads it onto any control:
+  #
+  #   <%= ui :form_field, label: "Email", hint: "We'll never share it.",
+  #         error: @user.errors[:email].first, required: true do |f| %>
+  #     <%= ui :input, type: "email", name: "user[email]", **f.input_attrs %>
   #   <% end %>
+  #
+  # ## Use when
+  # - You're composing a single labelled field by hand (a one-off form, or a control
+  #   the `TailwindFormBuilder` doesn't cover). For model-backed forms, prefer the
+  #   builder — it already does this wiring.
+  #
+  # ## Accessibility contract
+  # - **Guarantees:** a `<label for=id>` bound to the control; hint/error rendered with
+  #   ids `#{id}-hint`/`#{id}-error`; and `input_attrs` carrying `id` +
+  #   `describedby` (the hint/error ids → the control's `aria-describedby`) +
+  #   `invalid` (on error) + `required`. The required marker is a decorative
+  #   aria-hidden `*` on the Label — the caption never carries the requirement.
+  # - **You supply:** the control inside the block, spread with `**f.input_attrs` so it
+  #   adopts the field's id and aria wiring.
   class FormFieldComponent < ApplicationComponent
+    # data-slot adjacency rhythm (the Catalyst model): label→control 12px,
+    # control→description 8px, description→description 4px. Self-contained Tailwind
+    # arbitrary variants keyed on the children's data-slot — no host CSS needed.
+    WRAPPER = "[&>[data-slot=label]+[data-slot=control]]:mt-3 " \
+              "[&>[data-slot=control]+[data-slot=description]]:mt-2 " \
+              "[&>[data-slot=description]+[data-slot=description]]:mt-1"
+
     def initialize(label: nil, hint: nil, error: nil, required: false, **html_attrs)
       @label = label
       @hint = hint
       @error = error
       @required = required
+      @id = html_attrs.delete(:id) || "form_field_#{object_id}"
+      @describedby = [("#{@id}-hint" if @hint.present?), ("#{@id}-error" if @error.present?)].compact.join(" ").presence
       @extra_class = html_attrs.delete(:class)
       @html_attrs = html_attrs
     end
 
+    # The wiring the slotted control must spread (`**f.input_attrs`): id +
+    # aria-describedby (hint/error ids) + invalid + required. Mirrors exactly what
+    # TailwindFormBuilder injects into the controls it renders itself.
+    def input_attrs
+      { id: @id, describedby: @describedby, invalid: @error.present?, required: @required }
+    end
+
     def call
-      content_tag(:div, class: cn("space-y-1.5", @extra_class), **@html_attrs) do
-        concat field_label if @label
-        concat content
-        concat hint_tag if @hint && @error.blank?
-        concat error_tag if @error.present?
+      content_tag(:div, class: cn(WRAPPER, @extra_class), **@html_attrs) do
+        safe_join([
+          field_label,
+          content_tag(:div, content, data: { slot: "control" }),
+          hint_tag,
+          error_tag
+        ].compact)
       end
     end
 
     private
 
+    # The caption, via the Label primitive: a real `for=` association + the decorative
+    # aria-hidden `*` required mark. data-slot=label drives the adjacency spacing.
     def field_label
-      content_tag(:label,
-        label_text,
-        class: "text-sm font-medium leading-none")
-    end
+      return unless @label
 
-    def label_text
-      return @label unless @required
-
-      safe_join([@label, content_tag(:span, " *", class: "text-danger")])
+      render(UI::LabelComponent.new(@label, for: @id, required: @required, data: { slot: "label" }))
     end
 
     def hint_tag
-      content_tag(:p, @hint, class: "text-xs text-text-muted")
+      return unless @hint.present?
+
+      content_tag(:p, @hint, id: "#{@id}-hint", class: "text-sm text-text-muted", data: { slot: "description" })
     end
 
     def error_tag
-      content_tag(:p, @error, class: "text-xs text-danger", role: "alert")
+      return unless @error.present?
+
+      content_tag(:p, @error, id: "#{@id}-error", role: "alert", class: "text-sm text-danger", data: { slot: "description" })
     end
   end
 end

--- a/lib/generators/modelrails_ui/lookbook/templates/previews/ui/form_field_component_preview.rb
+++ b/lib/generators/modelrails_ui/lookbook/templates/previews/ui/form_field_component_preview.rb
@@ -1,0 +1,40 @@
+# frozen_string_literal: true
+
+module UI
+  # # Form Field
+  #
+  # A hand-composed labelled field: binds `<label for>` to the control, gives the
+  # hint/error real ids referenced by the control's `aria-describedby`, and injects
+  # `invalid`/`required`. The control arrives as a block; spread `**f.input_attrs`
+  # onto it to adopt the field's id + aria wiring.
+  #
+  # ## Use when
+  # - Composing a one-off labelled field by hand. For model-backed forms, prefer the
+  #   app's form builder — it already does this wiring.
+  #
+  # ## Accessibility contract
+  # - **Guarantees:** a bound `<label for=id>`, hint/error with `#{id}-hint`/`#{id}-error`
+  #   ids, and `input_attrs` carrying id + describedby + invalid + required. The
+  #   required `*` is a decorative aria-hidden mark on the label.
+  # - **You supply:** the control inside the block, spread with `**f.input_attrs`.
+  class FormFieldComponentPreview < ViewComponent::Preview
+    include UIHelper
+
+    # Label + control, no hint or error.
+    def default
+    end
+
+    # A hint paragraph (id #{id}-hint) referenced by the control's aria-describedby.
+    def with_hint
+    end
+
+    # An error paragraph (role=alert, id #{id}-error) — the control gets aria-invalid
+    # and aria-describedby pointing at it.
+    def with_error
+    end
+
+    # A required field — decorative `*` on the label; the control carries `required`.
+    def required
+    end
+  end
+end

--- a/lib/generators/modelrails_ui/lookbook/templates/previews/ui/form_field_component_preview/default.html.erb
+++ b/lib/generators/modelrails_ui/lookbook/templates/previews/ui/form_field_component_preview/default.html.erb
@@ -1,0 +1,3 @@
+<%= ui :form_field, label: "Email", id: "preview_email" do |f| %>
+  <%= ui :input, type: "email", name: "email", **f.input_attrs %>
+<% end %>

--- a/lib/generators/modelrails_ui/lookbook/templates/previews/ui/form_field_component_preview/required.html.erb
+++ b/lib/generators/modelrails_ui/lookbook/templates/previews/ui/form_field_component_preview/required.html.erb
@@ -1,0 +1,3 @@
+<%= ui :form_field, label: "Email", required: true, id: "preview_email" do |f| %>
+  <%= ui :input, type: "email", name: "email", **f.input_attrs %>
+<% end %>

--- a/lib/generators/modelrails_ui/lookbook/templates/previews/ui/form_field_component_preview/with_error.html.erb
+++ b/lib/generators/modelrails_ui/lookbook/templates/previews/ui/form_field_component_preview/with_error.html.erb
@@ -1,0 +1,3 @@
+<%= ui :form_field, label: "Email", error: "is not a valid address", id: "preview_email" do |f| %>
+  <%= ui :input, type: "email", name: "email", value: "not-an-email", **f.input_attrs %>
+<% end %>

--- a/lib/generators/modelrails_ui/lookbook/templates/previews/ui/form_field_component_preview/with_hint.html.erb
+++ b/lib/generators/modelrails_ui/lookbook/templates/previews/ui/form_field_component_preview/with_hint.html.erb
@@ -1,0 +1,3 @@
+<%= ui :form_field, label: "Email", hint: "We'll never share it.", id: "preview_email" do |f| %>
+  <%= ui :input, type: "email", name: "email", **f.input_attrs %>
+<% end %>

--- a/test/render/form_field_render_test.rb
+++ b/test/render/form_field_render_test.rb
@@ -1,0 +1,66 @@
+# frozen_string_literal: true
+
+require "render_test_helper"
+# FormFieldComponent renders the Label primitive, so both must be loaded.
+load_component "label", "label_component.rb.tt"
+load_component "form_field", "form_field_component.rb.tt"
+
+class FormFieldRenderTest < ViewComponent::TestCase
+  def render_field(**opts)
+    render_inline(UI::FormFieldComponent.new(id: "user_email", label: "Email", **opts)) do
+      "CONTROL"
+    end
+  end
+
+  def test_label_is_bound_to_the_control_with_for
+    render_field
+
+    assert_selector "label[for='user_email']", text: "Email"
+  end
+
+  def test_control_is_wrapped_in_a_data_slot_control_group
+    render_field
+
+    assert_selector "[data-slot='control']", text: "CONTROL"
+  end
+
+  def test_hint_has_an_id_and_description_slot
+    render_field(hint: "No spam.")
+
+    assert_selector "p#user_email-hint[data-slot='description']", text: "No spam."
+  end
+
+  def test_error_has_an_id_alert_role_and_description_slot
+    render_field(error: "is required")
+
+    assert_selector "p#user_email-error[role='alert'][data-slot='description']", text: "is required"
+  end
+
+  def test_label_carries_the_data_slot_for_adjacency_spacing
+    render_field
+
+    assert_selector "label[data-slot='label']"
+  end
+
+  def test_input_attrs_expose_the_full_wiring
+    c = UI::FormFieldComponent.new(id: "user_email", label: "Email", hint: "h", error: "e", required: true)
+
+    assert_equal(
+      {id: "user_email", describedby: "user_email-hint user_email-error", invalid: true, required: true},
+      c.input_attrs
+    )
+  end
+
+  def test_input_attrs_describedby_is_nil_with_no_hint_or_error
+    c = UI::FormFieldComponent.new(id: "user_email", label: "Email")
+
+    assert_nil c.input_attrs[:describedby]
+    refute c.input_attrs[:invalid]
+  end
+
+  def test_required_marker_is_decorative_on_the_label
+    render_field(required: true)
+
+    assert_selector "label span[aria-hidden='true']", text: "*"
+  end
+end

--- a/test/test_lookbook_previews_template_backed.rb
+++ b/test/test_lookbook_previews_template_backed.rb
@@ -13,7 +13,8 @@ class TestLookbookPreviewsTemplateBacked < Minitest::Test
     "input" => %w[default required invalid dont_raw_input],
     "textarea" => %w[default invalid dont_raw_textarea],
     "file_input" => %w[default images_only multiple dont_raw_file_input],
-    "avatar" => %w[image initials custom_hue dont_interactive_no_label]
+    "avatar" => %w[image initials custom_hue dont_interactive_no_label],
+    "form_field" => %w[default with_hint with_error required]
   }.freeze
 
   def preview_rb(component)


### PR DESCRIPTION
## Converged-conventions B1 (convention pass, Plan 3)

The standalone `UI::FormFieldComponent` was a **broken parallel path** to the (correct) form builder: its `<label>` had no `for`, its hint/error `<p>`s had no `id`, and it never injected `describedby`/`invalid`/`required` into the slotted control. Rewrite it as a thin correct mirror of the builder's wiring:

- mint one field `id`; render the caption via the **Label primitive** (`for: id`, decorative aria-hidden `*`);
- wrap the slotted control in a `data-slot=control` **group** (per the B1 input-group guard);
- render hint/error as `data-slot=description` `<p>`s with `#{id}-hint`/`#{id}-error` ids;
- **yield the field context** via `input_attrs` (id + describedby + invalid + required) so the caller spreads it onto any control — `<%= ui :input, **f.input_attrs %>`. The control arrives as a block, so yielding is the only way to wire it without making the component a divergent reimplementation of the builder.
- vertical rhythm via the Catalyst **data-slot-adjacency** model as self-contained arbitrary-variant classes (no host CSS).

### Scope
Gem-only repair of a component that is **unused/unadopted** in the host app today (the app's real forms use the already-correct `TailwindFormBuilder`, untouched). Fixes a latent footgun + brings `form_field` toward **proven**.

### Verification
0a render test (label `for` bound, hint/error ids, `input_attrs` wiring, decorative required marker) + a template-backed Lookbook preview (default/with_hint/with_error/required). Gem suite **470/0 + 428/0**. The app adoption + browser-axe 0b ship in the paired modelrails_base PR (AAA certifies in that PR's CI).