### PR TITLE
fix(ui): stepper status circles need role=img for the aria-label (4.1.2)

### DIFF
--- a/lib/generators/modelrails_ui/add/templates/stepper/stepper_component.rb.tt
+++ b/lib/generators/modelrails_ui/add/templates/stepper/stepper_component.rb.tt
@@ -93,6 +93,7 @@ module UI
       when :complete
         content_tag(:span, check_svg,
           class: cn(base, "border-interactive bg-interactive text-text-on-interactive"),
+          role: "img",
           "aria-label": I18n.t("modelrails_ui.stepper.completed", default: "Completed"))
       when :current
         content_tag(:span, "●",
@@ -101,6 +102,7 @@ module UI
       else
         content_tag(:span, "○",
           class: cn(base, "border-text-muted text-text-muted"),
+          role: "img",
           "aria-label": I18n.t("modelrails_ui.stepper.pending", default: "Pending"))
       end
     end

--- a/test/render/stepper_render_test.rb
+++ b/test/render/stepper_render_test.rb
@@ -24,8 +24,9 @@ class StepperRenderTest < ViewComponent::TestCase
   def test_complete_step_renders_the_check_svg_and_the_completed_label
     render_inline(UI::StepperComponent.new(steps: THREE_STEPS))
 
-    # The completed circle is named for AT and the check glyph is decorative.
-    assert_selector "span[aria-label='Completed'] svg[aria-hidden='true']"
+    # The completed circle is a named graphic (role=img so aria-label is legal on the
+    # span) and the check glyph is decorative.
+    assert_selector "span[role='img'][aria-label='Completed'] svg[aria-hidden='true']"
   end
 
   def test_current_step_carries_aria_current_step
@@ -37,7 +38,7 @@ class StepperRenderTest < ViewComponent::TestCase
   def test_pending_step_carries_the_i18n_pending_label
     render_inline(UI::StepperComponent.new(steps: THREE_STEPS))
 
-    assert_selector "span[aria-label='Pending']"
+    assert_selector "span[role='img'][aria-label='Pending']"
   end
 
   def test_status_defaults_to_pending_when_omitted


### PR DESCRIPTION
Follow-up to the disclosure band (#39). The stepper's complete/pending status circles carried `aria-label` on a bare `<span>`, which axe flags as **aria-prohibited-attr** (`aria-label` is invalid without a name-supporting role). Adds `role="img"` so each circle is a named graphic.

Caught by the **app-side 0b live-axe** (a structural ARIA rule, fails even at AA) — the 0a only checked the label was *present*, not that it was *legal*; the 0a is now strengthened to assert `role=img` so it can't regress. Full gem suite 626/0, rubocop clean.