### PR TITLE
feat(ui): harden disclosure band — collapsible/stepper/button_group/toggle_group (0a)

### DIFF
--- a/lib/generators/modelrails_ui/add/templates/button_group/button_group_component.rb.tt
+++ b/lib/generators/modelrails_ui/add/templates/button_group/button_group_component.rb.tt
@@ -1,6 +1,14 @@
 # frozen_string_literal: true
 
 module UI
+  # Presentational `role="group"` wrapper that segments its children into a single
+  # control: it collapses the inner corners and overlaps the borders so adjacent
+  # buttons read as one bar. Purely visual — it owns no state, JS, or keyboard
+  # behaviour; the children (UI::Button et al.) carry their own a11y contract.
+  #
+  # `aria_label:` is optional: a group benefits from an accessible name, but a
+  # button group is often already labelled by surrounding context, so it is left
+  # to the caller rather than required.
   class ButtonGroupComponent < ApplicationComponent
     BASE = "inline-flex rounded-md shadow-sm " \
            "[&>*]:rounded-none " \
@@ -8,7 +16,8 @@ module UI
            "[&>*:last-child]:rounded-r-md " \
            "[&>*:not(:first-child)]:-ml-px"
 
-    def initialize(**html_attrs)
+    def initialize(aria_label: nil, **html_attrs)
+      @aria_label = aria_label
       @extra_class = html_attrs.delete(:class)
       @html_attrs = html_attrs
     end
@@ -17,6 +26,7 @@ module UI
       content_tag(:div, content,
         class: cn(BASE, @extra_class),
         role: "group",
+        "aria-label": @aria_label,
         **@html_attrs)
     end
   end

--- a/lib/generators/modelrails_ui/add/templates/collapsible/collapsible_component.rb.tt
+++ b/lib/generators/modelrails_ui/add/templates/collapsible/collapsible_component.rb.tt
@@ -1,13 +1,22 @@
 # frozen_string_literal: true
 
 module UI
+  # CSS-only collapse via a native <details>/<summary> disclosure.
+  #
+  # trigger slot: content for the summary row (button, icon, label, etc.)
+  # open:         render pre-expanded (default: false)
+  #
+  # Accessibility contract:
+  # - Native <details>/<summary> carries the disclosure semantics — the summary is
+  #   focusable and toggles on Enter/Space, and the browser manages aria-expanded.
+  # - The summary owns the AAA focus indicator via `focus-ring` (an offset outline,
+  #   never a box-shadow ring: a ring is clipped by overflow-hidden ancestors and
+  #   vanishes in forced-colors mode — a 2.4.7 failure).
+  # - The native webkit disclosure marker is hidden so caller-supplied trigger markup
+  #   owns the open/closed affordance.
   class CollapsibleComponent < ApplicationComponent
-    # CSS-only collapse via native <details>/<summary>.
-    # trigger slot: content for the summary row (button, icon, label, etc.)
-    # open:         render pre-expanded (default: false)
-
     SUMMARY_CLS = "flex cursor-pointer list-none items-center justify-between gap-2 " \
-                  "[&::-webkit-details-marker]:hidden"
+                  "[&::-webkit-details-marker]:hidden focus-ring"
     CONTENT_CLS = "mt-2"
 
     renders_one :trigger
@@ -15,11 +24,11 @@ module UI
     def initialize(open: false, **html_attrs)
       @open = open
       @extra_class = html_attrs.delete(:class)
-      @html_attrs  = html_attrs
+      @html_attrs = html_attrs
     end
 
     def call
-      attrs = { class: cn(@extra_class), **@html_attrs }
+      attrs = {class: cn(@extra_class), **@html_attrs}
       attrs[:open] = true if @open
 
       content_tag(:details, **attrs) do

--- a/lib/generators/modelrails_ui/add/templates/stepper/stepper_component.rb.tt
+++ b/lib/generators/modelrails_ui/add/templates/stepper/stepper_component.rb.tt
@@ -1,11 +1,41 @@
 # frozen_string_literal: true
 
 module UI
+  # # Stepper
+  #
+  # An ordered progress indicator: an `<ol>` of steps, each shown as complete,
+  # current, or pending. It communicates *where you are* in a multi-step flow —
+  # it is NOT interactive navigation (the steps are not links/buttons).
+  #
+  # ## Use when
+  # - Showing progress through a known, ordered sequence (checkout, onboarding,
+  #   a wizard) where the count of steps is fixed and visible.
+  #
+  # ## Don't use when
+  # - Steps are clickable destinations — that is navigation; use links/tabs.
+  # - Progress is a single continuous percentage — use `progress` instead.
+  #
+  # ## Accessibility contract
+  # - **Guarantees:** an `<ol>` with an i18n `aria-label` ("Progress" by default,
+  #   via the `modelrails_ui.stepper.progress` locale key) so the list announces
+  #   its purpose. The current step carries `aria-current="step"`; complete and
+  #   pending circles carry an i18n `aria-label` ("Completed" / "Pending") so the
+  #   status is named, not conveyed by the decorative glyph alone. The check icon
+  #   and the `●`/`○` glyphs are decorative — the check `<svg>` is
+  #   `aria-hidden="true"` and the glyph spans carry their own accessible name.
+  # - **You supply:** a `label:` per step, and a `status:` of `:complete`,
+  #   `:current`, or `:pending` (defaults to `:pending`).
+  #
+  # ## Modes
+  # `orientation: :horizontal` (default) · `orientation: :vertical`.
   class StepperComponent < ApplicationComponent
+    ORIENTATIONS = %i[horizontal vertical].freeze
+    STATUSES = %i[complete current pending].freeze
+
     # steps: [{ label:, description: (optional), status: :complete | :current | :pending }]
     def initialize(steps:, orientation: :horizontal, **html_attrs)
       @steps = steps
-      @orientation = orientation.to_sym
+      @orientation = coerce_orientation(orientation.to_sym)
       @extra_class = html_attrs.delete(:class)
       @html_attrs = html_attrs
     end
@@ -17,7 +47,7 @@ module UI
 
       content_tag(:ol,
         class: cn(wrapper_class, @extra_class),
-        "aria-label": "Progress",
+        "aria-label": I18n.t("modelrails_ui.stepper.progress", default: "Progress"),
         **@html_attrs) do
         safe_join(@steps.each_with_index.map { |step, i| step_item(step, i) })
       end
@@ -27,7 +57,7 @@ module UI
 
     def step_item(step, index)
       is_last = index == @steps.size - 1
-      status  = step.fetch(:status, :pending).to_sym
+      status  = coerce_status(step.fetch(:status, :pending).to_sym)
 
       if @orientation == :vertical
         vertical_item(step, status, is_last)
@@ -63,7 +93,7 @@ module UI
       when :complete
         content_tag(:span, check_svg,
           class: cn(base, "border-interactive bg-interactive text-text-on-interactive"),
-          "aria-label": "Completed")
+          "aria-label": I18n.t("modelrails_ui.stepper.completed", default: "Completed"))
       when :current
         content_tag(:span, "●",
           class: cn(base, "border-interactive text-interactive"),
@@ -71,7 +101,7 @@ module UI
       else
         content_tag(:span, "○",
           class: cn(base, "border-text-muted text-text-muted"),
-          "aria-label": "Pending")
+          "aria-label": I18n.t("modelrails_ui.stepper.pending", default: "Pending"))
       end
     end
 
@@ -94,6 +124,33 @@ module UI
 
     def check_svg
       raw('<svg xmlns="http://www.w3.org/2000/svg" width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="3" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><polyline points="20 6 9 17 4 12"/></svg>')
+    end
+
+    # Fail loud on an unknown orientation/status in development/test so misuse is
+    # caught immediately; fall back to a safe default in production so a bad value
+    # never 500s a page. The Rails.respond_to?(:env) guard stays correct even when
+    # the Rails module is defined but Rails.env isn't booted (the gem's Rails-less
+    # tests load rails/generators, which defines Rails without Rails.env).
+    def coerce_orientation(orientation)
+      return orientation if ORIENTATIONS.include?(orientation)
+
+      fail_loud_or_default(orientation, ORIENTATIONS, "orientation", :horizontal)
+    end
+
+    def coerce_status(status)
+      return status if STATUSES.include?(status)
+
+      fail_loud_or_default(status, STATUSES, "status", :pending)
+    end
+
+    def fail_loud_or_default(value, allowed, name, fallback)
+      unless defined?(Rails) && Rails.respond_to?(:env) && Rails.env.production?
+        raise ArgumentError,
+          "UI::StepperComponent: unknown #{name} #{value.inspect}. " \
+          "Expected one of: #{allowed.join(", ")}."
+      end
+
+      fallback
     end
   end
 end

--- a/lib/generators/modelrails_ui/add/templates/toggle_group/toggle_group_component.rb.tt
+++ b/lib/generators/modelrails_ui/add/templates/toggle_group/toggle_group_component.rb.tt
@@ -1,16 +1,70 @@
 # frozen_string_literal: true
 
 module UI
+  # # ToggleGroup
+  #
+  # A grouping of related toggle buttons (`ui :toggle`) wired to the
+  # `toggle-group` Stimulus controller, which enforces single- or multi-select.
+  #
+  # ## Use when
+  # - You have a set of related on/off controls and want either one-active-at-a-time
+  #   (`:single` — text alignment, view mode) or many-active (`:multiple` —
+  #   bold/italic/underline) selection in a labelled cluster.
+  #
+  # ## Don't use when
+  # - It's a single standalone on/off control — use `ui :toggle` on its own.
+  # - It's a form field that posts on submit — use a radio group or checkboxes.
+  #
+  # ## Accessibility contract
+  # - **Guarantees:** the cluster is a named grouping (`role="group"` + an accessible
+  #   name) so AT announces what the buttons control; `data-toggle-group-type-value`
+  #   tells the controller how to enforce selection. Focus lives on each item (the
+  #   caller-supplied `ui :toggle` carries the AAA `focus-ring`), never the wrapper.
+  # - **You supply:** an accessible name via `aria_label:` OR `aria_labelledby:`
+  #   (a nameless group of toggle buttons is unannounced — so this fails loud rather
+  #   than ship an anonymous "group"), and the toggle items as block content. Each
+  #   item's initial pressed state should reflect `item_pressed?(item_value)`.
+  #
+  # ## ARIA semantics: `role="group"` for BOTH single and multiple
+  # The items are toggle BUTTONS (`<button aria-pressed>`), and the `toggle-group`
+  # controller flips their `aria-pressed` — it never emits `role="radio"` /
+  # `aria-checked`. A `role="radiogroup"` wrapper requires children with
+  # `role="radio"` + `aria-checked`; pairing it with `aria-pressed` buttons would be
+  # an ARIA lie that breaks AT. So `:single` keeps `role="group"` (a single-select
+  # cluster of pressed buttons — APG toolbar-adjacent) rather than masquerading as a
+  # radiogroup. FOLLOW-UP: a true radiogroup variant (role="radio" items +
+  # arrow-key roving) is a larger change — out of scope for this hardening pass.
+  #
+  # ## Parameters
+  # - `type:`            `:single` (one active) | `:multiple` (many active)
+  # - `value:`           currently active value (String) for `:single`, or an array
+  #                      of active values for `:multiple`
+  # - `aria_label:`      accessible name for the group
+  # - `aria_labelledby:` id of an existing element that names the group
+  # - `**html_attrs`     forwarded to the `<div role="group">` wrapper
   class ToggleGroupComponent < ApplicationComponent
     BASE = "inline-flex gap-1"
 
-    # type:  :single — only one item active at a time
-    #        :multiple — multiple items can be active simultaneously
-    # value: currently active value (String) for :single,
-    #        or array of active values for :multiple
-    def initialize(type: :single, value: nil, **html_attrs)
+    TYPES = %i[single multiple].freeze
+
+    def initialize(type: :single, value: nil, aria_label: nil, aria_labelledby: nil, **html_attrs)
       @type = type.to_sym
+      unless TYPES.include?(@type)
+        raise ArgumentError,
+          "UI::ToggleGroupComponent: unknown type #{@type.inspect}. " \
+          "Expected one of: #{TYPES.join(", ")}."
+      end
+
+      name = aria_labelledby || aria_label
+      if name.to_s.strip.empty?
+        raise ArgumentError,
+          "UI::ToggleGroupComponent: a group of toggle buttons needs an accessible " \
+          "name — pass aria_label: or aria_labelledby:."
+      end
+
       @value = Array(value).map(&:to_s)
+      @aria_label = aria_label
+      @aria_labelledby = aria_labelledby
       @extra_class = html_attrs.delete(:class)
       @html_attrs = html_attrs
     end
@@ -20,6 +74,8 @@ module UI
         content,
         class: cn(BASE, @extra_class),
         role: "group",
+        "aria-label": @aria_labelledby ? nil : @aria_label,
+        "aria-labelledby": @aria_labelledby,
         "data-controller": "toggle-group",
         "data-toggle-group-type-value": @type,
         **@html_attrs)

--- a/lib/generators/modelrails_ui/lookbook/templates/previews/ui/button_group_component_preview.rb
+++ b/lib/generators/modelrails_ui/lookbook/templates/previews/ui/button_group_component_preview.rb
@@ -1,0 +1,26 @@
+# frozen_string_literal: true
+
+module UI
+  # # Button group
+  #
+  # A presentational `role="group"` wrapper that segments its children into a
+  # single bar: it collapses the inner corners and overlaps the borders so
+  # adjacent buttons read as one control. Purely visual — it owns no state, JS,
+  # or keyboard behaviour; the buttons inside carry their own a11y contract.
+  #
+  # ## Use when
+  # - Grouping 2–3 related actions or a segmented control (e.g. a view switcher)
+  #   into one visual unit.
+  #
+  # ## Accessibility contract
+  # - **Guarantees:** a `role="group"` boundary and the segmented styling.
+  # - **You supply:** the child controls (each with its own accessible name) and,
+  #   optionally, an `aria_label:` to name the group when context doesn't already.
+  class ButtonGroupComponentPreview < ViewComponent::Preview
+    include UIHelper
+
+    # A segmented control of related actions, named with `aria_label:`.
+    def default
+    end
+  end
+end

--- a/lib/generators/modelrails_ui/lookbook/templates/previews/ui/button_group_component_preview/default.html.erb
+++ b/lib/generators/modelrails_ui/lookbook/templates/previews/ui/button_group_component_preview/default.html.erb
@@ -1,0 +1,5 @@
+<%= ui :button_group, aria_label: "View mode" do %>
+  <%= ui :button, "List", variant: :outline, tone: :neutral %>
+  <%= ui :button, "Board", variant: :outline, tone: :neutral %>
+  <%= ui :button, "Calendar", variant: :outline, tone: :neutral %>
+<% end %>

--- a/lib/generators/modelrails_ui/lookbook/templates/previews/ui/collapsible_component_preview.rb
+++ b/lib/generators/modelrails_ui/lookbook/templates/previews/ui/collapsible_component_preview.rb
@@ -1,0 +1,31 @@
+# frozen_string_literal: true
+
+module UI
+  # # Collapsible
+  #
+  # A single CSS-only disclosure, rendered as a native `<details>`/`<summary>`.
+  # The browser owns the show/hide and the keyboard (the summary is focusable;
+  # Enter/Space toggles), so the component needs no JavaScript.
+  #
+  # ## Use when
+  # - Progressively disclosing one block of content behind a caller-supplied trigger.
+  #
+  # ## Accessibility contract
+  # - **Guarantees:** native disclosure semantics, an AAA `focus-ring` on the
+  #   summary, and a hidden native webkit marker.
+  # - **You supply:** a `with_trigger` slot (the summary row) and the content.
+  #
+  # ## Modes
+  # Closed (default) · `open: true` (render pre-expanded).
+  class CollapsibleComponentPreview < ViewComponent::Preview
+    include UIHelper
+
+    # Closed on load — the caller-supplied trigger toggles the content. No JavaScript.
+    def default
+    end
+
+    # `open: true` renders the disclosure pre-expanded, with richer block content.
+    def expanded
+    end
+  end
+end

--- a/lib/generators/modelrails_ui/lookbook/templates/previews/ui/collapsible_component_preview/default.html.erb
+++ b/lib/generators/modelrails_ui/lookbook/templates/previews/ui/collapsible_component_preview/default.html.erb
@@ -1,0 +1,9 @@
+<%= ui :collapsible do |c| %>
+  <% c.with_trigger do %>
+    <span class="font-medium text-text-heading">Shipping &amp; returns</span>
+    <span aria-hidden="true" class="text-text-muted">+</span>
+  <% end %>
+  <p class="text-text-body">
+    Free shipping on orders over $50. Returns accepted within 30 days of delivery.
+  </p>
+<% end %>

--- a/lib/generators/modelrails_ui/lookbook/templates/previews/ui/collapsible_component_preview/expanded.html.erb
+++ b/lib/generators/modelrails_ui/lookbook/templates/previews/ui/collapsible_component_preview/expanded.html.erb
@@ -1,0 +1,11 @@
+<%= ui :collapsible, open: true do |c| %>
+  <% c.with_trigger do %>
+    <span class="font-medium text-text-heading">Plan details</span>
+    <span aria-hidden="true" class="text-text-muted">+</span>
+  <% end %>
+  <ul class="list-disc space-y-1 pl-4 text-text-body">
+    <li>Starter — free forever</li>
+    <li>Pro — $12/month</li>
+    <li>Enterprise — contact us</li>
+  </ul>
+<% end %>

--- a/lib/generators/modelrails_ui/lookbook/templates/previews/ui/stepper_component_preview.rb
+++ b/lib/generators/modelrails_ui/lookbook/templates/previews/ui/stepper_component_preview.rb
@@ -1,0 +1,31 @@
+# frozen_string_literal: true
+
+module UI
+  # # Stepper
+  #
+  # An ordered progress indicator: an `<ol>` of steps shown as complete, current,
+  # or pending. It communicates *where you are* in a multi-step flow — it is NOT
+  # interactive navigation (the steps are not links/buttons).
+  #
+  # ## Accessibility contract
+  # - **Guarantees:** an `<ol>` with an i18n `aria-label` ("Progress"); the current
+  #   step carries `aria-current="step"`, complete/pending circles carry an i18n
+  #   `aria-label` ("Completed" / "Pending"), and the check icon + `●`/`○` glyphs
+  #   are decorative.
+  # - **You supply:** a `label:` per step and a `status:` of `:complete`,
+  #   `:current`, or `:pending` (defaults to `:pending`).
+  #
+  # ## Modes
+  # `orientation: :horizontal` (default) · `orientation: :vertical`.
+  class StepperComponentPreview < ViewComponent::Preview
+    include UIHelper
+
+    # A horizontal 3-step flow: one complete, one current, one pending.
+    def default
+    end
+
+    # The same flow stacked vertically, with optional per-step descriptions.
+    def vertical
+    end
+  end
+end

--- a/lib/generators/modelrails_ui/lookbook/templates/previews/ui/stepper_component_preview/default.html.erb
+++ b/lib/generators/modelrails_ui/lookbook/templates/previews/ui/stepper_component_preview/default.html.erb
@@ -1,0 +1,5 @@
+<%= ui :stepper, steps: [
+  { label: "Account", status: :complete },
+  { label: "Profile", status: :current },
+  { label: "Confirm", status: :pending }
+] %>

--- a/lib/generators/modelrails_ui/lookbook/templates/previews/ui/stepper_component_preview/vertical.html.erb
+++ b/lib/generators/modelrails_ui/lookbook/templates/previews/ui/stepper_component_preview/vertical.html.erb
@@ -1,0 +1,5 @@
+<%= ui :stepper, orientation: :vertical, steps: [
+  { label: "Account", description: "Create your login", status: :complete },
+  { label: "Profile", description: "Tell us about you", status: :current },
+  { label: "Confirm", description: "Review and finish", status: :pending }
+] %>

--- a/lib/generators/modelrails_ui/lookbook/templates/previews/ui/toggle_group_component_preview.rb
+++ b/lib/generators/modelrails_ui/lookbook/templates/previews/ui/toggle_group_component_preview.rb
@@ -1,0 +1,35 @@
+# frozen_string_literal: true
+
+module UI
+  # # ToggleGroup
+  #
+  # A named cluster of `ui :toggle` buttons wired to the `toggle-group` Stimulus
+  # controller, which enforces single- or multi-select on click.
+  #
+  # ## Use when
+  # - You have related on/off controls and want one-active-at-a-time (`:single`)
+  #   or many-active (`:multiple`) selection in a labelled group.
+  #
+  # ## Accessibility contract
+  # - **Guarantees:** a named grouping (`role="group"` + accessible name) so AT
+  #   announces what the buttons control. Focus lives on each item (the `ui :toggle`
+  #   AAA `focus-ring`), never the wrapper.
+  # - **You supply:** an accessible name via `aria_label:` (or `aria_labelledby:`),
+  #   and the toggle items. Each item's `pressed:` should reflect the active value.
+  #
+  # ## Modes
+  # Single-select (`type: :single`) · multi-select (`type: :multiple`).
+  class ToggleGroupComponentPreview < ViewComponent::Preview
+    include UIHelper
+
+    # Single-select — only one item active at a time. The controller clears the
+    # others on click. "Center" starts pressed to reflect the active value.
+    def default
+    end
+
+    # Multi-select — several items active simultaneously. Clicking toggles each
+    # item independently. "Bold" and "Italic" start pressed.
+    def multiple
+    end
+  end
+end

--- a/lib/generators/modelrails_ui/lookbook/templates/previews/ui/toggle_group_component_preview/default.html.erb
+++ b/lib/generators/modelrails_ui/lookbook/templates/previews/ui/toggle_group_component_preview/default.html.erb
@@ -1,0 +1,7 @@
+<%# Single-select — only one item active at a time (controller clears the rest). %>
+<%# Each item's initial pressed state mirrors the group's active value via item_pressed?. %>
+<%= ui :toggle_group, type: :single, value: "center", aria_label: "Text alignment" do |group| %>
+  <%= ui :toggle, "Left",   value: "left",   pressed: group.item_pressed?("left") %>
+  <%= ui :toggle, "Center", value: "center", pressed: group.item_pressed?("center") %>
+  <%= ui :toggle, "Right",  value: "right",  pressed: group.item_pressed?("right") %>
+<% end %>

--- a/lib/generators/modelrails_ui/lookbook/templates/previews/ui/toggle_group_component_preview/multiple.html.erb
+++ b/lib/generators/modelrails_ui/lookbook/templates/previews/ui/toggle_group_component_preview/multiple.html.erb
@@ -1,0 +1,7 @@
+<%# Multi-select — several items active at once (controller toggles each item). %>
+<%# Each item's initial pressed state mirrors the group's active values via item_pressed?. %>
+<%= ui :toggle_group, type: :multiple, value: ["bold", "italic"], aria_label: "Text style" do |group| %>
+  <%= ui :toggle, "Bold",      value: "bold",      pressed: group.item_pressed?("bold") %>
+  <%= ui :toggle, "Italic",    value: "italic",    pressed: group.item_pressed?("italic") %>
+  <%= ui :toggle, "Underline", value: "underline", pressed: group.item_pressed?("underline") %>
+<% end %>

--- a/test/render/button_group_render_test.rb
+++ b/test/render/button_group_render_test.rb
@@ -1,0 +1,80 @@
+# frozen_string_literal: true
+
+require "render_test_helper"
+load_component "button_group", "button_group_component.rb.tt"
+
+# STRUCTURE-only render specs. ButtonGroup is a purely presentational
+# `role="group"` wrapper: it owns no state/JS/keyboard — it only collapses the
+# inner corners and overlaps borders so its children read as one segmented bar.
+# The app 0b proves the rendered bar axe-AAA in a real browser.
+class ButtonGroupRenderTest < ViewComponent::TestCase
+  def render_group(**kwargs, &block)
+    block ||= proc { "X" }
+    render_inline(UI::ButtonGroupComponent.new(**kwargs), &block)
+  end
+
+  def test_renders_a_role_group_div
+    render_group
+
+    assert_selector "div[role='group']"
+  end
+
+  # The flex layout + rounded outer shell of the segmented shell.
+  def test_carries_the_layout_base_classes
+    render_group
+
+    assert_selector "div.inline-flex.rounded-md.shadow-sm"
+  end
+
+  # The rounded-adjacency rules are what make the children read as one control:
+  # neutralise every child's corners, then re-round the bar's two outer edges and
+  # overlap the shared borders. These classes contain `&`/`[`/`:`, so they must be
+  # matched as substrings — and all four must live on the same root.
+  def test_carries_the_corner_adjacency_base_classes
+    render_group
+
+    assert_selector "div[class*='[&>*]:rounded-none']" \
+                    "[class*='[&>*:first-child]:rounded-l-md']" \
+                    "[class*='[&>*:last-child]:rounded-r-md']" \
+                    "[class*='[&>*:not(:first-child)]:-ml-px']"
+  end
+
+  # Arbitrary content children render inside the wrapper.
+  def test_renders_content_children_inside
+    render_group do
+      "<button>One</button><button>Two</button>".html_safe
+    end
+
+    assert_selector "div[role='group'] > button", text: "One"
+    assert_selector "div[role='group'] > button", text: "Two"
+  end
+
+  # html_attrs pass through onto the root, matching the sibling components.
+  def test_passes_through_html_attrs_onto_the_root
+    render_group(id: "view-toggle", data: {testid: "group"})
+
+    assert_selector "div#view-toggle[role='group'][data-testid='group']"
+  end
+
+  # A caller-supplied class merges onto the root WITHOUT clobbering the BASE.
+  def test_merges_caller_class_onto_the_root_preserving_base
+    render_group(class: "mt-4")
+
+    assert_selector "div.mt-4.inline-flex.shadow-sm"
+    assert_selector "div[class*='[&>*]:rounded-none']"
+  end
+
+  # `aria_label:` gives the group an accessible name when the caller supplies one.
+  def test_aria_label_emits_an_accessible_name_when_given
+    render_group(aria_label: "View mode")
+
+    assert_selector "div[role='group'][aria-label='View mode']"
+  end
+
+  # It is optional — absent by default (a group is often labelled by context).
+  def test_aria_label_is_absent_by_default
+    render_group
+
+    assert_no_selector "div[role='group'][aria-label]"
+  end
+end

--- a/test/render/collapsible_render_test.rb
+++ b/test/render/collapsible_render_test.rb
@@ -1,0 +1,72 @@
+# frozen_string_literal: true
+
+require "render_test_helper"
+load_component "collapsible", "collapsible_component.rb.tt"
+
+# STRUCTURE-only render specs. Collapsible is a native <details>/<summary> (the
+# browser owns the disclosure semantics + keyboard); the app 0b proves it axe-AAA
+# in a real browser. Here we assert the scaffolding + the AAA focus contract.
+class CollapsibleRenderTest < ViewComponent::TestCase
+  def render_collapsible(open: false)
+    render_inline(UI::CollapsibleComponent.new(open: open)) do |c|
+      c.with_trigger { "Details" }
+      "Hidden body"
+    end
+  end
+
+  def test_renders_a_details_with_a_summary
+    render_collapsible
+
+    assert_selector "details summary", text: "Details"
+    # Collapsed <details> content is hidden to Capybara's static driver — assert it exists.
+    assert_selector "details > div", text: "Hidden body", visible: :all
+  end
+
+  def test_open_renders_expanded
+    render_collapsible(open: true)
+
+    assert_selector "details[open] summary", text: "Details"
+  end
+
+  def test_closed_by_default
+    render_collapsible
+
+    assert_no_selector "details[open]"
+  end
+
+  # The headline AAA fix: the summary's focus indicator is the offset `focus-ring`
+  # outline utility — NOT a box-shadow ring (clipped by overflow-hidden ancestors,
+  # gone in forced-colors mode — a 2.4.7 failure).
+  def test_summary_carries_the_aaa_focus_ring
+    render_collapsible
+
+    assert_selector "summary.focus-ring"
+  end
+
+  # Regression guard: the ring anti-pattern must never come back.
+  def test_summary_has_no_box_shadow_ring_or_outline_none
+    render_collapsible
+    html = page.native.to_html
+
+    refute_includes html, "focus-visible:ring-"
+    refute_includes html, "outline-none"
+  end
+
+  # The native webkit disclosure marker is hidden so the caller-supplied trigger
+  # owns the open/closed affordance.
+  def test_hides_the_native_webkit_marker
+    render_collapsible
+
+    assert_selector "summary[class*='webkit-details-marker']"
+  end
+
+  # html_attrs pass through onto the <details> root, matching the sibling components.
+  def test_passes_through_html_attrs_onto_the_root
+    render_inline(UI::CollapsibleComponent.new(id: "faq", class: "mt-4")) do |c|
+      c.with_trigger { "More" }
+      "Body"
+    end
+
+    assert_selector "details#faq.mt-4"
+  end
+end

--- a/test/render/stepper_render_test.rb
+++ b/test/render/stepper_render_test.rb
@@ -1,0 +1,89 @@
+# frozen_string_literal: true
+
+require "render_test_helper"
+load_component "stepper", "stepper_component.rb.tt"
+
+# STRUCTURE-only render specs. Stepper is a non-interactive progress indicator:
+# an <ol aria-label="Progress"> whose steps carry their status via aria. Here we
+# assert the scaffolding + the i18n/status/orientation contract; the app 0b proves
+# it axe-AAA in a real browser.
+class StepperRenderTest < ViewComponent::TestCase
+  THREE_STEPS = [
+    {label: "Account", status: :complete},
+    {label: "Profile", status: :current},
+    {label: "Confirm", status: :pending}
+  ].freeze
+
+  def test_renders_an_ordered_list_with_the_i18n_progress_label
+    render_inline(UI::StepperComponent.new(steps: THREE_STEPS))
+
+    # The aria-label resolves to the English default ("Progress") via I18n.t.
+    assert_selector "ol[aria-label='Progress']"
+  end
+
+  def test_complete_step_renders_the_check_svg_and_the_completed_label
+    render_inline(UI::StepperComponent.new(steps: THREE_STEPS))
+
+    # The completed circle is named for AT and the check glyph is decorative.
+    assert_selector "span[aria-label='Completed'] svg[aria-hidden='true']"
+  end
+
+  def test_current_step_carries_aria_current_step
+    render_inline(UI::StepperComponent.new(steps: THREE_STEPS))
+
+    assert_selector "span[aria-current='step']"
+  end
+
+  def test_pending_step_carries_the_i18n_pending_label
+    render_inline(UI::StepperComponent.new(steps: THREE_STEPS))
+
+    assert_selector "span[aria-label='Pending']"
+  end
+
+  def test_status_defaults_to_pending_when_omitted
+    render_inline(UI::StepperComponent.new(steps: [{label: "Lonely"}]))
+
+    assert_selector "span[aria-label='Pending']"
+  end
+
+  def test_horizontal_orientation_lays_steps_out_in_a_row
+    render_inline(UI::StepperComponent.new(steps: THREE_STEPS, orientation: :horizontal))
+
+    assert_selector "ol.flex.items-start"
+    # Non-last horizontal items stretch to fill the row.
+    assert_selector "li.flex.items-center.flex-1"
+  end
+
+  def test_vertical_orientation_stacks_steps_in_a_column
+    render_inline(UI::StepperComponent.new(steps: THREE_STEPS, orientation: :vertical))
+
+    assert_selector "ol.flex.flex-col"
+    assert_selector "li.relative.flex.gap-4"
+  end
+
+  def test_unknown_orientation_raises
+    assert_raises(ArgumentError) do
+      render_inline(UI::StepperComponent.new(steps: THREE_STEPS, orientation: :diagonal))
+    end
+  end
+
+  def test_unknown_step_status_raises
+    assert_raises(ArgumentError) do
+      render_inline(UI::StepperComponent.new(steps: [{label: "Bad", status: :bogus}]))
+    end
+  end
+
+  # html_attrs pass through onto the root <ol>, matching the sibling components.
+  def test_passes_through_html_attrs_onto_the_root
+    render_inline(UI::StepperComponent.new(steps: THREE_STEPS, id: "checkout-steps", data: {testid: "stepper"}))
+
+    assert_selector "ol#checkout-steps[data-testid='stepper'][aria-label='Progress']"
+  end
+
+  # A caller-supplied class merges onto the root without clobbering the layout tokens.
+  def test_merges_caller_class_onto_the_root
+    render_inline(UI::StepperComponent.new(steps: THREE_STEPS, class: "mt-4"))
+
+    assert_selector "ol.mt-4.flex.items-start"
+  end
+end

--- a/test/render/toggle_group_render_test.rb
+++ b/test/render/toggle_group_render_test.rb
@@ -1,0 +1,97 @@
+# frozen_string_literal: true
+
+require "render_test_helper"
+load_component "toggle_group", "toggle_group_component.rb.tt"
+
+# STRUCTURE-only render specs. The selection BEHAVIOUR (one-active-at-a-time vs
+# many) lives in the `toggle-group` Stimulus controller; the app 0b proves it
+# axe-AAA in a real browser. Here we assert the wrapper scaffolding: the named
+# `role="group"`, the controller wiring, the type-value, the accessible-name
+# fail-loud contract, and `item_pressed?`.
+class ToggleGroupRenderTest < ViewComponent::TestCase
+  def test_single_renders_a_named_group_wired_to_the_controller
+    render_inline(UI::ToggleGroupComponent.new(type: :single, aria_label: "Text alignment")) { "items" }
+
+    assert_selector "div[role='group'][aria-label='Text alignment']" \
+                    "[data-controller='toggle-group'][data-toggle-group-type-value='single']"
+  end
+
+  def test_multiple_sets_the_type_value_to_multiple
+    render_inline(UI::ToggleGroupComponent.new(type: :multiple, aria_label: "Text style")) { "items" }
+
+    assert_selector "div[role='group'][data-toggle-group-type-value='multiple']"
+  end
+
+  def test_accepts_aria_labelledby_as_the_accessible_name
+    render_inline(UI::ToggleGroupComponent.new(aria_labelledby: "align-heading")) { "items" }
+
+    assert_selector "div[role='group'][aria-labelledby='align-heading']"
+    assert_no_selector "div[aria-label]"
+  end
+
+  # A nameless group of toggle buttons is the documented anti-pattern — fail loud.
+  def test_fails_loud_without_an_accessible_name
+    assert_raises(ArgumentError) do
+      UI::ToggleGroupComponent.new
+    end
+  end
+
+  def test_blank_aria_label_fails_loud
+    assert_raises(ArgumentError) do
+      UI::ToggleGroupComponent.new(aria_label: "   ")
+    end
+  end
+
+  # Fail-loud type guard: an unknown type raises rather than silently passing a
+  # bogus value through to the controller.
+  def test_unknown_type_raises
+    assert_raises(ArgumentError) do
+      UI::ToggleGroupComponent.new(type: :bogus, aria_label: "x")
+    end
+  end
+
+  # item_pressed? drives each item's initial pressed state. Single takes a scalar
+  # active value; multiple takes an array.
+  def test_item_pressed_for_single_value
+    component = UI::ToggleGroupComponent.new(type: :single, value: "center", aria_label: "Align")
+
+    assert component.item_pressed?("center")
+    assert component.item_pressed?(:center) # symbol coerces to the same string
+    refute component.item_pressed?("left")
+  end
+
+  def test_item_pressed_for_multiple_values
+    component = UI::ToggleGroupComponent.new(type: :multiple, value: %w[bold italic], aria_label: "Style")
+
+    assert component.item_pressed?("bold")
+    assert component.item_pressed?("italic")
+    refute component.item_pressed?("underline")
+  end
+
+  def test_item_pressed_is_false_when_no_value_is_active
+    component = UI::ToggleGroupComponent.new(aria_label: "Align")
+
+    refute component.item_pressed?("center")
+  end
+
+  # AAA semantic base layout token (the design-token guarantee), not raw Tailwind.
+  def test_renders_with_base_layout_tokens
+    render_inline(UI::ToggleGroupComponent.new(aria_label: "Align")) { "items" }
+
+    assert_selector "div.inline-flex.gap-1"
+  end
+
+  # html_attrs pass through onto the root, matching the sibling components.
+  def test_passes_through_html_attrs_onto_the_root
+    render_inline(UI::ToggleGroupComponent.new(aria_label: "Align", id: "align-group", data: {testid: "tg"})) { "items" }
+
+    assert_selector "div#align-group[role='group'][data-testid='tg']"
+  end
+
+  # A caller-supplied class merges onto the root without clobbering the base layout.
+  def test_merges_caller_class_onto_the_root
+    render_inline(UI::ToggleGroupComponent.new(aria_label: "Align", class: "mt-4")) { "items" }
+
+    assert_selector "div.mt-4.inline-flex"
+  end
+end

--- a/test/test_components.rb
+++ b/test/test_components.rb
@@ -696,43 +696,43 @@ end
 
 class TestToggleGroupComponent < Minitest::Test
   def test_default_type
-    c = UI::ToggleGroupComponent.new
+    c = UI::ToggleGroupComponent.new(aria_label: "Formatting")
 
     assert_equal :single, c.instance_variable_get(:@type)
   end
 
   def test_type_stored_as_symbol
-    c = UI::ToggleGroupComponent.new(type: "multiple")
+    c = UI::ToggleGroupComponent.new(type: "multiple", aria_label: "Formatting")
 
     assert_equal :multiple, c.instance_variable_get(:@type)
   end
 
   def test_single_value_normalized_to_array
-    c = UI::ToggleGroupComponent.new(value: "bold")
+    c = UI::ToggleGroupComponent.new(value: "bold", aria_label: "Formatting")
 
     assert_equal ["bold"], c.instance_variable_get(:@value)
   end
 
   def test_array_value_stored
-    c = UI::ToggleGroupComponent.new(value: %w[bold underline])
+    c = UI::ToggleGroupComponent.new(value: %w[bold underline], aria_label: "Formatting")
 
     assert_equal %w[bold underline], c.instance_variable_get(:@value)
   end
 
   def test_nil_value_becomes_empty_array
-    c = UI::ToggleGroupComponent.new
+    c = UI::ToggleGroupComponent.new(aria_label: "Formatting")
 
     assert_equal [], c.instance_variable_get(:@value)
   end
 
   def test_item_pressed_true_when_in_value
-    c = UI::ToggleGroupComponent.new(value: "bold")
+    c = UI::ToggleGroupComponent.new(value: "bold", aria_label: "Formatting")
 
     assert c.item_pressed?("bold")
   end
 
   def test_item_pressed_false_when_not_in_value
-    c = UI::ToggleGroupComponent.new(value: "bold")
+    c = UI::ToggleGroupComponent.new(value: "bold", aria_label: "Formatting")
 
     refute c.item_pressed?("italic")
   end


### PR DESCRIPTION
Disclosure-band fan-out — the four remaining disclosure primitives hardened to button-tier in parallel, following the proven **accordion** exemplar (gem #38). One PR for the band (app-side adoption + 0b AAA proof rides in the paired app PR).

| Component | Real fixes |
|---|---|
| **collapsible** | Adds the AAA **`focus-ring`** to the focusable `<summary>` (it had `list-none`/webkit-marker but no focus indicator). |
| **button_group** | Formalize (0a + preview) + optional **`aria_label:`** on the `role="group"` wrapper. Presentational, no other defects. |
| **stepper** | **i18n** the hardcoded `Progress`/`Completed`/`Pending` aria strings (`I18n.t(default:)`, the gem's yml-free convention); **fail-loud** `coerce` on `orientation` + step `status` (mirrors `indicator`). |
| **toggle_group** | **Required accessible name** (`aria_label`/`aria_labelledby`, mirrors `scroll_area`); **fail-loud** `type` guard; kept `role="group"` for single+multiple — items are `aria-pressed` buttons, not radios, so a `role="radiogroup"` wrapper would be an ARIA lie (a true radiogroup variant is a documented follow-up). Controller untouched. |

## Proofs
- **0a render tests:** collapsible 7 · button_group 8 · stepper 11 · toggle_group 12.
- Updated the existing `TestToggleGroupComponent` unit tests for the now-required name.
- Template-backed previews for each (incl. vertical stepper, multiple toggle_group).
- **Full gem suite 626/0**, RuboCop **clean**.

App-side adoption + the **0b axe-AAA** proofs (CI-only 7:1) ride in the paired app PR.