### PR TITLE
feat(ui): harden display-2 band — aspect_ratio/card/banner/list_group/chat_bubble/footer

### DIFF
--- a/COMPONENT_STATUS.md
+++ b/COMPONENT_STATUS.md
@@ -39,6 +39,12 @@ without extra verification.
 | indicator | proven | ✅ | ✅ | Wave 3 (raw palette → semantic success/warning + text-on-interactive; fail-loud variant) |
 | image | proven | ✅ | ✅ | Wave 3 (required alt; loading-mode validation; conditional srcset/sizes/width/height) |
 | figure | proven | ✅ | ✅ | Wave 3 (figcaption only when caption given; text-text-muted is AAA here) |
+| aspect_ratio | hardened | ✅ | ⏳ | Display-2 (presentational ratio wrapper; already clean — layout-only `overflow-hidden`, no enum so no fail-loud; slotted media carries its own a11y). 0a render test; app 0b/AAA CI pending |
+| card | hardened | ✅ | ⏳ | Display-2 (bare `border` → `border-border`; card_title hardcoded `<h3>` heading-hijack → caller-owned `level:` + fail-loud guard + `text-text-heading`). 0a render test; app 0b/AAA CI pending |
+| banner | hardened | ✅ | ⏳ | Display-2 (raw palette → tinted signal tokens; `role=region` + i18n aria-label; fail-loud variant; dismissible close button w/ focus-ring + co-located `banner_controller.js`). 0a render test; app 0b/AAA CI pending |
+| list_group | hardened | ✅ | ⏳ | Display-2 (invalid `<a>`-in-`<ul>` → `li>a`; added link focus-ring + aria-current=page on active; fail-loud variant). 0a render test; app 0b/AAA CI pending |
+| chat_bubble | hardened | ✅ | ⏳ | Display-2 (who-spoke by color/alignment alone → always-present sr-only direction label + optional author; received `text-text-heading`→`text-text-body`; fail-loud on non-boolean sent). 0a render test; app 0b/AAA CI pending |
+| footer | hardened | ✅ | ⏳ | Display-2 (`<footer>` contentinfo landmark; link columns are heading + `<ul>`/`<li>`/`<a>`; added the missing `focus-ring` on links; interpolated `md:grid-cols-#{n}` phantom class → static COLS map; optional i18n `label:` for multi-footer pages). 0a render test; app 0b/AAA CI pending |
 | dialog | proven | ✅ | ✅ | Wave 4 overlays exemplar (native <dialog>; 0a + JS-behavior 0b: open/escape/aria-modal + AAA on live modal). Was adopted unverified; now app-adopted + 0b green (#241) |
 | alert_dialog | proven | ✅ | ✅ | native `<dialog role=alertdialog>` (Wave 4); shared `modal` controller; 0a render test + role/labelledby/describedby + 44px i18n close |
 | drawer | proven | ✅ | ✅ | native bottom `<dialog>` slide-up (Wave 4); shared `modal` controller (translateY); decorative drag-handle + 44px close; 0a |

--- a/lib/generators/modelrails_ui/add/templates/banner/banner_component.rb.tt
+++ b/lib/generators/modelrails_ui/add/templates/banner/banner_component.rb.tt
@@ -1,29 +1,141 @@
 # frozen_string_literal: true
 
 module UI
+  # # Banner
+  #
+  # A prominent page-level announcement strip — a promo, cookie notice, or system
+  # message that spans the top of a page or section. Renders a labelled `region`
+  # landmark and, when `dismissible:`, a real `<button>` to close it.
+  #
+  # ## Use when
+  # - A standalone, page-level announcement: "We just shipped 2.0", a cookie
+  #   consent strip, a scheduled-maintenance heads-up.
+  #
+  # ## Don't use when
+  # - It's an inline message tied to surrounding content (a form-error summary, an
+  #   empty-state notice) — use `alert`, which carries `role="alert"`/`status`.
+  # - It's an ephemeral flash — use the app's toast system.
+  #
+  # ## Accessibility contract
+  # - **Guarantees:** a `role="region"` landmark named by an i18n `aria-label` (so
+  #   assistive tech can find and skip it), AAA-contrast text, and — when
+  #   `dismissible:` — a real focusable `<button>` with an i18n accessible name
+  #   ("Dismiss") and the `focus-ring` utility. A banner is NOT a live region: it
+  #   is present on load, not announced, so it carries no `role="alert"`/`status`.
+  # - **You supply:** the message (positional, `message:`/`label:`, or slot) and a
+  #   valid `variant` (an unknown one raises in development).
+  #
+  # ## Dismiss behavior
+  # When `dismissible:`, the banner root carries `data-controller="banner"` and the
+  # trailing close button fires `banner#dismiss`, which removes the strip (immediate,
+  # so it behaves under prefers-reduced-motion). The controller ships co-located
+  # (`banner_controller.js`) and is auto-registered by the generator. Persistence
+  # across page loads (a stable id + storage policy) is the host app's call — extend
+  # the controller if you need it.
+  #
+  # ## Variants
+  # `default` · `info` · `success` · `warning` · `destructive`
+  # Signal variants use the tinted-surface treatment (`bg-<signal>-surface` +
+  # `border-<signal>-border` + `text-<signal>`), never a solid signal fill.
   class BannerComponent < ApplicationComponent
     BASE = "flex items-center gap-3 rounded-lg border p-4 text-sm"
 
+    # Signal variants share the tinted-surface treatment used by `alert` and the
+    # toast cards (`bg-<signal>-surface` + `border-<signal>-border` + `text-<signal>`).
+    # Base signal tokens are TEXT colors, so the fill is the dedicated `-surface`
+    # token — never `bg-<signal>` (a solid fill) or an opacity hack like `bg-<signal>/10`.
     VARIANTS = {
-      default:     "bg-surface-raised text-text-heading",
-      info:        "border-blue-200 bg-blue-50 text-blue-900",
-      warning:     "border-yellow-200 bg-yellow-50 text-yellow-900",
-      destructive: "border-danger-border/40 bg-danger/10 text-danger",
-      success:     "border-green-200 bg-green-50 text-green-900"
+      default:     "bg-surface-raised border-border text-text-body",
+      info:        "bg-info-surface border-info-border text-info",
+      success:     "bg-success-surface border-success-border text-success",
+      warning:     "bg-warning-surface border-warning-border text-warning",
+      destructive: "bg-danger-surface border-danger-border text-danger"
     }.freeze
 
-    def initialize(message = nil, variant: :default, **html_attrs)
-      @message = message || html_attrs.delete(:message) || html_attrs.delete(:label)
-      @variant = variant.to_sym
+    # message:     banner text — positional, `message:`, or `label:` keyword, or block content
+    # variant:     visual style (unknown raises in development)
+    # dismissible: render a trailing close <button> (needs the `banner` controller to act)
+    # label:       region accessible name (i18n; defaults to t("ui.banner.label", default: "Announcement"))
+    def initialize(message = nil, variant: :default, dismissible: false, label: nil, **html_attrs)
+      @message = message || html_attrs.delete(:message)
+      @variant = resolve_variant(variant)
+      @dismissible = dismissible
+      @region_label = label
       @extra_class = html_attrs.delete(:class)
       @html_attrs = html_attrs
     end
 
     def call
-      content_tag(:div,
-        content.presence || @message,
-        class: cn(BASE, VARIANTS.fetch(@variant, VARIANTS[:default]), @extra_class),
-        **@html_attrs)
+      content_tag(:div, banner_body,
+        **@html_attrs,
+        role: "region",
+        "aria-label": region_label,
+        class: cn(BASE, VARIANTS.fetch(@variant), @extra_class),
+        data: dismiss_root_data)
+    end
+
+    private
+
+    # t() is resolved at RENDER time (here, not in initialize — no view context there).
+    def region_label
+      @region_label || t("ui.banner.label", default: "Announcement")
+    end
+
+    def banner_body
+      safe_join([message_content, dismiss_button].compact)
+    end
+
+    def message_content
+      content_tag(:div, content.presence || @message, class: "flex-1")
+    end
+
+    # The dismiss control is a real <button> (focusable, keyboard-operable) with an
+    # i18n accessible name and the `focus-ring` utility (NEVER focus:ring-* — clipped /
+    # forced-colors-mode fails). It hooks the `banner` controller's dismiss action.
+    def dismiss_button
+      return unless @dismissible
+
+      content_tag(:button, dismiss_icon,
+        type: "button",
+        "aria-label": dismiss_label,
+        class: "-m-1 shrink-0 rounded-md p-1 text-current hover:opacity-80 focus-ring",
+        data: { action: "banner#dismiss" })
+    end
+
+    def dismiss_root_data
+      @dismissible ? { controller: "banner" } : {}
+    end
+
+    def dismiss_label
+      t("ui.banner.dismiss", default: "Dismiss")
+    end
+
+    # Fail loud on an unknown variant in development/test so misuse is caught
+    # immediately; fall back to :default in production so a bad variant never 500s
+    # a page. The Rails.respond_to?(:env) guard stays correct even when the Rails
+    # module is defined but Rails.env isn't booted (the gem's Rails-less render
+    # tests load rails/generators, which defines Rails without Rails.env).
+    def resolve_variant(variant)
+      variant = variant.to_sym
+      return variant if VARIANTS.key?(variant)
+
+      unless defined?(Rails) && Rails.respond_to?(:env) && Rails.env.production?
+        raise ArgumentError,
+          "UI::BannerComponent: unknown variant #{variant.inspect}. " \
+          "Expected one of: #{VARIANTS.keys.join(", ")}."
+      end
+
+      :default
+    end
+
+    def dismiss_icon
+      if helpers.respond_to?(:icon)
+        helpers.icon(:x_mark, size: :sm)
+      else
+        raw('<svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" viewBox="0 0 24 24" fill="none" ' \
+            'stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true">' \
+            '<path d="M18 6 6 18"/><path d="m6 6 12 12"/></svg>')
+      end
     end
   end
 end

--- a/lib/generators/modelrails_ui/add/templates/banner/banner_controller.js
+++ b/lib/generators/modelrails_ui/add/templates/banner/banner_controller.js
@@ -1,0 +1,14 @@
+import { Controller } from "@hotwired/stimulus"
+
+// Dismiss for the banner announcement strip. The controller sits on the banner root
+// (data-controller="banner"); the trailing close button fires banner#dismiss. Removal
+// is immediate (no transition) so it behaves correctly under prefers-reduced-motion.
+//
+// Persistence (keeping a banner dismissed across page loads) is intentionally the host
+// app's call — it needs a stable banner identity + a storage policy (cookie/localStorage).
+// Extend this controller in the app if you need it; the primitive just removes the node.
+export default class extends Controller {
+  dismiss() {
+    this.element.remove()
+  }
+}

--- a/lib/generators/modelrails_ui/add/templates/card/card_component.rb.tt
+++ b/lib/generators/modelrails_ui/add/templates/card/card_component.rb.tt
@@ -1,8 +1,30 @@
 # frozen_string_literal: true
 
 module UI
+  # # Card
+  #
+  # A presentational content container, optionally composed of header / content /
+  # footer regions via the sibling sub-components. The card itself is a plain
+  # `<div>` — it carries NO document structure. Any heading lives inside, supplied
+  # by `card_title` (or your own markup), so the card never hijacks the outline.
+  #
+  # ## Use when
+  # - Grouping related content into a bordered, raised surface (a settings panel,
+  #   a summary tile, a media object).
+  #
+  # ## Don't use when
+  # - The whole card should be a link/button — a card is a static container by
+  #   contract. Put a real focusable `link`/`button` inside it instead of making
+  #   the `<div>` interactive (a clickable `<div>` is not keyboard-reachable).
+  #
+  # ## Accessibility contract
+  # - **Guarantees:** AAA-contrast `text-text-body` on `bg-surface-raised`, a
+  #   semantic `border-border` rule, and a system `shadow-sm` (no raw color/shadow).
+  #   The container is non-interactive and adds no ARIA role — it is a neutral box.
+  # - **You supply:** the heading (via `card_title`, whose level you set with
+  #   `level:`) and any focusable controls inside `card_content` / `card_footer`.
   class CardComponent < ApplicationComponent
-    BASE = "bg-surface-raised text-text-body flex flex-col gap-6 rounded-xl border py-6 shadow-sm"
+    BASE = "bg-surface-raised text-text-body flex flex-col gap-6 rounded-xl border border-border py-6 shadow-sm"
 
     def initialize(**html_attrs)
       @extra_class = html_attrs.delete(:class)

--- a/lib/generators/modelrails_ui/add/templates/card/card_title_component.rb.tt
+++ b/lib/generators/modelrails_ui/add/templates/card/card_title_component.rb.tt
@@ -1,17 +1,51 @@
 # frozen_string_literal: true
 
 module UI
-  class CardTitleComponent < ApplicationComponent
-    BASE = "leading-none font-semibold"
+  # # Card title
+  #
+  # The heading inside a card. It is a real heading element so it participates in
+  # the document outline — which means the CALLER owns its level. It defaults to
+  # `<h3>` (a card usually sits under an `<h2>` section), but you MUST pass `level:`
+  # whenever that default would skip or misorder the page's heading hierarchy.
+  #
+  # ## Accessibility contract
+  # - **Guarantees:** renders a real `<h1>`–`<h6>` (never a styled `<div>`) using
+  #   the `text-text-heading` token; an out-of-range `level:` fails loud in dev and
+  #   falls back to `<h3>` in production rather than emitting invalid markup.
+  # - **You supply:** the correct `level:` for where this card sits in the outline.
+  LEVELS = (1..6).freeze
+  DEFAULT_LEVEL = 3
 
-    def initialize(title = nil, **html_attrs)
+  class CardTitleComponent < ApplicationComponent
+    BASE = "text-text-heading leading-none font-semibold"
+
+    def initialize(title = nil, level: DEFAULT_LEVEL, **html_attrs)
       @title = title || html_attrs.delete(:label) || html_attrs.delete(:title)
+      @level = resolve_level(level)
       @extra_class = html_attrs.delete(:class)
       @html_attrs = html_attrs
     end
 
     def call
-      content_tag(:h3, content.presence || @title, class: cn(BASE, @extra_class), **@html_attrs)
+      content_tag(:"h#{@level}", content.presence || @title, class: cn(BASE, @extra_class), **@html_attrs)
+    end
+
+    private
+
+    # Fail loud on an out-of-range level in development/test so a skipped/invalid
+    # heading is caught immediately; fall back to <h3> in production so a bad level
+    # never emits invalid markup. The Rails.respond_to?(:env) guard stays correct
+    # even when the Rails module is defined but Rails.env isn't booted (the gem's
+    # Rails-less tests load rails/generators, which defines Rails without Rails.env).
+    def resolve_level(level)
+      return level.to_i if LEVELS.include?(level.to_i)
+
+      unless defined?(Rails) && Rails.respond_to?(:env) && Rails.env.production?
+        raise ArgumentError,
+          "UI::CardTitleComponent: level: must be 1-6, got #{level.inspect}."
+      end
+
+      DEFAULT_LEVEL
     end
   end
 end

--- a/lib/generators/modelrails_ui/add/templates/chat_bubble/chat_bubble_component.rb.tt
+++ b/lib/generators/modelrails_ui/add/templates/chat_bubble/chat_bubble_component.rb.tt
@@ -1,38 +1,76 @@
 # frozen_string_literal: true
 
 module UI
+  # # ChatBubble
+  #
+  # A single message bubble for a chat or comment transcript. Purely presentational:
+  # it styles *one* message (sent vs received) and optionally shows the author,
+  # timestamp, and a decorative avatar. It is NOT the transcript itself — wrap a
+  # sequence of bubbles in your own log/list container (that container, not this
+  # bubble, would carry `role="log"`).
+  #
+  # ## Use when
+  # - Rendering an individual message in a chat thread, comment list, or support inbox.
+  #
+  # ## Don't use when
+  # - You need who-spoke conveyed by alignment/color alone — pass `author:` (or rely
+  #   on the sr-only direction label) so a screen-reader user knows the speaker.
+  # - You want the bubble to be interactive — it is a presentational `<div>`.
+  #
+  # ## Accessibility contract
+  # - **Guarantees:** the speaker is *always perceivable* in text, never by alignment
+  #   or color alone — a visible `author:` when given, otherwise an sr-only
+  #   "You said" / "They said" direction label (i18n via `t` with English defaults).
+  #   AAA-contrast bubble fills (`bg-interactive` + `text-text-on-interactive` for
+  #   sent; `bg-surface-sunken` + `text-text-body` for received), AAA `text-text-muted`
+  #   timestamp, and a decorative avatar/tail that is `aria-hidden`.
+  # - **You supply:** the message body via slot content; optionally `author:`,
+  #   `timestamp:`, and an `avatar:` URL (received messages only).
   class ChatBubbleComponent < ApplicationComponent
-    # sent: true  → right-aligned, primary-colored bubble
-    # sent: false → left-aligned, muted bubble (default)
-
     BUBBLE_BASE = "max-w-[80%] rounded-2xl px-4 py-2 text-sm leading-relaxed"
-    BUBBLE_SENT = "bg-interactive text-text-on-interactive rounded-br-none"
-    BUBBLE_RECV = "bg-surface-sunken text-text-heading rounded-bl-none"
 
-    TIMESTAMP_BASE = "mt-1 text-xs text-text-muted"
+    # Sent uses a SOLID interactive fill with adaptive on-color (white in light, dark
+    # in dark) — AAA. Received uses the sunken surface with body text — AAA. Body copy
+    # is text-text-body, never text-text-heading (heading token is for headings).
+    VARIANTS = {
+      sent:     "bg-interactive text-text-on-interactive rounded-br-none",
+      received: "bg-surface-sunken text-text-body rounded-bl-none"
+    }.freeze
 
-    # sent:      true for outgoing messages, false for incoming (default)
-    # timestamp: optional time string rendered below the bubble
-    # avatar:    optional URL for a small avatar image (incoming only)
-    def initialize(sent: false, timestamp: nil, avatar: nil, **html_attrs)
-      @sent      = sent
-      @timestamp = timestamp
-      @avatar    = avatar
+    ALIGN = {
+      sent:     "flex-row-reverse",
+      received: "flex-row"
+    }.freeze
+
+    META_BASE = "mt-1 flex items-baseline gap-2 text-xs text-text-muted"
+
+    # sent:      true for outgoing messages, false for incoming (default).
+    # author:    optional speaker name, shown above the bubble. When omitted, an
+    #            sr-only direction label still makes the speaker perceivable.
+    # timestamp: optional time string rendered with the meta line.
+    # avatar:    optional URL for a small decorative avatar (received messages only).
+    def initialize(sent: false, author: nil, timestamp: nil, avatar: nil, **html_attrs)
+      @variant     = coerce_variant(sent)
+      @author      = author
+      @timestamp   = timestamp
+      @avatar      = avatar
       @extra_class = html_attrs.delete(:class)
       @html_attrs  = html_attrs
     end
 
     def call
-      wrapper_cls = cn("flex items-end gap-2", @sent ? "flex-row-reverse" : "flex-row", @extra_class)
+      wrapper_cls = cn("flex items-end gap-2", ALIGN.fetch(@variant), @extra_class)
 
       content_tag(:div, class: wrapper_cls, **@html_attrs) do
-        concat avatar_img if @avatar && !@sent
+        concat avatar_img if @avatar && @variant == :received
         concat bubble_block
       end
     end
 
     private
 
+    # Decorative — the speaker is conveyed by text (author/sr-only label), so the
+    # avatar adds nothing for AT and carries empty alt + aria-hidden.
     def avatar_img
       content_tag(:img, nil,
         src: @avatar,
@@ -42,12 +80,50 @@ module UI
     end
 
     def bubble_block
-      content_tag(:div, class: cn("flex flex-col", @sent ? "items-end" : "items-start")) do
-        concat content_tag(:div, content,
-          class: cn(BUBBLE_BASE, @sent ? BUBBLE_SENT : BUBBLE_RECV))
-        concat content_tag(:p, @timestamp,
-          class: TIMESTAMP_BASE) if @timestamp
+      content_tag(:div, class: cn("flex flex-col", @variant == :sent ? "items-end" : "items-start")) do
+        concat speaker_label
+        concat content_tag(:div, content, class: cn(BUBBLE_BASE, VARIANTS.fetch(@variant)))
+        concat meta_line if @author || @timestamp
       end
+    end
+
+    # The speaker is NEVER conveyed by alignment/color alone. A named author is shown
+    # visibly in the meta line; the direction (you vs them) is always announced via an
+    # sr-only label so an SR user knows who spoke regardless of visual side.
+    def speaker_label
+      content_tag(:span, direction_label, class: "sr-only")
+    end
+
+    def meta_line
+      content_tag(:p, class: META_BASE) do
+        concat content_tag(:span, @author) if @author
+        concat content_tag(:span, @timestamp) if @timestamp
+      end
+    end
+
+    def direction_label
+      key = @variant == :sent ? "sent" : "received"
+      default = @variant == :sent ? "You said" : "They said"
+      I18n.t("modelrails_ui.chat_bubble.#{key}", default: default)
+    end
+
+    # Fail loud on an unknown variant in development/test so misuse is caught
+    # immediately; fall back to :received in production so a bad value never 500s a
+    # page. `sent:` is the boolean public API — true→:sent, false→:received — but a
+    # caller passing anything else (e.g. a stray string) is a real bug, not a third
+    # variant. The Rails.respond_to?(:env) guard stays correct even when Rails is
+    # defined but not booted (the gem's Rails-less render tests).
+    def coerce_variant(sent)
+      return :sent if sent == true
+      return :received if sent == false || sent.nil?
+
+      unless defined?(Rails) && Rails.respond_to?(:env) && Rails.env.production?
+        raise ArgumentError,
+          "UI::ChatBubbleComponent: unknown sent value #{sent.inspect}. " \
+          "Expected true (sent) or false (received)."
+      end
+
+      :received
     end
   end
 end

--- a/lib/generators/modelrails_ui/add/templates/footer/footer_component.rb.tt
+++ b/lib/generators/modelrails_ui/add/templates/footer/footer_component.rb.tt
@@ -1,20 +1,54 @@
 # frozen_string_literal: true
 
 module UI
+  # # Footer
+  #
+  # A page/site footer — the `<footer>` contentinfo landmark with optional link
+  # columns (each a heading + a real `<ul>` of `<a>`), an optional block-content
+  # area, and an optional copyright row below a divider.
+  #
+  # ## Use when
+  # - Closing a page with site-wide navigation (product / company / legal columns),
+  #   social/legal links, and a copyright line.
+  #
+  # ## Don't use when
+  # - You only need an inline list of links inside an article — that isn't the
+  #   page's contentinfo landmark. Use a plain `<ul>`.
+  #
+  # ## Accessibility contract
+  # - **Guarantees:** a `<footer>` (contentinfo landmark); each column is a real
+  #   heading + `<ul>`/`<li>`/`<a>`; links carry the `focus-ring` utility (a visible
+  #   AAA focus outline); AAA-contrast text on `bg-surface-raised`. Pass `label:`
+  #   (i18n) to name the landmark when a page has more than one footer.
+  # - **You supply:** `columns:` (`[{ title:, links: [{ label:, href: }] }]`) and/or
+  #   block content and/or `copyright:`. Every link needs a human-readable `label:`
+  #   (its accessible name) and an `href:`.
   class FooterComponent < ApplicationComponent
     BASE = "border-t bg-surface-raised"
-    LINK = "text-sm text-text-muted hover:text-text-heading transition-colors"
+    LINK = "rounded-sm text-sm text-text-muted transition-colors " \
+           "hover:text-text-heading " \
+           "focus-ring focus-visible:text-text-heading"
 
-    # columns: [{ title:, links: [{ label:, href: }] }]
-    def initialize(copyright: nil, columns: [], **html_attrs)
+    # Literal grid-cols classes per column count — Tailwind only sees statically
+    # present class strings, so an interpolated `md:grid-cols-#{n}` would be a
+    # phantom class that never compiles. Caps at 4 columns wide.
+    COLS = {
+      1 => "md:grid-cols-1", 2 => "md:grid-cols-2",
+      3 => "md:grid-cols-3", 4 => "md:grid-cols-4"
+    }.freeze
+
+    # columns: [{ title:, links: [{ label:, href: }] }]. copyright: bottom-row text.
+    # label: the <footer> accessible name (i18n; only needed when a page has 2+ footers).
+    def initialize(copyright: nil, columns: [], label: nil, **html_attrs)
       @copyright = copyright
       @columns   = columns
+      @label     = label
       @extra_class = html_attrs.delete(:class)
       @html_attrs  = html_attrs
     end
 
     def call
-      content_tag(:footer, class: cn(BASE, @extra_class), **@html_attrs) do
+      content_tag(:footer, class: cn(BASE, @extra_class), "aria-label": @label, **@html_attrs) do
         content_tag(:div, class: "container mx-auto px-6 py-10") do
           concat columns_grid if @columns.any?
           concat content if content?
@@ -26,7 +60,7 @@ module UI
     private
 
     def columns_grid
-      content_tag(:div, class: "grid gap-8 sm:grid-cols-2 md:grid-cols-#{[@columns.size, 4].min} mb-10") do
+      content_tag(:div, class: cn("mb-10 grid gap-8 sm:grid-cols-2", COLS[[@columns.size, 4].min])) do
         safe_join(@columns.map { |col| column(col) })
       end
     end
@@ -43,7 +77,7 @@ module UI
     end
 
     def copyright_row
-      content_tag(:div, class: "border-t pt-8 mt-8 text-center") do
+      content_tag(:div, class: "mt-8 border-t pt-8 text-center") do
         content_tag(:p, @copyright, class: "text-sm text-text-muted")
       end
     end

--- a/lib/generators/modelrails_ui/add/templates/list_group/list_group_component.rb.tt
+++ b/lib/generators/modelrails_ui/add/templates/list_group/list_group_component.rb.tt
@@ -1,8 +1,21 @@
 # frozen_string_literal: true
 
 module UI
+  # # ListGroup
+  #
+  # A styled vertical list of rows — static items, navigation links, or actions.
+  # Renders a real `<ul>`; each child is a `list_group_item` (`<li>`, or an `<a>`
+  # wrapped in `<li>` when navigable). Accessibility hinges on this semantics: a
+  # static list is a `<ul>`/`<li>`, a list of links is a `<ul>` of `<a>`, and
+  # interactive rows are real focusable elements — never `<div>` rows.
+  #
+  # ## Accessibility contract
+  # - **Guarantees:** a semantic `<ul>` on a token surface (`bg-surface`,
+  #   `border-border`, `divide-border` between rows). Row semantics and focus
+  #   handling live in `list_group_item`.
+  # - **You supply:** the rows, via `list_group_item` (slot/block content).
   class ListGroupComponent < ApplicationComponent
-    BASE = "divide-y divide-border overflow-hidden rounded-lg border"
+    BASE = "divide-y divide-border overflow-hidden rounded-lg border border-border bg-surface"
 
     def initialize(**html_attrs)
       @extra_class = html_attrs.delete(:class)

--- a/lib/generators/modelrails_ui/add/templates/list_group/list_group_item_component.rb.tt
+++ b/lib/generators/modelrails_ui/add/templates/list_group/list_group_item_component.rb.tt
@@ -1,8 +1,28 @@
 # frozen_string_literal: true
 
 module UI
+  # # ListGroupItem
+  #
+  # A single row inside a `list_group`. Semantics follow interactivity: a static
+  # row is a plain `<li>`; a navigable row is an `<a>` wrapped in its `<li>` (an
+  # `<a>` is not a valid direct child of `<ul>`). A clickable row is a real focusable
+  # element, never a `<div>` with a click handler.
+  #
+  # ## Accessibility contract
+  # - **Guarantees:** AAA-contrast tokens (`text-text-heading`/`text-text-muted` on
+  #   `bg-surface`; the active row is a solid `bg-interactive` fill with adaptive
+  #   `text-text-on-interactive`). Link rows are real `<a>` elements inside `<li>`,
+  #   carry the `focus-ring` utility, and — when active — `aria-current="page"`.
+  #   A non-interactive row is never made focusable. An unknown `variant` raises
+  #   in development.
+  # - **You supply:** the row text (positional arg, `label:`, or slot content); an
+  #   `href:` to make the row a link; `active: true` to mark the current row.
   class ListGroupItemComponent < ApplicationComponent
     BASE = "flex items-center justify-between px-4 py-3 text-sm"
+
+    # Interactive (link) rows get the shared focus-ring utility (AAA offset outline)
+    # plus token-based hover/active — never focus:ring-* and never raw colors.
+    LINK = "focus-ring transition-colors"
 
     VARIANTS = {
       default: "text-text-heading hover:bg-surface-sunken",
@@ -13,19 +33,56 @@ module UI
     def initialize(label = nil, href: nil, active: false, variant: :default, **html_attrs)
       @label = label || html_attrs.delete(:label)
       @href = href
-      @variant = active ? :active : variant.to_sym
+      @active = active
+      @variant = coerce_variant(active ? :active : variant.to_sym)
       @extra_class = html_attrs.delete(:class)
       @html_attrs = html_attrs
     end
 
     def call
-      tag_name = @href ? :a : :li
-      extra = @href ? { href: @href } : {}
-      content_tag(tag_name,
-        content.presence || @label,
-        class: cn(BASE, VARIANTS.fetch(@variant, VARIANTS[:default]), @extra_class),
-        **extra,
+      @href ? link_row : static_row
+    end
+
+    private
+
+    # A navigable row: <a> inside its <li>. The link carries the row styling, the
+    # focus-ring, and aria-current="page" when it is the active page.
+    def link_row
+      content_tag(:li) do
+        content_tag(:a, body,
+          href: @href,
+          class: cn(BASE, LINK, VARIANTS.fetch(@variant), @extra_class),
+          "aria-current": (@active ? "page" : nil),
+          **@html_attrs)
+      end
+    end
+
+    # A static row: a plain, non-interactive <li>. Never focusable.
+    def static_row
+      content_tag(:li, body,
+        class: cn(BASE, VARIANTS.fetch(@variant), @extra_class),
         **@html_attrs)
+    end
+
+    def body
+      content.presence || @label
+    end
+
+    # Fail loud on an unknown variant in development/test so misuse is caught
+    # immediately; fall back to :default in production so a bad variant never
+    # 500s a page. The Rails.respond_to?(:env) guard stays correct even when the
+    # Rails module is defined but Rails.env isn't booted (the gem's Rails-less
+    # render tests load rails/generators, which defines Rails without Rails.env).
+    def coerce_variant(variant)
+      return variant if VARIANTS.key?(variant)
+
+      unless defined?(Rails) && Rails.respond_to?(:env) && Rails.env.production?
+        raise ArgumentError,
+          "UI::ListGroupItemComponent: unknown variant #{variant.inspect}. " \
+          "Expected one of: #{VARIANTS.keys.join(", ")}."
+      end
+
+      :default
     end
   end
 end

--- a/lib/generators/modelrails_ui/lookbook/templates/previews/ui/aspect_ratio_component_preview.rb
+++ b/lib/generators/modelrails_ui/lookbook/templates/previews/ui/aspect_ratio_component_preview.rb
@@ -1,0 +1,43 @@
+# frozen_string_literal: true
+
+module UI
+  # # Aspect Ratio
+  #
+  # A layout wrapper that constrains its slotted content to a fixed aspect ratio
+  # (e.g. `16 / 9`) via the CSS `aspect-ratio` property. Purely presentational and
+  # non-interactive — it frames media, it is never itself a target.
+  #
+  # ## Use when
+  # - Embedding media that must hold a ratio regardless of width: a video `<iframe>`,
+  #   a responsive `<img>`, a map, a thumbnail.
+  #
+  # ## Don't use when
+  # - There is no content to frame — an empty ratio box reserves space for nothing.
+  # - The content already has intrinsic dimensions you want to respect — let it size
+  #   itself instead of clipping it to a forced ratio.
+  #
+  # ## Accessibility contract
+  # - **Guarantees:** a presentational wrapper with no role, no tabindex, and no
+  #   focus ring — it adds nothing for assistive tech to announce.
+  # - **You supply:** slotted media that carries its own a11y (an `<img>` with `alt`,
+  #   an `<iframe>` with `title`, etc.). The wrapper does not speak for it.
+  class AspectRatioComponentPreview < ViewComponent::Preview
+    include UIHelper
+
+    # Widescreen 16:9 framing an image.
+    def default
+    end
+
+    # A square (1:1) thumbnail.
+    def square
+    end
+
+    # ## Don't — an empty ratio box
+    #
+    # With no slotted content the wrapper reserves layout space for nothing and
+    # announces nothing. Give it media to frame, or drop the wrapper entirely.
+    # @label Don't · no content
+    def dont_no_content
+    end
+  end
+end

--- a/lib/generators/modelrails_ui/lookbook/templates/previews/ui/aspect_ratio_component_preview/default.html.erb
+++ b/lib/generators/modelrails_ui/lookbook/templates/previews/ui/aspect_ratio_component_preview/default.html.erb
@@ -1,0 +1,6 @@
+<%= ui :aspect_ratio, ratio: "16 / 9", class: "rounded-lg" do %>
+  <%= ui :image,
+        src: "https://picsum.photos/id/1015/800/450",
+        alt: "A river winding between forested cliffs",
+        class: "size-full object-cover" %>
+<% end %>

--- a/lib/generators/modelrails_ui/lookbook/templates/previews/ui/aspect_ratio_component_preview/dont_no_content.html.erb
+++ b/lib/generators/modelrails_ui/lookbook/templates/previews/ui/aspect_ratio_component_preview/dont_no_content.html.erb
@@ -1,0 +1,2 @@
+<%# ✗ Empty wrapper — reserves a 16:9 layout box that frames and announces nothing. Give it media or drop the wrapper. %>
+<%= ui :aspect_ratio, ratio: "16 / 9", class: "w-64 border border-border" %>

--- a/lib/generators/modelrails_ui/lookbook/templates/previews/ui/aspect_ratio_component_preview/square.html.erb
+++ b/lib/generators/modelrails_ui/lookbook/templates/previews/ui/aspect_ratio_component_preview/square.html.erb
@@ -1,0 +1,6 @@
+<%= ui :aspect_ratio, ratio: 1, class: "w-48 rounded-lg" do %>
+  <%= ui :image,
+        src: "https://picsum.photos/id/237/400/400",
+        alt: "A black puppy sitting on a wooden floor",
+        class: "size-full object-cover" %>
+<% end %>

--- a/lib/generators/modelrails_ui/lookbook/templates/previews/ui/banner_component_preview.rb
+++ b/lib/generators/modelrails_ui/lookbook/templates/previews/ui/banner_component_preview.rb
@@ -1,0 +1,53 @@
+# frozen_string_literal: true
+
+module UI
+  # # Banner
+  #
+  # A prominent page-level announcement strip (promo / cookie / system notice).
+  # Renders a labelled `region` landmark and, when `dismissible:`, a real
+  # focusable close `<button>`.
+  #
+  # ## Use when
+  # - A standalone, page-level announcement: "We shipped 2.0", a cookie strip, a
+  #   scheduled-maintenance heads-up.
+  #
+  # ## Don't use when
+  # - It's an inline message tied to surrounding content — use `alert`.
+  # - It's an ephemeral flash — use the app's toast system.
+  #
+  # ## Accessibility contract
+  # - **Guarantees:** a `role="region"` landmark named by an i18n `aria-label`,
+  #   AAA-contrast text, and — when `dismissible:` — a real focusable `<button>`
+  #   with an i18n accessible name and the `focus-ring` utility.
+  # - **You supply:** the message, a valid `variant`, and (for a working dismiss)
+  #   the `banner` Stimulus controller, which the gem does not yet ship.
+  #
+  # ## Variants
+  # `default` · `info` · `success` · `warning` · `destructive`
+  class BannerComponentPreview < ViewComponent::Preview
+    include UIHelper
+
+    # Neutral page-level announcement on the raised surface.
+    def default
+    end
+
+    # Informational signal on the info-tinted surface.
+    def info
+    end
+
+    # A dismissible cookie/consent strip — the trailing close button is a real
+    # focusable <button> with an i18n accessible name + focus-ring. (Acting on the
+    # click needs the `banner` Stimulus controller, which the gem does not yet ship.)
+    def dismissible
+    end
+
+    # ## Don't — a dismiss control without an accessible name
+    #
+    # An icon-only close button with no `aria-label` is an unnamed button to screen
+    # readers ("button"). The component always names it (i18n "Dismiss"); never
+    # hand-roll a bare icon `<button>` in its place.
+    # @label Don't · dismiss with no label
+    def dont_dismiss_no_label
+    end
+  end
+end

--- a/lib/generators/modelrails_ui/lookbook/templates/previews/ui/banner_component_preview/default.html.erb
+++ b/lib/generators/modelrails_ui/lookbook/templates/previews/ui/banner_component_preview/default.html.erb
@@ -1,0 +1,1 @@
+<%= ui :banner, "We just released version 2.0 — see what's new." %>

--- a/lib/generators/modelrails_ui/lookbook/templates/previews/ui/banner_component_preview/dismissible.html.erb
+++ b/lib/generators/modelrails_ui/lookbook/templates/previews/ui/banner_component_preview/dismissible.html.erb
@@ -1,0 +1,1 @@
+<%= ui :banner, "We use cookies to improve your experience.", dismissible: true %>

--- a/lib/generators/modelrails_ui/lookbook/templates/previews/ui/banner_component_preview/dont_dismiss_no_label.html.erb
+++ b/lib/generators/modelrails_ui/lookbook/templates/previews/ui/banner_component_preview/dont_dismiss_no_label.html.erb
@@ -1,0 +1,8 @@
+<%# ✗ A bare icon-only close button with no aria-label is announced as just "button". %>
+<%# The component always names its dismiss control (i18n "Dismiss") — never hand-roll this. %>
+<div role="region" aria-label="Announcement" class="flex items-center gap-3 rounded-lg border border-border bg-surface-raised p-4 text-sm text-text-body">
+  <div class="flex-1">We use cookies to improve your experience.</div>
+  <button type="button" class="-m-1 shrink-0 rounded-md p-1 text-current focus-ring">
+    <svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><path d="M18 6 6 18"/><path d="m6 6 12 12"/></svg>
+  </button>
+</div>

--- a/lib/generators/modelrails_ui/lookbook/templates/previews/ui/banner_component_preview/info.html.erb
+++ b/lib/generators/modelrails_ui/lookbook/templates/previews/ui/banner_component_preview/info.html.erb
@@ -1,0 +1,1 @@
+<%= ui :banner, "Scheduled maintenance this Sunday, 02:00–04:00 UTC.", variant: :info %>

--- a/lib/generators/modelrails_ui/lookbook/templates/previews/ui/card_component_preview.rb
+++ b/lib/generators/modelrails_ui/lookbook/templates/previews/ui/card_component_preview.rb
@@ -1,0 +1,46 @@
+# frozen_string_literal: true
+
+module UI
+  # # Card
+  #
+  # A presentational content container composed of optional header / content /
+  # footer regions. The card itself is a neutral `<div>` and carries no document
+  # structure — the heading inside (`card_title`) is the only structural piece, and
+  # the CALLER owns its level via `level:`.
+  #
+  # ## Use when
+  # - Grouping related content into a bordered, raised surface (settings panel,
+  #   summary tile, media object).
+  #
+  # ## Don't use when
+  # - The whole card should be a link/button — put a real focusable `link`/`button`
+  #   inside it; never make the container `<div>` itself interactive.
+  #
+  # ## Accessibility contract
+  # - **Guarantees:** AAA `text-text-body` on `bg-surface-raised`, a semantic
+  #   `border-border` rule, and a system shadow (no raw color/shadow). The container
+  #   is non-interactive and adds no ARIA role.
+  # - **You supply:** the heading via `card_title` (set `level:` so it sits correctly
+  #   in the page outline) and any focusable controls inside the regions.
+  class CardComponentPreview < ViewComponent::Preview
+    include UIHelper
+
+    # Title + description in a header, with body content.
+    def default
+    end
+
+    # The full composition — header, content, and a footer action bar.
+    def with_footer
+    end
+
+    # ## Don't — skip a heading level
+    #
+    # `card_title` renders a real heading, so its `level:` must follow the page
+    # outline. Dropping an `<h3>` directly under an `<h1>` skips `<h2>` and breaks
+    # navigation for screen-reader users. Pass the `level:` that fits where the card
+    # sits (here, `level: 2` under the page's `<h1>`).
+    # @label Don't · skip a heading level
+    def dont_heading_misuse
+    end
+  end
+end

--- a/lib/generators/modelrails_ui/lookbook/templates/previews/ui/card_component_preview/default.html.erb
+++ b/lib/generators/modelrails_ui/lookbook/templates/previews/ui/card_component_preview/default.html.erb
@@ -1,0 +1,9 @@
+<%= ui :card, class: "max-w-sm" do %>
+  <%= ui :card_header do %>
+    <%= ui :card_title, "Account settings", level: 2 %>
+    <%= ui :card_description, "Manage your account preferences." %>
+  <% end %>
+  <%= ui :card_content do %>
+    <p class="text-sm text-text-body">Update your name, email, and notification choices.</p>
+  <% end %>
+<% end %>

--- a/lib/generators/modelrails_ui/lookbook/templates/previews/ui/card_component_preview/dont_heading_misuse.html.erb
+++ b/lib/generators/modelrails_ui/lookbook/templates/previews/ui/card_component_preview/dont_heading_misuse.html.erb
@@ -1,0 +1,9 @@
+<h1 class="text-text-heading mb-4 text-xl font-bold">Settings</h1>
+
+<%# ✗ Under an <h1>, the next heading should be <h2> — the default <h3> skips a level. %>
+<%= ui :card, class: "max-w-sm" do %>
+  <%= ui :card_header do %>
+    <%= ui :card_title, "Profile" %>
+    <%= ui :card_description, "Default level: 3 skips <h2> here — pass level: 2 instead." %>
+  <% end %>
+<% end %>

--- a/lib/generators/modelrails_ui/lookbook/templates/previews/ui/card_component_preview/with_footer.html.erb
+++ b/lib/generators/modelrails_ui/lookbook/templates/previews/ui/card_component_preview/with_footer.html.erb
@@ -1,0 +1,13 @@
+<%= ui :card, class: "max-w-sm" do %>
+  <%= ui :card_header do %>
+    <%= ui :card_title, "Delete project", level: 2 %>
+    <%= ui :card_description, "This permanently removes the project and its data." %>
+  <% end %>
+  <%= ui :card_content do %>
+    <p class="text-sm text-text-body">You can export your data before deleting.</p>
+  <% end %>
+  <%= ui :card_footer, class: "justify-end gap-2" do %>
+    <%= ui :button, "Cancel", variant: :secondary %>
+    <%= ui :button, "Delete", variant: :destructive %>
+  <% end %>
+<% end %>

--- a/lib/generators/modelrails_ui/lookbook/templates/previews/ui/chat_bubble_component_preview.rb
+++ b/lib/generators/modelrails_ui/lookbook/templates/previews/ui/chat_bubble_component_preview.rb
@@ -1,0 +1,51 @@
+# frozen_string_literal: true
+
+module UI
+  # # ChatBubble
+  #
+  # A single message bubble for a chat or comment transcript. Presentational — it
+  # styles *one* message (sent vs received) with an optional author, timestamp, and
+  # decorative avatar. It is not the transcript: wrap a sequence in your own log
+  # container (that container, not the bubble, carries `role="log"`).
+  #
+  # ## Use when
+  # - Rendering an individual message in a chat thread, comment list, or inbox.
+  #
+  # ## Don't use when
+  # - Who-spoke is conveyed by alignment/color alone — pass `author:` (or rely on the
+  #   sr-only direction label) so a screen-reader user knows the speaker.
+  # - You need it interactive — it is a presentational `<div>`.
+  #
+  # ## Accessibility contract
+  # - **Guarantees:** the speaker is always perceivable in text (visible `author:` or
+  #   an sr-only "You said" / "They said" label), AAA bubble fills (`bg-interactive` +
+  #   `text-text-on-interactive` sent; `bg-surface-sunken` + `text-text-body`
+  #   received), an AAA `text-text-muted` timestamp, and a decorative `aria-hidden`
+  #   avatar.
+  # - **You supply:** the body via slot content; optionally `author:`, `timestamp:`,
+  #   and an `avatar:` URL (received only).
+  class ChatBubbleComponentPreview < ViewComponent::Preview
+    include UIHelper
+
+    # An outgoing message — right-aligned interactive fill.
+    def sent
+    end
+
+    # An incoming message (default) — left-aligned sunken surface.
+    def received
+    end
+
+    # With a named author and timestamp shown in the meta line.
+    def with_meta
+    end
+
+    # ## Don't — speaker conveyed by color/alignment only
+    #
+    # Sighted users read the side and fill to tell who spoke, but with no `author:`
+    # and the sr-only direction label stripped, a screen-reader user gets nothing.
+    # Keep the direction label (or pass `author:`).
+    # @label Don't · color-only author
+    def dont_color_only_author
+    end
+  end
+end

--- a/lib/generators/modelrails_ui/lookbook/templates/previews/ui/chat_bubble_component_preview/dont_color_only_author.html.erb
+++ b/lib/generators/modelrails_ui/lookbook/templates/previews/ui/chat_bubble_component_preview/dont_color_only_author.html.erb
@@ -1,0 +1,11 @@
+<%# ✗ Who spoke is shown only by side + fill. Sighted users infer it; with no author: %>
+<%# and the sr-only direction label removed, a screen-reader user would get nothing. %>
+<%# Keep the built-in sr-only label, or pass author: to name the speaker. %>
+<div class="flex flex-col gap-4">
+  <%= ui :chat_bubble do %>
+    Did you get my last message?
+  <% end %>
+  <%= ui :chat_bubble, sent: true do %>
+    Yes — replying now.
+  <% end %>
+</div>

--- a/lib/generators/modelrails_ui/lookbook/templates/previews/ui/chat_bubble_component_preview/received.html.erb
+++ b/lib/generators/modelrails_ui/lookbook/templates/previews/ui/chat_bubble_component_preview/received.html.erb
@@ -1,0 +1,3 @@
+<%= ui :chat_bubble do %>
+  Hello! How can I help you today?
+<% end %>

--- a/lib/generators/modelrails_ui/lookbook/templates/previews/ui/chat_bubble_component_preview/sent.html.erb
+++ b/lib/generators/modelrails_ui/lookbook/templates/previews/ui/chat_bubble_component_preview/sent.html.erb
@@ -1,0 +1,3 @@
+<%= ui :chat_bubble, sent: true do %>
+  I'd like to book an appointment.
+<% end %>

--- a/lib/generators/modelrails_ui/lookbook/templates/previews/ui/chat_bubble_component_preview/with_meta.html.erb
+++ b/lib/generators/modelrails_ui/lookbook/templates/previews/ui/chat_bubble_component_preview/with_meta.html.erb
@@ -1,0 +1,8 @@
+<div class="flex flex-col gap-4">
+  <%= ui :chat_bubble, author: "Ada Lovelace", timestamp: "10:32 AM" do %>
+    I'll check and get back to you shortly.
+  <% end %>
+  <%= ui :chat_bubble, sent: true, author: "You", timestamp: "10:34 AM" do %>
+    Sounds great, see you then!
+  <% end %>
+</div>

--- a/lib/generators/modelrails_ui/lookbook/templates/previews/ui/footer_component_preview.rb
+++ b/lib/generators/modelrails_ui/lookbook/templates/previews/ui/footer_component_preview.rb
@@ -1,0 +1,46 @@
+# frozen_string_literal: true
+
+module UI
+  # # Footer
+  #
+  # A page/site footer — the `<footer>` contentinfo landmark with optional link
+  # columns (heading + real `<ul>`/`<a>`), an optional block-content area, and an
+  # optional copyright row below a divider.
+  #
+  # ## Use when
+  # - Closing a page with site-wide navigation (product / company / legal columns),
+  #   social/legal links, and a copyright line.
+  #
+  # ## Don't use when
+  # - You only need an inline list of links inside an article — that isn't the page's
+  #   contentinfo landmark. Use a plain `<ul>`.
+  #
+  # ## Accessibility contract
+  # - **Guarantees:** a `<footer>` contentinfo landmark; each column is a heading +
+  #   `<ul>`/`<li>`/`<a>`; links carry the `focus-ring` utility (visible AAA focus
+  #   outline); AAA-contrast text on `bg-surface-raised`.
+  # - **You supply:** `columns:` (`[{ title:, links: [{ label:, href: }] }]`),
+  #   `copyright:`, optional block content, and `label:` (i18n) to name the landmark
+  #   when a page has more than one footer. Every link needs a readable `label:` (its
+  #   accessible name) and an `href:`.
+  class FooterComponentPreview < ViewComponent::Preview
+    include UIHelper
+
+    # Full footer — link columns plus a copyright row.
+    def default
+    end
+
+    # Just a copyright / legal line — no columns.
+    def minimal
+    end
+
+    # ## Don't — non-semantic link rows
+    #
+    # Flowing links inside `<div>`s (or links with no `href`/accessible name) aren't a
+    # navigable list to assistive tech. Pass `columns:` so each group renders a real
+    # heading + `<ul>`/`<li>`/`<a>` with the focus-ring.
+    # @label Don't · div link rows
+    def dont_div_links
+    end
+  end
+end

--- a/lib/generators/modelrails_ui/lookbook/templates/previews/ui/footer_component_preview/default.html.erb
+++ b/lib/generators/modelrails_ui/lookbook/templates/previews/ui/footer_component_preview/default.html.erb
@@ -1,0 +1,7 @@
+<%= ui :footer,
+       copyright: "© 2026 Acme Inc. All rights reserved.",
+       columns: [
+         { title: "Product", links: [{ label: "Features", href: "#" }, { label: "Pricing", href: "#" }, { label: "Changelog", href: "#" }] },
+         { title: "Company", links: [{ label: "About",    href: "#" }, { label: "Blog",    href: "#" }, { label: "Careers",   href: "#" }] },
+         { title: "Legal",   links: [{ label: "Privacy",  href: "#" }, { label: "Terms",   href: "#" }] }
+       ] %>

--- a/lib/generators/modelrails_ui/lookbook/templates/previews/ui/footer_component_preview/dont_div_links.html.erb
+++ b/lib/generators/modelrails_ui/lookbook/templates/previews/ui/footer_component_preview/dont_div_links.html.erb
@@ -1,0 +1,16 @@
+<%# ✗ Hand-rolled footer: <div> rows of links (not a <ul>) and an icon-only %>
+<%# social link with no accessible name. Screen readers can't list these as %>
+<%# navigation, and the icon link announces only its href. Pass `columns:` instead. %>
+<footer class="border-t bg-surface-raised">
+  <div class="container mx-auto px-6 py-10">
+    <div class="mb-10 flex flex-wrap gap-6">
+      <div class="text-sm text-text-muted">Features</div>
+      <div class="text-sm text-text-muted">Pricing</div>
+      <div class="text-sm text-text-muted">About</div>
+      <a href="#" class="text-text-muted">
+        <svg width="20" height="20" viewBox="0 0 24 24" fill="currentColor" aria-hidden="true"><circle cx="12" cy="12" r="10"/></svg>
+      </a>
+    </div>
+    <p class="text-sm text-text-muted">© 2026 Acme Inc.</p>
+  </div>
+</footer>

--- a/lib/generators/modelrails_ui/lookbook/templates/previews/ui/footer_component_preview/minimal.html.erb
+++ b/lib/generators/modelrails_ui/lookbook/templates/previews/ui/footer_component_preview/minimal.html.erb
@@ -1,0 +1,1 @@
+<%= ui :footer, copyright: "© 2026 Acme Inc. All rights reserved." %>

--- a/lib/generators/modelrails_ui/lookbook/templates/previews/ui/list_group_component_preview.rb
+++ b/lib/generators/modelrails_ui/lookbook/templates/previews/ui/list_group_component_preview.rb
@@ -1,0 +1,45 @@
+# frozen_string_literal: true
+
+module UI
+  # # ListGroup
+  #
+  # A styled vertical list of rows — static items, navigation links, or actions.
+  # Renders a real `<ul>` of `<li>`; navigable rows are an `<a>` inside `<li>`.
+  #
+  # ## Use when
+  # - You have a short, related set of rows: a settings menu, a sidebar of links,
+  #   a list of records, a stack of choices.
+  #
+  # ## Don't use when
+  # - The rows are tabular data with columns — use a `data_table`.
+  # - You need `<div>` rows with click handlers — that breaks list semantics and
+  #   keyboard access. Use real `<a>`/`<button>` rows (see the Don't below).
+  #
+  # ## Accessibility contract
+  # - **Guarantees:** a semantic `<ul>` on a token surface; link rows are real
+  #   `<a>` elements inside `<li>` with the `focus-ring` utility; the active link
+  #   carries `aria-current="page"`; static rows are never made focusable.
+  # - **You supply:** the rows via `list_group_item` (text or block content),
+  #   `href:` for navigable rows, and `active: true` on the current page.
+  class ListGroupComponentPreview < ViewComponent::Preview
+    include UIHelper
+
+    # Static rows — a plain <ul> of <li>, with a muted row for de-emphasis.
+    def default
+    end
+
+    # Navigable rows — each is an <a> inside its <li>, with the current page
+    # marked `active: true` (renders `aria-current="page"`).
+    def links
+    end
+
+    # ## Don't — non-semantic <div> rows
+    #
+    # Building rows as <div>s with click handlers is invisible to assistive tech
+    # and unreachable by keyboard. Use a real `<a>` (href:) or `<button>` row so
+    # the list stays a `<ul>`/`<li>` and every interactive row is focusable.
+    # @label Don't · div rows
+    def dont_div_rows
+    end
+  end
+end

--- a/lib/generators/modelrails_ui/lookbook/templates/previews/ui/list_group_component_preview/default.html.erb
+++ b/lib/generators/modelrails_ui/lookbook/templates/previews/ui/list_group_component_preview/default.html.erb
@@ -1,0 +1,6 @@
+<%= ui :list_group do %>
+  <%= ui :list_group_item, "Dashboard" %>
+  <%= ui :list_group_item, "Settings" %>
+  <%= ui :list_group_item, "Billing" %>
+  <%= ui :list_group_item, "Help", variant: :muted %>
+<% end %>

--- a/lib/generators/modelrails_ui/lookbook/templates/previews/ui/list_group_component_preview/dont_div_rows.html.erb
+++ b/lib/generators/modelrails_ui/lookbook/templates/previews/ui/list_group_component_preview/dont_div_rows.html.erb
@@ -1,0 +1,10 @@
+<%# ✗ <div> rows with click handlers: not a list, not focusable, invisible to AT. %>
+<%# Use ui :list_group with link/button rows instead — real <ul>/<li> + <a>/<button>. %>
+<div class="divide-y divide-border overflow-hidden rounded-lg border border-border bg-surface">
+  <div class="flex items-center justify-between px-4 py-3 text-sm text-text-heading" data-action="click->nav#go">
+    Dashboard
+  </div>
+  <div class="flex items-center justify-between px-4 py-3 text-sm text-text-heading" data-action="click->nav#go">
+    Settings
+  </div>
+</div>

--- a/lib/generators/modelrails_ui/lookbook/templates/previews/ui/list_group_component_preview/links.html.erb
+++ b/lib/generators/modelrails_ui/lookbook/templates/previews/ui/list_group_component_preview/links.html.erb
@@ -1,0 +1,6 @@
+<%# Each row is an <a> inside its <li>; the active row renders aria-current="page" %>
+<%= ui :list_group do %>
+  <%= ui :list_group_item, "Home",    href: "#" %>
+  <%= ui :list_group_item, "Profile", href: "#", active: true %>
+  <%= ui :list_group_item, "Logout",  href: "#" %>
+<% end %>

--- a/test/render/aspect_ratio_render_test.rb
+++ b/test/render/aspect_ratio_render_test.rb
@@ -1,0 +1,48 @@
+# frozen_string_literal: true
+
+require "render_test_helper"
+load_component "aspect_ratio", "aspect_ratio_component.rb.tt"
+
+class AspectRatioRenderTest < ViewComponent::TestCase
+  def test_renders_the_ratio_wrapper_with_slotted_content
+    render_inline(UI::AspectRatioComponent.new) { "<img src='/x.jpg' alt='x'>".html_safe }
+
+    assert_selector "div img[src='/x.jpg']"
+  end
+
+  # AAA semantic tokens / layout-only utilities — no raw color, no off-system class.
+  # The wrapper is presentational, so the only base utility is the clip that keeps
+  # slotted media inside the ratio box.
+  def test_renders_with_layout_only_base_classes
+    render_inline(UI::AspectRatioComponent.new) { "content" }
+
+    assert_selector "div.overflow-hidden"
+  end
+
+  # Non-interactive by contract — a layout wrapper is never a focus/pointer target,
+  # so it carries no role, no tabindex, and no focus ring.
+  def test_is_a_presentational_wrapper
+    render_inline(UI::AspectRatioComponent.new) { "content" }
+
+    assert_no_selector "div[role]"
+    assert_no_selector "div[tabindex]"
+  end
+
+  def test_applies_the_default_square_ratio
+    render_inline(UI::AspectRatioComponent.new) { "content" }
+
+    assert_selector "div[style*='aspect-ratio: 1']"
+  end
+
+  def test_applies_a_custom_ratio
+    render_inline(UI::AspectRatioComponent.new(ratio: "16 / 9")) { "content" }
+
+    assert_selector "div[style*='aspect-ratio: 16 / 9']"
+  end
+
+  def test_merges_caller_classes
+    render_inline(UI::AspectRatioComponent.new(class: "mt-2")) { "content" }
+
+    assert_selector "div.overflow-hidden.mt-2"
+  end
+end

--- a/test/render/banner_render_test.rb
+++ b/test/render/banner_render_test.rb
@@ -1,0 +1,78 @@
+# frozen_string_literal: true
+
+require "render_test_helper"
+load_component "banner", "banner_component.rb.tt"
+
+class BannerRenderTest < ViewComponent::TestCase
+  def test_renders_a_region_landmark_with_the_message
+    render_inline(UI::BannerComponent.new("We shipped 2.0!"))
+
+    assert_selector "div[role='region']", text: "We shipped 2.0!"
+  end
+
+  def test_region_has_an_i18n_accessible_name
+    render_inline(UI::BannerComponent.new("Hi"))
+
+    assert_selector "div[role='region'][aria-label='Announcement']"
+  end
+
+  def test_accepts_the_message_via_message_kwarg
+    render_inline(UI::BannerComponent.new(message: "Maintenance Sunday"))
+
+    assert_selector "div[role='region']", text: "Maintenance Sunday"
+  end
+
+  def test_slot_content_takes_precedence_over_the_message
+    render_inline(UI::BannerComponent.new("ignored")) { "From the block" }
+
+    assert_text "From the block"
+    assert_no_text "ignored"
+  end
+
+  # AAA semantic tokens (the design-token guarantee), not raw blue-50/green-50 etc.
+  def test_default_uses_aaa_neutral_tokens
+    render_inline(UI::BannerComponent.new("Hi"))
+
+    assert_selector "div.bg-surface-raised.text-text-body"
+  end
+
+  # Signal variants use the tinted-surface treatment (bg-*-surface + *-border +
+  # text-*), never a solid signal fill.
+  def test_signal_variant_uses_tinted_surface_tokens
+    render_inline(UI::BannerComponent.new("Heads up", variant: :warning))
+
+    assert_selector "div.bg-warning-surface.border-warning-border.text-warning"
+  end
+
+  # Dismiss is a real focusable <button> with an i18n accessible name + focus-ring.
+  def test_dismissible_renders_an_accessible_dismiss_button
+    render_inline(UI::BannerComponent.new("Cookies", dismissible: true))
+
+    assert_selector "button[type='button'][aria-label='Dismiss']"
+  end
+
+  def test_dismiss_button_uses_the_focus_ring_utility
+    render_inline(UI::BannerComponent.new("Cookies", dismissible: true))
+
+    assert_selector "button.focus-ring"
+  end
+
+  def test_not_dismissible_by_default
+    render_inline(UI::BannerComponent.new("Hi"))
+
+    assert_no_selector "button"
+  end
+
+  # Fail loud in development/test so a typo'd variant is caught immediately.
+  def test_unknown_variant_raises
+    error = assert_raises(ArgumentError) { render_inline(UI::BannerComponent.new("x", variant: :nope)) }
+
+    assert_match(/unknown variant/, error.message)
+  end
+
+  def test_merges_caller_classes
+    render_inline(UI::BannerComponent.new("Hi", class: "mt-4"))
+
+    assert_selector "div.mt-4"
+  end
+end

--- a/test/render/card_render_test.rb
+++ b/test/render/card_render_test.rb
@@ -1,0 +1,109 @@
+# frozen_string_literal: true
+
+require "render_test_helper"
+# Card is a compound primitive — the outer container plus five region
+# sub-components. Each is an independent class, so all must be loaded.
+load_component "card", "card_component.rb.tt"
+load_component "card", "card_header_component.rb.tt"
+load_component "card", "card_title_component.rb.tt"
+load_component "card", "card_description_component.rb.tt"
+load_component "card", "card_content_component.rb.tt"
+load_component "card", "card_footer_component.rb.tt"
+
+class CardRenderTest < ViewComponent::TestCase
+  # --- Container ----------------------------------------------------------
+
+  def test_renders_a_plain_div_container_with_slot_content
+    render_inline(UI::CardComponent.new) { "Body" }
+
+    assert_selector "div", text: "Body"
+  end
+
+  # The card is a neutral box — it adds no role and is never a link/button.
+  def test_container_is_non_interactive_with_no_aria_role
+    render_inline(UI::CardComponent.new) { "Body" }
+
+    assert_no_selector "div[role]"
+  end
+
+  # AAA semantic tokens (raised surface + body text + semantic border), never raw.
+  def test_container_uses_aaa_tokens
+    render_inline(UI::CardComponent.new) { "x" }
+
+    assert_selector "div.bg-surface-raised.text-text-body"
+    assert_selector "div.border-border"
+  end
+
+  def test_container_merges_caller_classes
+    render_inline(UI::CardComponent.new(class: "mt-4")) { "x" }
+
+    assert_selector "div.mt-4"
+  end
+
+  # --- Title (the only structural sub-component) --------------------------
+
+  def test_title_defaults_to_h3_with_the_heading_token
+    render_inline(UI::CardTitleComponent.new("Account"))
+
+    assert_selector "h3.text-text-heading", text: "Account"
+  end
+
+  # The caller owns the heading level so the card never hijacks the outline.
+  def test_title_honours_caller_supplied_level
+    render_inline(UI::CardTitleComponent.new("Account", level: 2))
+
+    assert_selector "h2", text: "Account"
+    assert_no_selector "h3"
+  end
+
+  def test_title_accepts_label_kwarg_and_block
+    render_inline(UI::CardTitleComponent.new(label: "From label"))
+
+    assert_selector "h3", text: "From label"
+
+    render_inline(UI::CardTitleComponent.new("ignored")) { "From block" }
+
+    assert_selector "h3", text: "From block"
+  end
+
+  # Fail-loud: an out-of-range level raises in dev/test (Rails.env is non-prod here).
+  def test_title_raises_on_out_of_range_level
+    assert_raises(ArgumentError) { UI::CardTitleComponent.new("x", level: 7) }
+  end
+
+  # --- Description --------------------------------------------------------
+
+  # Muted == body in this token system, so text-text-muted still clears AAA 7:1.
+  def test_description_uses_muted_token
+    render_inline(UI::CardDescriptionComponent.new("Subtitle"))
+
+    assert_selector "p.text-text-muted", text: "Subtitle"
+  end
+
+  # --- Slot composition ---------------------------------------------------
+
+  def test_regions_compose_into_a_single_card
+    vc = vc_test_controller.view_context
+    render_inline(UI::CardComponent.new) do
+      header = UI::CardHeaderComponent.new.render_in(vc) do
+        UI::CardTitleComponent.new("Title").render_in(vc)
+      end
+      footer = UI::CardFooterComponent.new.render_in(vc) { "Footer" }
+      (header + UI::CardContentComponent.new.render_in(vc) { "Body" } + footer).html_safe
+    end
+
+    assert_selector "div h3", text: "Title"
+    assert_selector "div", text: /Body/
+    assert_selector "div", text: /Footer/
+  end
+
+  def test_content_and_footer_merge_caller_classes
+    render_inline(UI::CardContentComponent.new(class: "space-y-2")) { "x" }
+
+    assert_selector "div.space-y-2.px-6"
+
+    render_inline(UI::CardFooterComponent.new(class: "justify-end")) { "x" }
+
+    assert_selector "div.justify-end.px-6"
+  end
+end

--- a/test/render/chat_bubble_render_test.rb
+++ b/test/render/chat_bubble_render_test.rb
@@ -1,0 +1,73 @@
+# frozen_string_literal: true
+
+require "render_test_helper"
+load_component "chat_bubble", "chat_bubble_component.rb.tt"
+
+class ChatBubbleRenderTest < ViewComponent::TestCase
+  def test_sent_uses_the_aaa_interactive_fill
+    render_inline(UI::ChatBubbleComponent.new(sent: true)) { "Hi" }
+
+    assert_selector "div.bg-interactive.text-text-on-interactive", text: "Hi"
+  end
+
+  def test_received_uses_the_aaa_sunken_surface_with_body_text
+    render_inline(UI::ChatBubbleComponent.new(sent: false)) { "Hello" }
+
+    assert_selector "div.bg-surface-sunken.text-text-body", text: "Hello"
+  end
+
+  # Who spoke is perceivable in text, never by alignment/color alone: an sr-only
+  # direction label is always present so a screen-reader user knows the speaker.
+  def test_sent_announces_the_speaker_direction_to_assistive_tech
+    render_inline(UI::ChatBubbleComponent.new(sent: true)) { "Hi" }
+
+    assert_selector "span.sr-only", text: "You said"
+  end
+
+  def test_received_announces_the_speaker_direction_to_assistive_tech
+    render_inline(UI::ChatBubbleComponent.new(sent: false)) { "Hello" }
+
+    assert_selector "span.sr-only", text: "They said"
+  end
+
+  # A named author is shown visibly (perceivable without color/alignment).
+  def test_renders_a_named_author_visibly
+    render_inline(UI::ChatBubbleComponent.new(author: "Ada", timestamp: "10:32")) { "Hi" }
+
+    assert_selector "p span", text: "Ada"
+    assert_selector "p span", text: "10:32"
+  end
+
+  # Timestamps de-emphasize via the AAA muted token (same neutral as body).
+  def test_timestamp_uses_the_aaa_muted_token
+    render_inline(UI::ChatBubbleComponent.new(timestamp: "10:32")) { "Hi" }
+
+    assert_selector "p.text-text-muted", text: "10:32"
+  end
+
+  # The avatar is decorative — empty alt + aria-hidden so it is not announced.
+  def test_received_avatar_is_decorative
+    render_inline(UI::ChatBubbleComponent.new(avatar: "/a.png")) { "Hi" }
+
+    assert_selector "img[alt=''][aria-hidden='true']"
+  end
+
+  # The avatar applies to received messages only.
+  def test_sent_messages_have_no_avatar
+    render_inline(UI::ChatBubbleComponent.new(sent: true, avatar: "/a.png")) { "Hi" }
+
+    assert_no_selector "img"
+  end
+
+  def test_merges_caller_classes
+    render_inline(UI::ChatBubbleComponent.new(class: "mb-4")) { "Hi" }
+
+    assert_selector "div.mb-4"
+  end
+
+  def test_raises_on_an_unknown_sent_value
+    assert_raises(ArgumentError) do
+      render_inline(UI::ChatBubbleComponent.new(sent: "left")) { "Hi" }
+    end
+  end
+end

--- a/test/render/footer_render_test.rb
+++ b/test/render/footer_render_test.rb
@@ -1,0 +1,69 @@
+# frozen_string_literal: true
+
+require "render_test_helper"
+load_component "footer", "footer_component.rb.tt"
+
+class FooterRenderTest < ViewComponent::TestCase
+  COLUMNS = [
+    {title: "Product", links: [{label: "Features", href: "/features"}, {label: "Pricing", href: "/pricing"}]},
+    {title: "Company", links: [{label: "About", href: "/about"}]}
+  ].freeze
+
+  # The contentinfo landmark — a real <footer>, not a styled <div>.
+  def test_renders_a_footer_landmark
+    render_inline(UI::FooterComponent.new(copyright: "© 2026 Acme"))
+
+    assert_selector "footer"
+  end
+
+  # Link groups are real lists, and each link is a real <a> with an accessible name + href.
+  def test_link_columns_are_semantic_lists
+    render_inline(UI::FooterComponent.new(columns: COLUMNS))
+
+    assert_selector "footer h3", text: "Product"
+    assert_selector "footer ul li a[href='/features']", text: "Features"
+  end
+
+  # Every link carries the focus-ring utility (visible AAA focus outline), never focus:ring-*.
+  def test_links_use_the_focus_ring_utility
+    render_inline(UI::FooterComponent.new(columns: COLUMNS))
+
+    assert_selector "footer a.focus-ring", minimum: 3
+    assert_no_selector "footer a[class*='focus:ring-']"
+  end
+
+  # AAA semantic tokens (the design-token guarantee), not raw Tailwind. text-text-muted
+  # resolves to the same neutral as text-text-body here, so it clears AAA 7:1.
+  def test_renders_with_aaa_tokens
+    render_inline(UI::FooterComponent.new(copyright: "© 2026 Acme"))
+
+    assert_selector "footer.bg-surface-raised"
+    assert_selector "footer p.text-text-muted", text: "© 2026 Acme"
+  end
+
+  # Column count maps to a STATIC grid-cols class (no interpolated phantom class).
+  def test_column_count_maps_to_static_grid_class
+    render_inline(UI::FooterComponent.new(columns: COLUMNS))
+
+    assert_selector "footer div.md\\:grid-cols-2"
+  end
+
+  # The landmark is named only when label: is supplied (single footer needs no name).
+  def test_landmark_named_only_when_label_given
+    render_inline(UI::FooterComponent.new(copyright: "© 2026 Acme", label: "Site footer"))
+
+    assert_selector "footer[aria-label='Site footer']"
+  end
+
+  def test_landmark_unnamed_by_default
+    render_inline(UI::FooterComponent.new(copyright: "© 2026 Acme"))
+
+    assert_no_selector "footer[aria-label]"
+  end
+
+  def test_merges_caller_classes
+    render_inline(UI::FooterComponent.new(copyright: "© 2026 Acme", class: "mt-12"))
+
+    assert_selector "footer.mt-12"
+  end
+end

--- a/test/render/list_group_render_test.rb
+++ b/test/render/list_group_render_test.rb
@@ -1,0 +1,82 @@
+# frozen_string_literal: true
+
+require "render_test_helper"
+load_component "list_group", "list_group_component.rb.tt"
+load_component "list_group", "list_group_item_component.rb.tt"
+
+# STRUCTURE-only render specs. The app 0b preview-host spec proves AAA contrast in a
+# real browser; here we assert the semantic scaffolding: a <ul> of <li>, link rows as
+# <a> inside <li> with the focus-ring utility, aria-current on the active link, AAA
+# tokens, and caller-class merge.
+class ListGroupRenderTest < ViewComponent::TestCase
+  # Render an item to an HTML-safe string so it can be composed inside the group's
+  # block, mirroring how views nest `ui :list_group_item` inside `ui :list_group`.
+  def render_item(*args, **kwargs)
+    UI::ListGroupItemComponent.new(*args, **kwargs).render_in(vc_test_controller.view_context)
+  end
+
+  def test_renders_a_ul_with_li_items
+    items = render_item("Dashboard") + render_item("Settings")
+    render_inline(UI::ListGroupComponent.new) { items }
+
+    assert_selector "ul > li", text: "Dashboard"
+    assert_selector "ul > li", text: "Settings"
+  end
+
+  def test_group_uses_aaa_surface_tokens
+    render_inline(UI::ListGroupComponent.new)
+
+    assert_selector "ul.bg-surface.border-border"
+    assert_selector "ul.divide-border"
+  end
+
+  def test_static_item_is_a_plain_non_focusable_li
+    render_inline(UI::ListGroupItemComponent.new("Billing"))
+
+    assert_selector "li.text-text-heading", text: "Billing"
+    assert_no_selector "a"
+  end
+
+  def test_muted_item_uses_the_aaa_muted_token
+    render_inline(UI::ListGroupItemComponent.new("Help", variant: :muted))
+
+    assert_selector "li.text-text-muted", text: "Help"
+  end
+
+  def test_link_item_is_an_anchor_inside_an_li_with_focus_ring
+    render_inline(UI::ListGroupItemComponent.new("Home", href: "/"))
+
+    assert_selector "li > a[href='/'].focus-ring", text: "Home"
+  end
+
+  def test_active_link_carries_aria_current_and_the_solid_fill
+    render_inline(UI::ListGroupItemComponent.new("Profile", href: "/profile", active: true))
+
+    assert_selector "a[aria-current='page'].bg-interactive.text-text-on-interactive", text: "Profile"
+  end
+
+  def test_inactive_link_has_no_aria_current
+    render_inline(UI::ListGroupItemComponent.new("Logout", href: "/logout"))
+
+    assert_no_selector "[aria-current]"
+  end
+
+  def test_slot_content_takes_precedence_over_the_label
+    render_inline(UI::ListGroupItemComponent.new("ignored")) { "Alice" }
+
+    assert_selector "li", text: "Alice"
+    assert_no_text "ignored"
+  end
+
+  def test_merges_caller_classes
+    render_inline(UI::ListGroupItemComponent.new("X", class: "mt-2"))
+
+    assert_selector "li.mt-2"
+  end
+
+  def test_unknown_variant_fails_loud
+    assert_raises(ArgumentError) do
+      render_inline(UI::ListGroupItemComponent.new("X", variant: :bogus))
+    end
+  end
+end

--- a/test/test_components.rb
+++ b/test/test_components.rb
@@ -2047,13 +2047,13 @@ class TestChatBubbleComponent < Minitest::Test
   def test_sent_defaults_to_false
     c = UI::ChatBubbleComponent.new
 
-    refute c.instance_variable_get(:@sent)
+    assert_equal :received, c.instance_variable_get(:@variant)
   end
 
   def test_sent_stored
     c = UI::ChatBubbleComponent.new(sent: true)
 
-    assert c.instance_variable_get(:@sent)
+    assert_equal :sent, c.instance_variable_get(:@variant)
   end
 
   def test_timestamp_nil_by_default

--- a/test/test_generator_components.rb
+++ b/test/test_generator_components.rb
@@ -313,7 +313,7 @@ class TestGeneratorComponents < Minitest::Test
     source = File.read(File.join(TEMPLATE_ROOT, "chat_bubble", "chat_bubble_component.rb.tt"))
 
     assert_includes source, "sent"
-    assert_includes source, "BUBBLE_RECV"
+    assert_includes source, "received"
   end
 
   def test_device_mockup_has_phone_and_browser_variants

--- a/test/test_lookbook_previews_template_backed.rb
+++ b/test/test_lookbook_previews_template_backed.rb
@@ -14,7 +14,13 @@ class TestLookbookPreviewsTemplateBacked < Minitest::Test
     "textarea" => %w[default invalid dont_raw_textarea],
     "file_input" => %w[default images_only multiple dont_raw_file_input],
     "avatar" => %w[image initials custom_hue dont_interactive_no_label],
-    "form_field" => %w[default with_hint with_error required]
+    "form_field" => %w[default with_hint with_error required],
+    "aspect_ratio" => %w[default square dont_no_content],
+    "card" => %w[default with_footer dont_heading_misuse],
+    "banner" => %w[default info dismissible dont_dismiss_no_label],
+    "list_group" => %w[default links dont_div_rows],
+    "chat_bubble" => %w[sent received with_meta dont_color_only_author],
+    "footer" => %w[default minimal dont_div_links]
   }.freeze
 
   def preview_rb(component)


### PR DESCRIPTION
## Display-2 hardening band (6 primitives → 0a + Lookbook previews)

Hardens 6 display primitives to the proven Wave-3 groove (0a render test + template-backed preview). Real a11y/token bugs fixed, not cosmetics:

- **card:** `card_title` hardcoded `<h3>` (silent heading-outline hijack) → caller-owned `level:` + fail-loud guard + `text-text-heading`; bare `border` → `border-border`.
- **banner:** raw palette (`bg-blue-50`/`text-blue-900`…) → tinted signal tokens; `role=region` + i18n aria-label; fail-loud variant; dismissible close button (focus-ring) + the **missing** co-located `banner_controller.js` (auto-registered).
- **list_group:** invalid `<a>`-in-`<ul>` → `li>a`; link focus-ring + `aria-current=page` on active.
- **chat_bubble:** who-spoke by color/alignment alone → always-present sr-only direction label + optional author; received `text-text-heading`→`text-text-body`; fail-loud `sent`.
- **footer:** missing link focus-ring; interpolated `md:grid-cols-#{n}` **phantom class** → static COLS map; optional i18n landmark label.
- **aspect_ratio:** assessed clean (presentational wrapper) — 0a + preview only.

Registers all 6 in the template-backed-preview test; realigns 2 stale chat_bubble structural tests to the new internals. COMPONENT_STATUS: 6 rows `hardened` (app 0b/AAA CI pending). Gem suite **470/0 + 484/0**. App adoption + browser-axe 0b ship in the paired modelrails_base PR.