### PR TITLE
feat(ui): harden nav-remainder band — sidebar/bottom_nav/speed_dial/mega_menu/navigation_menu (0a)

### DIFF
--- a/lib/generators/modelrails_ui/add/templates/bottom_nav/bottom_nav_component.rb.tt
+++ b/lib/generators/modelrails_ui/add/templates/bottom_nav/bottom_nav_component.rb.tt
@@ -1,18 +1,37 @@
 # frozen_string_literal: true
 
 module UI
+  # # BottomNav
+  #
+  # A fixed mobile bottom navigation bar (a `<nav>` landmark) — a row of icon+label
+  # destinations pinned to the bottom of the viewport.
+  #
+  # ## Accessibility contract
+  # - **Guarantees:** a named `<nav>` landmark (i18n default "Bottom navigation",
+  #   override via `label:`), the AAA `focus-ring` on every item, and
+  #   `aria-current="page"` on the active item.
+  # - **You supply:** `items:` (`[{ label:, href:, active: (optional),
+  #   icon: (optional HTML string) }]`).
   class BottomNavComponent < ApplicationComponent
-    BASE = "fixed bottom-0 left-0 z-50 w-full border-t bg-surface-raised"
+    BASE = "fixed bottom-0 left-0 z-50 w-full border-t border-border bg-surface-raised"
+
+    ITEM = "flex flex-col items-center justify-center gap-1 px-4 py-2 text-xs " \
+           "font-medium transition-colors focus-ring"
 
     # items: [{ label:, href:, active: (optional), icon: (optional HTML string) }]
-    def initialize(items: [], **html_attrs)
+    # label: accessible name for the <nav> landmark (i18n default "Bottom navigation").
+    def initialize(items: [], label: nil, **html_attrs)
       @items = items
+      @label = label
       @extra_class = html_attrs.delete(:class)
       @html_attrs = html_attrs
     end
 
     def call
-      content_tag(:nav, class: cn(BASE, @extra_class), **@html_attrs) do
+      content_tag(:nav,
+        class: cn(BASE, @extra_class),
+        "aria-label": nav_label,
+        **@html_attrs) do
         content_tag(:div, class: "mx-auto flex h-16 max-w-lg items-center justify-around") do
           safe_join(@items.map { |item| nav_item(item) })
         end
@@ -21,12 +40,17 @@ module UI
 
     private
 
+    # Resolved at RENDER time (view context exists here, not in initialize).
+    def nav_label
+      @label || I18n.t("modelrails_ui.bottom_nav.nav_label", default: "Bottom navigation")
+    end
+
     def nav_item(item)
       active = item[:active]
       content_tag(:a,
         href: item[:href],
         class: cn(
-          "flex flex-col items-center justify-center gap-1 px-4 py-2 text-xs font-medium transition-colors",
+          ITEM,
           active ? "text-interactive" : "text-text-muted hover:text-text-heading"
         ),
         "aria-current": (active ? "page" : nil)) do

--- a/lib/generators/modelrails_ui/add/templates/mega_menu/mega_menu_component.rb.tt
+++ b/lib/generators/modelrails_ui/add/templates/mega_menu/mega_menu_component.rb.tt
@@ -1,14 +1,34 @@
 # frozen_string_literal: true
 
 module UI
-  class MegaMenuComponent < ApplicationComponent
-    # Full-width dropdown panel anchored to a trigger button.
-    # Columns are rendered via with_column blocks.
+  # # Mega menu
+  #
+  # A disclosure button that reveals a full-width panel of grouped *navigation
+  # links* (columns of titled link lists). Open/close is owned by the component's
+  # own `mega-menu` Stimulus controller (a simple disclosure toggle).
+  #
+  # ## Menu-vs-nav semantics (deliberate)
+  # This is a **disclosure + navigation region**, NOT the WAI-ARIA `menu` pattern,
+  # so it does NOT reuse the shared `menu` controller (which `dropdown_menu`/`menubar`
+  # consume). `role="menu"`/`menuitem` is for a list of *commands* with a roving-tabindex
+  # arrow-key model; this panel holds ordinary `<a>` navigation links that must keep
+  # native Tab/anchor behavior. Forcing `role=menu` here would impose a keyboard model
+  # the links don't honour and remove them from the link/landmark trees. So: a real
+  # `<button>` disclosure (`aria-expanded` + `aria-haspopup` + `aria-controls`) reveals a
+  # named `<nav>` region of links.
+  #
+  # ## Accessibility contract
+  # - **Guarantees:** a real `<button>` trigger with `aria-haspopup`, synced
+  #   `aria-expanded`, and `aria-controls` pointing at the panel; the panel is a named
+  #   `<nav>` landmark (`aria-label` ← the trigger label); the AAA `focus-ring` on the
+  #   trigger and every link; outside-click dismissal; the chevron is decorative
+  #   (`aria-hidden`).
+  # - **You supply:** a `label:` (trigger text) and one or more `with_column` blocks.
 
-    TRIGGER_CLS = "inline-flex h-9 items-center justify-center gap-1.5 rounded-md bg-surface-raised " \
-                  "px-4 py-2 text-sm font-medium transition-[color,box-shadow] outline-none " \
+  class MegaMenuComponent < ApplicationComponent
+    TRIGGER_CLS = "focus-ring inline-flex h-9 items-center justify-center gap-1.5 rounded-md bg-surface-raised " \
+                  "px-4 py-2 text-sm font-medium transition-[color,box-shadow] " \
                   "hover:bg-surface-sunken hover:text-text-heading " \
-                  "focus-visible:ring-[3px] focus-visible:ring-interactive-focus " \
                   "data-[state=open]:bg-surface-sunken/50 data-[state=open]:text-text-heading"
 
     PANEL_CLS = "absolute left-0 top-full z-50 mt-1.5 w-full overflow-hidden rounded-md border " \
@@ -18,9 +38,8 @@ module UI
 
     COLUMN_HEADING = "mb-2 text-xs font-semibold uppercase tracking-wide text-text-muted"
 
-    ITEM_CLS = "group flex items-start gap-3 rounded-sm p-2 text-sm transition-colors outline-none " \
-               "hover:bg-surface-sunken hover:text-text-heading " \
-               "focus-visible:ring-[3px] focus-visible:ring-interactive-focus"
+    ITEM_CLS = "focus-ring group flex items-start gap-3 rounded-sm p-2 text-sm transition-colors " \
+               "hover:bg-surface-sunken hover:text-text-heading"
 
     ITEM_TITLE = "font-medium leading-none"
     ITEM_DESC  = "mt-1 text-xs text-text-muted group-hover:text-text-heading/70"
@@ -29,22 +48,26 @@ module UI
 
     renders_many :columns, "UI::MegaMenuComponent::ColumnComponent"
 
-    # label:   trigger button text
+    # label:   trigger button text (also names the revealed <nav> landmark)
     # cols:    number of columns in the grid (default: auto based on column count)
     def initialize(label:, cols: nil, **html_attrs)
       @label = label
       @cols  = cols
+      @id    = html_attrs.delete(:id) || "mega-menu-#{SecureRandom.hex(4)}"
+      @panel_id = "#{@id}-panel"
       @extra_class = html_attrs.delete(:class)
       @html_attrs  = html_attrs
     end
 
     def call
+      caller_data = @html_attrs.delete(:data) || {}
       content_tag(:div,
+        id: @id,
         class: cn("relative", @extra_class),
         data: {
           controller: "mega-menu",
           action: "click@document->mega-menu#closeOnClickOutside"
-        },
+        }.merge(caller_data),
         **@html_attrs) do
         concat trigger_btn
         concat panel
@@ -57,7 +80,9 @@ module UI
       content_tag(:button,
         type: "button",
         class: TRIGGER_CLS,
+        "aria-haspopup": "true",
         "aria-expanded": "false",
+        "aria-controls": @panel_id,
         data: { mega_menu_target: "trigger", state: "closed",
                 action: "click->mega-menu#toggle" }) do
         concat @label
@@ -69,7 +94,9 @@ module UI
       col_count = @cols || [columns.size, 1].max
       grid_cls  = "grid-cols-#{col_count}"
 
-      content_tag(:div,
+      content_tag(:nav,
+        id: @panel_id,
+        "aria-label": @label,
         hidden: true,
         class: PANEL_CLS,
         data: { mega_menu_target: "panel" }) do

--- a/lib/generators/modelrails_ui/add/templates/navigation_menu/navigation_menu_component.rb.tt
+++ b/lib/generators/modelrails_ui/add/templates/navigation_menu/navigation_menu_component.rb.tt
@@ -1,23 +1,53 @@
 # frozen_string_literal: true
 
 module UI
+  # # Navigation menu
+  #
+  # A horizontal site-navigation bar (the WAI-ARIA APG **navigation-menu**, i.e. a
+  # `<nav>` of links where some entries open a **disclosure** flyout — NOT a
+  # `role="menu"` widget). Each flyout trigger is a real `<button>` whose
+  # `aria-expanded` is kept in sync (and `aria-controls` points at its panel) by the
+  # component-owned `navigation-menu` Stimulus controller; the panel is hover/click
+  # managed with outside-click dismissal.
+  #
+  # ## Use when
+  # - Top-level site navigation where some sections reveal a small set of links.
+  #
+  # ## Don't use when
+  # - You need a *command/action menu* (Edit, Delete…) — use `dropdown_menu`.
+  # - You need an application rail with grouped sections — use `sidebar`.
+  #
+  # ## Accessibility contract
+  # - **Guarantees:** a **named** `<nav>` landmark (i18n default, override via `label:`);
+  #   flyout triggers are real `<button>`s carrying `aria-expanded` (synced) +
+  #   `aria-controls` → their `id`'d panel (the disclosure pattern); the AAA offset
+  #   `focus-ring` on every trigger, link and panel link; `aria-current="page"` on the
+  #   active link; the chevron is decorative (`aria-hidden`).
+  # - **You supply:** items (label, optional href, optional active) and — for flyout
+  #   items — the panel links via the slot block.
   class NavigationMenuComponent < ApplicationComponent
-    ROOT = "relative flex max-w-max flex-1 items-center justify-center"
-    LIST = "flex flex-1 list-none items-center justify-center gap-1"
+    ROOT = "relative flex max-w-max flex-1 items-center"
+
+    # List justification keyed off the `align:` enum (fail-loud guarded).
+    JUSTIFY = {
+      start: "justify-start",
+      center: "justify-center",
+      end: "justify-end"
+    }.freeze
+
+    LIST = "flex flex-1 list-none items-center gap-1"
 
     # Trigger button style (item with flyout content)
     TRIGGER = "group inline-flex h-9 w-max items-center justify-center rounded-md bg-surface-raised " \
-              "px-4 py-2 text-sm font-medium transition-[color,box-shadow] outline-none " \
+              "px-4 py-2 text-sm font-medium transition-[color,box-shadow] focus-ring " \
               "hover:bg-surface-sunken hover:text-text-heading " \
-              "focus-visible:ring-[3px] focus-visible:ring-interactive-focus " \
               "disabled:pointer-events-none disabled:opacity-50 " \
               "data-[state=open]:bg-surface-sunken/50 data-[state=open]:text-text-heading"
 
     # Plain link style (item without flyout)
     LINK_CLS = "inline-flex h-9 w-max items-center justify-center rounded-md bg-surface-raised " \
-               "px-4 py-2 text-sm font-medium transition-[color,box-shadow] outline-none " \
+               "px-4 py-2 text-sm font-medium transition-[color,box-shadow] focus-ring " \
                "hover:bg-surface-sunken hover:text-text-heading " \
-               "focus-visible:ring-[3px] focus-visible:ring-interactive-focus " \
                "aria-[current]:bg-surface-sunken/50 aria-[current]:text-text-heading"
 
     # Flyout panel
@@ -25,27 +55,45 @@ module UI
               "bg-surface-overlay p-1 text-text-body shadow"
 
     # Styled link inside a flyout panel
-    PANEL_LINK = "flex flex-col gap-1 rounded-sm p-2 text-sm transition-all outline-none " \
+    PANEL_LINK = "flex flex-col gap-1 rounded-sm p-2 text-sm transition-all focus-ring " \
                  "hover:bg-surface-sunken hover:text-text-heading " \
-                 "focus-visible:ring-[3px] focus-visible:ring-interactive-focus " \
                  "aria-[current]:bg-surface-sunken/50 aria-[current]:text-text-heading"
 
     CHEVRON_PATH = "m6 9 6 6 6-6"
 
     renders_many :items, "UI::NavigationMenuComponent::ItemComponent"
 
-    def initialize(**html_attrs)
+    # align: list justification — :start | :center | :end (default :center)
+    # label: accessible name for the <nav> landmark (default: i18n "Main")
+    def initialize(align: :center, label: nil, **html_attrs)
+      @align = validate(:align, align, JUSTIFY.keys)
+      @label = label
       @extra_class = html_attrs.delete(:class)
-      @html_attrs  = html_attrs
+      @html_attrs = html_attrs
     end
 
     def call
-      content_tag(:nav, class: cn(ROOT, @extra_class), **@html_attrs) do
-        content_tag(:ul, class: LIST) do
+      content_tag(:nav,
+        class: cn(ROOT, @extra_class),
+        "aria-label": @label || I18n.t("modelrails_ui.navigation_menu.nav_label", default: "Main"),
+        **@html_attrs) do
+        content_tag(:ul, class: cn(LIST, JUSTIFY.fetch(@align))) do
           safe_join(items.map { |item| content_tag(:li, item, class: "relative") })
         end
       end
     end
+
+    private
+
+    def validate(name, value, allowed)
+      key = value.to_sym
+      return key if allowed.include?(key)
+
+      raise ArgumentError,
+        "UI::NavigationMenuComponent unknown #{name}: #{value.inspect} (allowed: #{allowed.join(", ")})"
+    end
+
+    public
 
     # Represents one entry in the navigation bar.
     # href: present  → plain styled link
@@ -54,11 +102,12 @@ module UI
       CHEVRON_PATH = "m6 9 6 6 6-6"
 
       def initialize(label:, href: nil, active: false, **html_attrs)
-        @label  = label
-        @href   = href
+        @label = label
+        @href = href
         @active = active
+        @panel_id = "nav-flyout-#{SecureRandom.hex(4)}"
         @extra_class = html_attrs.delete(:class)
-        @html_attrs  = html_attrs
+        @html_attrs = html_attrs
       end
 
       def call
@@ -97,7 +146,9 @@ module UI
           type: "button",
           class: cn(NavigationMenuComponent::TRIGGER, @extra_class),
           "aria-expanded": "false",
-          data: { navigation_menu_target: "trigger", state: "closed" },
+          "aria-haspopup": "true",
+          "aria-controls": @panel_id,
+          data: {navigation_menu_target: "trigger", state: "closed"},
           **@html_attrs) do
           concat @label
           concat chevron
@@ -107,6 +158,7 @@ module UI
       def flyout
         content_tag(:div,
           content,
+          id: @panel_id,
           class: NavigationMenuComponent::CONTENT,
           hidden: true,
           data: {

--- a/lib/generators/modelrails_ui/add/templates/sidebar/sidebar_component.rb.tt
+++ b/lib/generators/modelrails_ui/add/templates/sidebar/sidebar_component.rb.tt
@@ -20,7 +20,7 @@ module UI
 
     TOGGLE_CLS = "inline-flex size-8 items-center justify-center rounded-md " \
                  "text-text-muted hover:bg-surface-sunken hover:text-text-heading " \
-                 "focus-visible:ring-[3px] focus-visible:ring-interactive-focus outline-none transition"
+                 "focus-ring transition"
 
     NAV_CLS = "flex-1 overflow-y-auto px-2 py-3"
 
@@ -33,7 +33,7 @@ module UI
                "group-data-[collapsed=true]:justify-center group-data-[collapsed=true]:gap-0 " \
                "hover:bg-surface-sunken hover:text-text-heading " \
                "aria-[current]:bg-surface-sunken aria-[current]:text-text-heading aria-[current]:font-semibold " \
-               "focus-visible:ring-[3px] focus-visible:ring-interactive-focus outline-none"
+               "focus-ring"
 
     ITEM_LABEL = "transition-[opacity,width] group-data-[collapsed=true]:w-0 " \
                  "group-data-[collapsed=true]:opacity-0 group-data-[collapsed=true]:overflow-hidden " \
@@ -44,9 +44,11 @@ module UI
 
     # brand:     text shown in the header
     # collapsed: initial collapsed state (default: false)
-    def initialize(brand: nil, collapsed: false, **html_attrs)
+    # label:     accessible name for the <nav> landmark (default: i18n "Sidebar")
+    def initialize(brand: nil, collapsed: false, label: nil, **html_attrs)
       @brand       = brand
       @collapsed   = collapsed
+      @label       = label
       @extra_class = html_attrs.delete(:class)
       @html_attrs  = html_attrs
     end
@@ -75,12 +77,13 @@ module UI
     def toggle_btn
       content_tag(:button, type: "button",
         class: TOGGLE_CLS,
-        "aria-label": "Toggle sidebar",
+        "aria-label": I18n.t("modelrails_ui.sidebar.toggle", default: "Toggle sidebar"),
         data: { action: "click->sidebar#toggle" }) { chevron_icon }
     end
 
     def nav_body
-      content_tag(:nav, class: NAV_CLS) do
+      content_tag(:nav, class: NAV_CLS,
+        "aria-label": @label || I18n.t("modelrails_ui.sidebar.nav_label", default: "Sidebar")) do
         concat safe_join(groups) if groups.any?
         concat content_tag(:div, safe_join(items), class: "space-y-0.5") if items.any?
         concat content if content?

--- a/lib/generators/modelrails_ui/add/templates/speed_dial/speed_dial_component.rb.tt
+++ b/lib/generators/modelrails_ui/add/templates/speed_dial/speed_dial_component.rb.tt
@@ -2,51 +2,68 @@
 
 module UI
   class SpeedDialComponent < ApplicationComponent
-    # Floating action button that expands into a stack of sub-action buttons.
+    # Floating action button (FAB) that expands into a stack of sub-action buttons.
+    #
+    # ## Accessibility contract
+    # - The FAB is a **disclosure trigger**: it carries `aria-expanded` (synced to the
+    #   open state by the `speed-dial` controller) + `aria-controls` pointing at the
+    #   hidden action panel, and an i18n accessible name (it's an icon-only button).
+    # - The FAB and every action carry the AAA offset `focus-ring` (never a box-shadow
+    #   `ring`, which is clipped by `overflow:hidden` ancestors and vanishes in
+    #   forced-colors mode).
+    # - The `+` glyph is decorative (`aria-hidden`); the accessible name comes from
+    #   `aria-label`.
+    # - `position:` is fail-loud — an unknown value raises in dev rather than silently
+    #   falling back.
     #
     # Usage:
-    #   ui :speed_dial, icon: :plus do |dial|
-    #     dial.with_action(label: "New document", icon: :file, href: "/docs/new")
-    #     dial.with_action(label: "Upload",        icon: :upload, data: { action: "..." })
+    #   ui :speed_dial do |dial|
+    #     dial.with_action(label: "New document", href: "/docs/new")
+    #     dial.with_action(label: "Upload", data: { action: "..." })
     #   end
 
     FAB_CLS = "relative z-50 inline-flex size-14 items-center justify-center rounded-full " \
               "bg-interactive text-text-on-interactive shadow-lg transition-transform " \
-              "hover:bg-interactive-hover focus-visible:outline-none focus-visible:ring-[3px] " \
-              "focus-visible:ring-interactive-focus active:scale-95"
+              "hover:bg-interactive-hover focus-ring active:scale-95"
 
     PANEL_CLS = "absolute bottom-16 right-0 flex flex-col-reverse items-end gap-2"
 
     ACTION_CLS = "flex items-center gap-2 rounded-full bg-surface-raised px-4 py-2 text-sm font-medium " \
-                 "shadow-md border border-border transition-all " \
-                 "hover:bg-surface-sunken hover:text-text-heading " \
-                 "focus-visible:ring-[3px] focus-visible:ring-interactive-focus outline-none " \
+                 "shadow-md border border-border transition-colors " \
+                 "hover:bg-surface-sunken hover:text-text-heading focus-ring " \
                  "whitespace-nowrap"
 
-    PLUS_PATH  = "M12 5v14M5 12h14"
+    PLUS_PATH = "M12 5v14M5 12h14"
+
+    # position: which corner the dial anchors to (and which way actions stack).
+    POSITIONS = {
+      bottom_right:  "fixed bottom-6 right-6",
+      bottom_left:   "fixed bottom-6 left-6",
+      bottom_center: "fixed bottom-6 left-1/2 -translate-x-1/2"
+    }.freeze
 
     renders_many :actions, "UI::SpeedDialComponent::ActionComponent"
 
     # position: :bottom_right (default) | :bottom_left | :bottom_center
-    def initialize(position: :bottom_right, **html_attrs)
-      @position    = position.to_sym
+    # label:    accessible name for the FAB (default: i18n "Open actions")
+    def initialize(position: :bottom_right, label: nil, **html_attrs)
+      @position    = coerce_position(position)
+      @label       = label
+      @panel_id    = "speed-dial-panel-#{SecureRandom.hex(4)}"
       @extra_class = html_attrs.delete(:class)
       @html_attrs  = html_attrs
     end
 
     def call
-      position_cls = {
-        bottom_right:  "fixed bottom-6 right-6",
-        bottom_left:   "fixed bottom-6 left-6",
-        bottom_center: "fixed bottom-6 left-1/2 -translate-x-1/2"
-      }.fetch(@position, "fixed bottom-6 right-6")
-
+      # Merge the controller wiring UNDER any caller-supplied data: so passthrough
+      # attrs never clobber the speed-dial controller/action binding.
+      caller_data = @html_attrs.delete(:data) || {}
       content_tag(:div,
-        class: cn("relative", position_cls, @extra_class),
+        class: cn("relative", POSITIONS.fetch(@position), @extra_class),
         data: {
           controller: "speed-dial",
           action: "click@document->speed-dial#closeOnClickOutside"
-        },
+        }.merge(caller_data),
         **@html_attrs) do
         concat action_panel
         concat fab_button
@@ -55,12 +72,22 @@ module UI
 
     private
 
+    def coerce_position(value)
+      key = value.to_sym
+      return key if POSITIONS.key?(key)
+
+      raise ArgumentError,
+        "UI::SpeedDialComponent: unknown position #{value.inspect}. " \
+        "Expected one of: #{POSITIONS.keys.join(", ")}."
+    end
+
     def fab_button
       content_tag(:button,
         type: "button",
         class: FAB_CLS,
         "aria-expanded": "false",
-        "aria-label": "Open actions",
+        "aria-controls": @panel_id,
+        "aria-label": @label || I18n.t("modelrails_ui.speed_dial.open", default: "Open actions"),
         data: {
           speed_dial_target: "fab",
           action: "click->speed-dial#toggle"
@@ -71,6 +98,7 @@ module UI
 
     def action_panel
       content_tag(:div,
+        id: @panel_id,
         class: PANEL_CLS,
         hidden: true,
         data: { speed_dial_target: "panel" }) do

--- a/lib/generators/modelrails_ui/lookbook/templates/previews/ui/bottom_nav_component_preview.rb
+++ b/lib/generators/modelrails_ui/lookbook/templates/previews/ui/bottom_nav_component_preview.rb
@@ -1,0 +1,21 @@
+# frozen_string_literal: true
+
+module UI
+  # # BottomNav
+  #
+  # A fixed mobile bottom navigation bar: a **named** `<nav>` landmark pinned to the
+  # bottom of the viewport, holding a row of icon+label destinations.
+  #
+  # ## Accessibility contract
+  # - **Guarantees:** a named `<nav>` landmark (i18n default "Bottom navigation",
+  #   override via `label:`), the AAA `focus-ring` on every item, and
+  #   `aria-current="page"` on the active item.
+  # - **You supply:** `items:` (`[{ label:, href:, active:, icon: }]`).
+  class BottomNavComponentPreview < ViewComponent::Preview
+    include UIHelper
+
+    # A three-tab bar with the first item active and inline SVG icons.
+    def default
+    end
+  end
+end

--- a/lib/generators/modelrails_ui/lookbook/templates/previews/ui/bottom_nav_component_preview/default.html.erb
+++ b/lib/generators/modelrails_ui/lookbook/templates/previews/ui/bottom_nav_component_preview/default.html.erb
@@ -1,0 +1,21 @@
+<%# The bar is `fixed bottom-0` in the app; the relative wrapper pins it inside the preview frame. %>
+<div class="relative h-40 overflow-hidden rounded-lg border border-border bg-page">
+  <%= ui :bottom_nav, items: [
+        {
+          label: "Home",
+          href: "#",
+          active: true,
+          icon: %(<svg xmlns="http://www.w3.org/2000/svg" width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><path d="m3 9 9-7 9 7v11a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2z"/><path d="M9 22V12h6v10"/></svg>)
+        },
+        {
+          label: "Search",
+          href: "#",
+          icon: %(<svg xmlns="http://www.w3.org/2000/svg" width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><circle cx="11" cy="11" r="8"/><path d="m21 21-4.3-4.3"/></svg>)
+        },
+        {
+          label: "Profile",
+          href: "#",
+          icon: %(<svg xmlns="http://www.w3.org/2000/svg" width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><circle cx="12" cy="8" r="5"/><path d="M20 21a8 8 0 0 0-16 0"/></svg>)
+        }
+      ] %>
+</div>

--- a/lib/generators/modelrails_ui/lookbook/templates/previews/ui/mega_menu_component_preview.rb
+++ b/lib/generators/modelrails_ui/lookbook/templates/previews/ui/mega_menu_component_preview.rb
@@ -1,0 +1,24 @@
+# frozen_string_literal: true
+
+module UI
+  # # Mega menu
+  #
+  # A disclosure button that reveals a full-width panel of grouped **navigation
+  # links**. Unlike `dropdown_menu`/`menubar` (which use the WAI-ARIA `menu`
+  # pattern), this is a disclosure + named `<nav>` region — the panel holds ordinary
+  # anchor links that keep native Tab/anchor behavior.
+  #
+  # ## Accessibility contract
+  # - **Guarantees:** a real `<button>` trigger with `aria-haspopup`, synced
+  #   `aria-expanded`, and `aria-controls` → the panel; the panel is a `<nav>`
+  #   landmark named by the trigger label; AAA `focus-ring` on the trigger and every
+  #   link; a decorative (`aria-hidden`) chevron; outside-click dismissal.
+  # - **You supply:** a `label:` and one or more `with_column(heading:, items:)` blocks.
+  class MegaMenuComponentPreview < ViewComponent::Preview
+    include UIHelper
+
+    # A two-column products menu of navigation links.
+    def default
+    end
+  end
+end

--- a/lib/generators/modelrails_ui/lookbook/templates/previews/ui/mega_menu_component_preview/default.html.erb
+++ b/lib/generators/modelrails_ui/lookbook/templates/previews/ui/mega_menu_component_preview/default.html.erb
@@ -1,0 +1,14 @@
+<%= ui :mega_menu, label: "Products" do |m| %>
+  <% m.with_column(heading: "Platform", items: [
+    { title: "Overview", description: "Tour the whole product", href: "#" },
+    { title: "Pricing", description: "Plans for every team", href: "#" }
+  ]) %>
+  <% m.with_column(heading: "Solutions", items: [
+    { title: "For startups", description: "Ship faster", href: "#" },
+    { title: "For enterprise", description: "Scale securely", href: "#" }
+  ]) %>
+  <% m.with_column(heading: "Resources", items: [
+    { title: "Docs", description: "Guides and API reference", href: "#" },
+    { title: "Changelog", href: "#" }
+  ]) %>
+<% end %>

--- a/lib/generators/modelrails_ui/lookbook/templates/previews/ui/navigation_menu_component_preview.rb
+++ b/lib/generators/modelrails_ui/lookbook/templates/previews/ui/navigation_menu_component_preview.rb
@@ -1,0 +1,26 @@
+# frozen_string_literal: true
+
+module UI
+  # # Navigation menu
+  #
+  # A horizontal site-navigation bar: a **named** `<nav>` landmark whose entries are
+  # links, with some opening a **disclosure** flyout (the APG navigation-menu — NOT a
+  # `role="menu"` widget). Flyout triggers are real `<button>`s whose `aria-expanded`
+  # is synced (and `aria-controls` points at their `id`'d panel) by the component-owned
+  # `navigation-menu` controller.
+  #
+  # ## Accessibility contract
+  # - **Guarantees:** a named `<nav>` landmark (i18n default, override via `label:`);
+  #   disclosure triggers carry `aria-expanded` (synced) + `aria-controls`; the AAA
+  #   `focus-ring` on every link, trigger and panel link; `aria-current="page"` on the
+  #   active link; the chevron is decorative.
+  # - **You supply:** items (label, optional href, optional active) and — for flyout
+  #   items — the panel links via the slot block.
+  class NavigationMenuComponentPreview < ViewComponent::Preview
+    include UIHelper
+
+    # A bar of links plus a disclosure flyout.
+    def default
+    end
+  end
+end

--- a/lib/generators/modelrails_ui/lookbook/templates/previews/ui/navigation_menu_component_preview/default.html.erb
+++ b/lib/generators/modelrails_ui/lookbook/templates/previews/ui/navigation_menu_component_preview/default.html.erb
@@ -1,0 +1,14 @@
+<%= ui :navigation_menu, label: "Primary" do |nav| %>
+  <% nav.with_item(label: "Home", href: "#", active: true) %>
+  <% nav.with_item(label: "Docs", href: "#") %>
+  <% nav.with_item(label: "Products") do %>
+    <a href="#" class="flex flex-col gap-1 rounded-sm p-2 text-sm transition-all focus-ring hover:bg-surface-sunken hover:text-text-heading">
+      <span class="font-medium text-text-heading">Analytics</span>
+      <span class="text-text-muted">Dashboards and reports</span>
+    </a>
+    <a href="#" class="flex flex-col gap-1 rounded-sm p-2 text-sm transition-all focus-ring hover:bg-surface-sunken hover:text-text-heading">
+      <span class="font-medium text-text-heading">Automation</span>
+      <span class="text-text-muted">Workflows and triggers</span>
+    </a>
+  <% end %>
+<% end %>

--- a/lib/generators/modelrails_ui/lookbook/templates/previews/ui/sidebar_component_preview.rb
+++ b/lib/generators/modelrails_ui/lookbook/templates/previews/ui/sidebar_component_preview.rb
@@ -1,0 +1,26 @@
+# frozen_string_literal: true
+
+module UI
+  # # Sidebar
+  #
+  # A collapsible application sidebar: an `<aside>` rail containing a **named**
+  # `<nav>` landmark with grouped items. The rail collapses to an icon strip
+  # (purely visual — labels stay in the accessibility tree).
+  #
+  # ## Accessibility contract
+  # - **Guarantees:** a named `<nav>` landmark (i18n default, override via `label:`),
+  #   an i18n-labelled toggle, AAA `focus-ring` on the toggle and every item, and
+  #   `aria-current="page"` on the active item.
+  # - **You supply:** groups/items (label, href, optional icon, active).
+  class SidebarComponentPreview < ViewComponent::Preview
+    include UIHelper
+
+    # Expanded rail with grouped nav items.
+    def default
+    end
+
+    # The collapsed rail — labels clip to icons but remain in the a11y tree.
+    def collapsed
+    end
+  end
+end

--- a/lib/generators/modelrails_ui/lookbook/templates/previews/ui/sidebar_component_preview/collapsed.html.erb
+++ b/lib/generators/modelrails_ui/lookbook/templates/previews/ui/sidebar_component_preview/collapsed.html.erb
@@ -1,0 +1,7 @@
+<%= ui :sidebar, brand: "Acme", collapsed: true do |s| %>
+  <% s.with_group(label: "Main") do |g| %>
+    <% g.with_item(label: "Dashboard", href: "#", icon: :home, active: true) %>
+    <% g.with_item(label: "Tasks", href: "#", icon: :tasks) %>
+    <% g.with_item(label: "Team", href: "#", icon: :users) %>
+  <% end %>
+<% end %>

--- a/lib/generators/modelrails_ui/lookbook/templates/previews/ui/sidebar_component_preview/default.html.erb
+++ b/lib/generators/modelrails_ui/lookbook/templates/previews/ui/sidebar_component_preview/default.html.erb
@@ -1,0 +1,11 @@
+<%= ui :sidebar, brand: "Acme" do |s| %>
+  <% s.with_group(label: "Main") do |g| %>
+    <% g.with_item(label: "Dashboard", href: "#", icon: :home, active: true) %>
+    <% g.with_item(label: "Tasks", href: "#", icon: :tasks) %>
+    <% g.with_item(label: "Team", href: "#", icon: :users) %>
+  <% end %>
+  <% s.with_group(label: "Account") do |g| %>
+    <% g.with_item(label: "Settings", href: "#", icon: :settings) %>
+    <% g.with_item(label: "Sign out", href: "#", icon: :logout) %>
+  <% end %>
+<% end %>

--- a/lib/generators/modelrails_ui/lookbook/templates/previews/ui/speed_dial_component_preview.rb
+++ b/lib/generators/modelrails_ui/lookbook/templates/previews/ui/speed_dial_component_preview.rb
@@ -1,0 +1,29 @@
+# frozen_string_literal: true
+
+module UI
+  # # Speed dial
+  #
+  # A floating action button (FAB) that expands into a stack of sub-actions — the
+  # classic Material "speed dial". The FAB anchors to a screen corner; tapping it
+  # discloses the action panel, driven by the `speed-dial` Stimulus controller.
+  #
+  # ## Accessibility contract
+  # - **Guarantees:** the FAB is a disclosure trigger — i18n accessible name
+  #   (`label:` to override), `aria-expanded` synced to the open state, and
+  #   `aria-controls` pointing at the hidden action panel. The FAB and every action
+  #   carry the AAA offset `focus-ring`. The `+` glyph is decorative (`aria-hidden`).
+  # - **You supply:** actions (label + optional href; an href renders an `<a>`,
+  #   otherwise a `<button>`).
+  # - **Fail-loud:** an unknown `position:` raises in dev.
+  class SpeedDialComponentPreview < ViewComponent::Preview
+    include UIHelper
+
+    # The default bottom-right dial with three actions. The panel is collapsed until
+    # the FAB is activated.
+    #
+    # @param position select { choices: [bottom_right, bottom_left, bottom_center] }
+    def default(position: :bottom_right)
+      render_with_template(locals: {position: position.to_sym})
+    end
+  end
+end

--- a/lib/generators/modelrails_ui/lookbook/templates/previews/ui/speed_dial_component_preview/default.html.erb
+++ b/lib/generators/modelrails_ui/lookbook/templates/previews/ui/speed_dial_component_preview/default.html.erb
@@ -1,0 +1,5 @@
+<%= ui :speed_dial, position: position do |dial| %>
+  <% dial.with_action(label: "New document", href: "#") %>
+  <% dial.with_action(label: "Upload file", href: "#") %>
+  <% dial.with_action(label: "Invite people") %>
+<% end %>

--- a/test/render/bottom_nav_render_test.rb
+++ b/test/render/bottom_nav_render_test.rb
@@ -1,0 +1,86 @@
+# frozen_string_literal: true
+
+require "render_test_helper"
+
+load_component "bottom_nav", "bottom_nav_component.rb.tt"
+
+# STRUCTURE-only render specs. BottomNav is a fixed <nav> landmark holding a row of
+# link items; each item carries the AAA focus-ring and the active one gets
+# aria-current="page". The app 0b proves AAA contrast in a real browser; here we
+# assert the scaffolding + the landmark/focus contract.
+class BottomNavRenderTest < ViewComponent::TestCase
+  def items
+    [
+      {label: "Home", href: "/", active: true},
+      {label: "Search", href: "/search"},
+      {label: "Profile", href: "/profile"}
+    ]
+  end
+
+  def render_basic(**opts)
+    render_inline(UI::BottomNavComponent.new(items: items, **opts))
+  end
+
+  def test_renders_a_fixed_nav_bar
+    render_basic
+
+    assert_selector "nav.fixed.bottom-0.bg-surface-raised"
+  end
+
+  # The <nav> landmark gets an accessible name (i18n default) so it's distinguishable
+  # from other navs on the page.
+  def test_nav_landmark_has_the_i18n_default_accessible_name
+    render_basic
+
+    assert_selector "nav[aria-label='Bottom navigation']"
+  end
+
+  def test_custom_label_names_the_nav
+    render_basic(label: "Primary")
+
+    assert_selector "nav[aria-label='Primary']"
+  end
+
+  def test_items_carry_the_focus_ring_and_active_gets_aria_current
+    render_basic
+
+    assert_selector "a.focus-ring[href='/'][aria-current='page']", text: "Home"
+    assert_selector "a.focus-ring[href='/search']", text: "Search"
+    assert_no_selector "a[href='/search'][aria-current]"
+  end
+
+  def test_active_item_uses_the_interactive_token
+    render_basic
+
+    assert_selector "a.text-interactive[href='/']", text: "Home"
+    assert_selector "a.text-text-muted[href='/search']", text: "Search"
+  end
+
+  def test_renders_an_optional_icon_string
+    render_inline(
+      UI::BottomNavComponent.new(
+        items: [{label: "Home", href: "/", icon: "<svg data-icon='home'></svg>"}]
+      )
+    )
+
+    assert_selector "a[href='/'] svg[data-icon='home']"
+  end
+
+  # Regression guard: the ring anti-pattern must never come back.
+  def test_no_box_shadow_ring_or_outline_none
+    render_basic
+    html = page.native.to_html
+
+    refute_includes html, "focus-visible:ring-"
+    refute_includes html, "outline-none"
+  end
+
+  # html_attrs pass through onto the root <nav>.
+  def test_passes_through_html_attrs_onto_the_root
+    render_inline(
+      UI::BottomNavComponent.new(items: items, id: "app-bottom-nav", data: {testid: "bn"})
+    )
+
+    assert_selector "nav#app-bottom-nav[data-testid='bn']"
+  end
+end

--- a/test/render/mega_menu_render_test.rb
+++ b/test/render/mega_menu_render_test.rb
@@ -1,0 +1,129 @@
+# frozen_string_literal: true
+
+require "render_test_helper"
+load_component "mega_menu", "mega_menu_component.rb.tt"
+
+# STRUCTURE-only render specs. The `mega-menu` controller's BEHAVIOR (open/close,
+# outside-click dismissal, aria-expanded sync) is proven by the app 0b browser spec —
+# the render harness cannot exercise JS, so here we assert the static scaffolding the
+# controller drives, the disclosure/nav semantics, and the AAA focus-ring contract.
+#
+# Semantics note: a mega menu is a disclosure revealing a <nav> region of links, NOT
+# the WAI-ARIA `menu` pattern — so there is intentionally no role=menu / role=menuitem
+# and no shared `menu` controller here (unlike dropdown_menu/menubar).
+class MegaMenuRenderTest < ViewComponent::TestCase
+  def render_menu(**opts)
+    render_inline(UI::MegaMenuComponent.new(label: "Products", **opts)) do |m|
+      m.with_column(heading: "Platform", items: [
+        {title: "Overview", description: "Tour the product", href: "/overview"},
+        {title: "Pricing", href: "/pricing"}
+      ])
+      m.with_column(heading: "Resources", items: [
+        {title: "Docs", href: "/docs"}
+      ])
+    end
+  end
+
+  def test_wrapper_wires_the_mega_menu_controller_and_outside_click
+    render_menu(id: "mm1")
+
+    assert_selector "div#mm1[data-controller='mega-menu']" \
+                    "[data-action~='click@document->mega-menu#closeOnClickOutside']",
+      visible: :all
+  end
+
+  # Disclosure button: real <button> with haspopup, synced aria-expanded, and
+  # aria-controls pointing at the panel.
+  def test_trigger_is_a_disclosure_button_with_aria_wiring
+    render_menu(id: "mm2")
+
+    assert_selector "button[type='button'][aria-haspopup='true'][aria-expanded='false']" \
+                    "[aria-controls='mm2-panel'][data-mega-menu-target='trigger']" \
+                    "[data-action~='click->mega-menu#toggle']",
+      text: "Products", visible: :all
+  end
+
+  # The trigger label IS the accessible name — no separate i18n string needed, but the
+  # trigger must carry the offset focus-ring (not a box-shadow ring).
+  def test_trigger_carries_the_focus_ring
+    render_menu
+
+    assert_selector "button.focus-ring[aria-haspopup='true']", text: "Products", visible: :all
+  end
+
+  # The revealed panel is a named <nav> landmark (named by the trigger label) and is
+  # hidden until disclosed, wired as the controller's panel target + aria-controls target.
+  def test_panel_is_a_named_nav_landmark_and_hidden
+    render_menu(id: "mm3")
+
+    assert_selector "nav#mm3-panel[aria-label='Products'][hidden]" \
+                    "[data-mega-menu-target='panel']",
+      visible: :all
+  end
+
+  def test_columns_render_their_headings
+    render_menu
+
+    assert_selector "p", text: "Platform", visible: :all
+    assert_selector "p", text: "Resources", visible: :all
+  end
+
+  def test_columns_render_link_items
+    render_menu
+
+    assert_selector "a[href='/overview']", text: "Overview", visible: :all
+    assert_selector "a[href='/docs']", text: "Docs", visible: :all
+  end
+
+  # Nav links carry the AAA focus-ring (they are ordinary anchors, not role=menuitem).
+  def test_link_items_carry_the_focus_ring
+    render_menu
+
+    assert_selector "a.focus-ring[href='/overview']", text: "Overview", visible: :all
+  end
+
+  # Semantics guard: this is a disclosure+nav, NOT a role=menu. The menu roles must
+  # never leak in.
+  def test_does_not_use_the_menu_role_pattern
+    render_menu
+
+    assert_no_selector "[role='menu']", visible: :all
+    assert_no_selector "[role='menuitem']", visible: :all
+  end
+
+  # The chevron is decorative.
+  def test_chevron_is_decorative
+    render_menu
+
+    assert_selector "svg[aria-hidden='true'][data-mega-menu-target='chevron']", visible: :all
+  end
+
+  # Regression guard: the ring anti-pattern must never come back.
+  def test_no_box_shadow_ring_or_outline_none
+    render_menu
+    html = page.native.to_html
+
+    refute_includes html, "focus-visible:ring-"
+    refute_includes html, "outline-none"
+  end
+
+  def test_explicit_cols_overrides_the_auto_grid
+    render_menu(cols: 4)
+
+    assert_selector "div.grid-cols-4", visible: :all
+  end
+
+  def test_requires_a_label
+    assert_raises(ArgumentError) { UI::MegaMenuComponent.new }
+  end
+
+  # html_attrs pass through onto the root <div>, and a caller class merges without
+  # clobbering the positioning context.
+  def test_passes_through_html_attrs_and_merges_class
+    render_inline(UI::MegaMenuComponent.new(label: "Products", class: "mt-4", data: {testid: "mm"})) do |m|
+      m.with_column(items: [{title: "Docs", href: "/docs"}])
+    end
+
+    assert_selector "div.relative.mt-4[data-testid='mm']", visible: :all
+  end
+end

--- a/test/render/navigation_menu_render_test.rb
+++ b/test/render/navigation_menu_render_test.rb
@@ -1,0 +1,118 @@
+# frozen_string_literal: true
+
+require "render_test_helper"
+load_component "navigation_menu", "navigation_menu_component.rb.tt"
+
+# STRUCTURE-only render specs. Navigation menu is a named <nav> landmark whose
+# flyout triggers are real <button>s implementing the APG *disclosure* pattern
+# (aria-expanded synced by the component-owned `navigation-menu` controller +
+# aria-controls → an id'd panel). The links/triggers carry the AAA focus-ring.
+# The app 0b proves AAA contrast in a real browser; here we assert the
+# scaffolding + the landmark/disclosure/focus contract.
+class NavigationMenuRenderTest < ViewComponent::TestCase
+  def render_basic(**opts)
+    render_inline(UI::NavigationMenuComponent.new(**opts)) do |nav|
+      nav.with_item(label: "Home", href: "/", active: true)
+      nav.with_item(label: "Docs", href: "/docs")
+      nav.with_item(label: "Products") do
+        "<a href='/a' class='#{UI::NavigationMenuComponent::PANEL_LINK}'>A</a>".html_safe
+      end
+    end
+  end
+
+  def test_root_is_a_named_nav_landmark_with_the_i18n_default
+    render_basic
+
+    assert_selector "nav[aria-label='Main'] > ul"
+  end
+
+  def test_custom_label_names_the_nav
+    render_basic(label: "Primary")
+
+    assert_selector "nav[aria-label='Primary']"
+  end
+
+  # Plain links carry the offset focus-ring (not a box-shadow ring); active → aria-current.
+  def test_links_carry_the_focus_ring_and_active_gets_aria_current
+    render_basic
+
+    assert_selector "a.focus-ring[href='/'][aria-current='page']", text: "Home"
+    assert_selector "a.focus-ring[href='/docs']", text: "Docs"
+    assert_no_selector "a[href='/docs'][aria-current]"
+  end
+
+  # The disclosure trigger is a real <button> with the focus-ring and synced aria-expanded.
+  def test_flyout_trigger_is_a_button_with_focus_ring_and_aria_expanded
+    render_basic
+
+    assert_selector "button.focus-ring[type='button'][aria-expanded='false'][aria-haspopup='true']",
+      text: "Products"
+    assert_selector "button[data-navigation-menu-target='trigger']", text: "Products"
+  end
+
+  # Disclosure wiring: the trigger's aria-controls points at its id'd, hidden flyout panel.
+  def test_trigger_aria_controls_points_at_its_hidden_flyout_panel
+    render_basic
+
+    trigger = page.find("button[aria-haspopup='true']")
+    panel_id = trigger["aria-controls"]
+
+    refute_nil panel_id
+    assert_selector "div##{panel_id}[data-navigation-menu-target='content']", visible: :all
+  end
+
+  # The trigger wires the component-owned `navigation-menu` controller (NOT the shared `menu`).
+  def test_trigger_item_wires_the_navigation_menu_controller
+    render_basic
+
+    assert_selector "div[data-controller='navigation-menu']"
+    assert_no_selector "[data-controller='menu']"
+  end
+
+  # The chevron is decorative — kept out of the accessibility tree.
+  def test_chevron_is_decorative
+    render_basic
+
+    assert_selector "button[aria-haspopup='true'] svg[aria-hidden='true']"
+  end
+
+  # align: drives the list justification via a fail-loud enum.
+  def test_align_drives_list_justification
+    render_basic(align: :end)
+
+    assert_selector "ul[class*='justify-end']"
+  end
+
+  def test_unknown_align_raises
+    assert_raises(ArgumentError) do
+      render_inline(UI::NavigationMenuComponent.new(align: :bogus))
+    end
+  end
+
+  # Regression guard: the box-shadow ring / outline-none anti-pattern must never come back.
+  def test_no_box_shadow_ring_or_outline_none
+    render_basic
+    html = page.native.to_html
+
+    refute_includes html, "focus-visible:ring-"
+    refute_includes html, "outline-none"
+  end
+
+  # html_attrs pass through onto the root <nav>.
+  def test_passes_through_html_attrs_onto_the_root
+    render_inline(UI::NavigationMenuComponent.new(id: "site-nav", data: {testid: "nav"})) do |nav|
+      nav.with_item(label: "Home", href: "/")
+    end
+
+    assert_selector "nav#site-nav[data-testid='nav']"
+  end
+
+  # A caller-supplied class merges onto the root without clobbering the layout tokens.
+  def test_merges_caller_class_onto_the_root
+    render_inline(UI::NavigationMenuComponent.new(class: "mt-4")) do |nav|
+      nav.with_item(label: "Home", href: "/")
+    end
+
+    assert_selector "nav.mt-4[class*='max-w-max']"
+  end
+end

--- a/test/render/sidebar_render_test.rb
+++ b/test/render/sidebar_render_test.rb
@@ -1,0 +1,86 @@
+# frozen_string_literal: true
+
+require "render_test_helper"
+load_component "sidebar", "sidebar_component.rb.tt"
+
+# STRUCTURE-only render specs. Sidebar is an <aside> rail with a named <nav>
+# landmark; the toggle/items carry the AAA focus-ring. The app 0b proves AAA in a
+# real browser; here we assert the scaffolding + the landmark/focus contract.
+class SidebarRenderTest < ViewComponent::TestCase
+  def render_basic(**opts)
+    render_inline(UI::SidebarComponent.new(**opts)) do |s|
+      s.with_item(label: "Dashboard", href: "/", icon: :home, active: true)
+      s.with_item(label: "Settings", href: "/settings", icon: :settings)
+    end
+  end
+
+  def test_renders_an_aside_rail_wired_to_the_sidebar_controller
+    render_basic
+
+    assert_selector "aside[data-controller='sidebar'][data-collapsed='false']"
+  end
+
+  # The <nav> landmark gets an accessible name (i18n default) so it's distinguishable
+  # from other navs on the page.
+  def test_nav_landmark_has_the_i18n_default_accessible_name
+    render_basic
+
+    assert_selector "nav[aria-label='Sidebar']"
+  end
+
+  def test_custom_label_names_the_nav
+    render_basic(label: "Main menu")
+
+    assert_selector "nav[aria-label='Main menu']"
+  end
+
+  # The toggle is i18n-labelled and carries the offset focus-ring (not a box-shadow ring).
+  def test_toggle_button_is_i18n_labelled_and_carries_the_focus_ring
+    render_basic
+
+    assert_selector "button.focus-ring[aria-label='Toggle sidebar'][data-action='click->sidebar#toggle']"
+  end
+
+  def test_items_carry_the_focus_ring_and_active_gets_aria_current
+    render_basic
+
+    assert_selector "a.focus-ring[href='/'][aria-current='page']", text: "Dashboard"
+    assert_selector "a.focus-ring[href='/settings']", text: "Settings"
+    assert_no_selector "a[href='/settings'][aria-current]"
+  end
+
+  # Regression guard: the ring anti-pattern must never come back.
+  def test_no_box_shadow_ring_or_outline_none
+    render_basic
+    html = page.native.to_html
+
+    refute_includes html, "focus-visible:ring-"
+    refute_includes html, "outline-none"
+  end
+
+  def test_collapsed_state_renders_on_the_rail
+    render_basic(collapsed: true)
+
+    assert_selector "aside[data-collapsed='true']"
+  end
+
+  def test_renders_groups_with_labels
+    render_inline(UI::SidebarComponent.new) do |s|
+      s.with_group(label: "Main") do |g|
+        g.with_item(label: "Dashboard", href: "/")
+      end
+    end
+
+    assert_selector "p", text: "Main"
+    assert_selector "nav a[href='/']", text: "Dashboard"
+  end
+
+  # html_attrs pass through onto the root <aside>.
+  def test_passes_through_html_attrs_onto_the_root
+    render_inline(UI::SidebarComponent.new(id: "app-sidebar", data: {testid: "sb"})) do |s|
+      s.with_item(label: "X", href: "/x")
+    end
+
+    assert_selector "aside#app-sidebar[data-testid='sb']"
+  end
+end

--- a/test/render/speed_dial_render_test.rb
+++ b/test/render/speed_dial_render_test.rb
@@ -1,0 +1,113 @@
+# frozen_string_literal: true
+
+require "render_test_helper"
+load_component "speed_dial", "speed_dial_component.rb.tt"
+
+# STRUCTURE-only render specs. The disclosure behavior (toggle, aria-expanded sync to
+# the open state, outside-click dismissal, icon rotation) is driven by the `speed-dial`
+# Stimulus controller and proven by the app 0b browser spec — the render harness can't
+# exercise JS, so here we assert the static scaffolding + the focus/disclosure contract.
+class SpeedDialRenderTest < ViewComponent::TestCase
+  def render_dial(**opts)
+    render_inline(UI::SpeedDialComponent.new(**opts)) do |dial|
+      dial.with_action(label: "New document", href: "/docs/new")
+      dial.with_action(label: "Upload")
+    end
+  end
+
+  def test_renders_a_div_wired_to_the_speed_dial_controller
+    render_dial
+
+    assert_selector "div[data-controller='speed-dial']" \
+                    "[data-action~='click@document->speed-dial#closeOnClickOutside']",
+      visible: :all
+  end
+
+  # The FAB is a disclosure trigger: focus-ring + aria-expanded + i18n accessible name,
+  # wired to toggle the controller.
+  def test_fab_is_an_i18n_labelled_disclosure_trigger_with_the_focus_ring
+    render_dial
+
+    assert_selector "button.focus-ring[type='button']" \
+                    "[aria-expanded='false'][aria-controls][aria-label='Open actions']" \
+                    "[data-speed-dial-target='fab'][data-action~='click->speed-dial#toggle']",
+      visible: :all
+  end
+
+  def test_custom_label_names_the_fab
+    render_dial(label: "Quick actions")
+
+    assert_selector "button[aria-label='Quick actions']", visible: :all
+  end
+
+  # aria-controls points at the hidden action panel's id (disclosure target).
+  def test_fab_controls_the_hidden_action_panel
+    render_dial
+
+    button = page.find("button[data-speed-dial-target='fab']", visible: :all)
+    panel_id = button["aria-controls"]
+
+    assert_selector "div##{panel_id}[data-speed-dial-target='panel'][hidden]", visible: :all
+  end
+
+  # The decorative + glyph is hidden from the accessibility tree.
+  def test_plus_icon_is_decorative
+    render_dial
+
+    assert_selector "svg[aria-hidden='true'][data-speed-dial-target='icon']", visible: :all
+  end
+
+  # Every action carries the AAA offset focus-ring; a href renders an <a>, no href a <button>.
+  def test_actions_are_focusable_links_or_buttons_with_the_focus_ring
+    render_dial
+
+    assert_selector "div[data-speed-dial-target='panel'] a.focus-ring[href='/docs/new']",
+      text: "New document", visible: :all
+    assert_selector "div[data-speed-dial-target='panel'] button.focus-ring[type='button']",
+      text: "Upload", visible: :all
+  end
+
+  def test_unknown_position_raises
+    assert_raises(ArgumentError) do
+      render_inline(UI::SpeedDialComponent.new(position: :bogus))
+    end
+  end
+
+  def test_known_positions_render
+    %i[bottom_right bottom_left bottom_center].each do |pos|
+      render_inline(UI::SpeedDialComponent.new(position: pos))
+
+      assert_selector "div[data-controller='speed-dial']", visible: :all
+    end
+  end
+
+  # Regression guard: the ring anti-pattern must never come back.
+  def test_no_box_shadow_ring_or_outline_none
+    render_dial
+    html = page.native.to_html
+
+    refute_includes html, "focus-visible:ring-"
+    refute_includes html, "outline-none"
+  end
+
+  # html_attrs pass through onto the root <div>.
+  def test_passes_through_html_attrs_onto_the_root
+    render_inline(UI::SpeedDialComponent.new(id: "page-fab", data: {testid: "sd"}))
+
+    assert_selector "div#page-fab[data-testid='sd'][data-controller='speed-dial']", visible: :all
+  end
+
+  # A caller-supplied class merges onto the root without clobbering the position token.
+  def test_merges_caller_class_onto_the_root
+    render_inline(UI::SpeedDialComponent.new(class: "z-10"))
+
+    assert_selector "div.z-10[data-controller='speed-dial']", visible: :all
+  end
+
+  # Caller data: merges UNDER the controller wiring — it must not clobber it.
+  def test_caller_data_merges_without_clobbering_the_controller
+    render_inline(UI::SpeedDialComponent.new(data: {turbo_frame: "f"}))
+
+    assert_selector "div[data-controller='speed-dial'][data-turbo-frame='f']", visible: :all
+  end
+end


### PR DESCRIPTION
> ⚠️ **HOLD — do not merge until the paired app 0b confirms AAA.** The live-axe 0b catches ARIA bugs the gem-side gates can't (cf. the disclosure-band stepper `aria-prohibited-attr`). I'll comment when the app PR is green.

Nav-remainder band — sidebar exemplar + 4-way parallel fan-out.

| Component | Hardening |
|---|---|
| **sidebar** | `focus-ring` ×2; named `<nav>` landmark (`label:`→`aria-label`, i18n default); i18n toggle |
| **bottom_nav** | named `<nav>` landmark; added the missing `focus-ring` on items; semantic border token |
| **speed_dial** | `focus-ring` ×3; `aria-controls` panel wiring (controller already syncs `aria-expanded`); i18n FAB label; fail-loud `position`; **fixed a caller-`data:` attr-clobber** that silently dropped the controller |
| **mega_menu** | `focus-ring` ×2; disclosure aria (haspopup/expanded/controls); panel → named `<nav>`; caller-data merge; documented **nav-disclosure, not `role=menu`** (owns its controller) |
| **navigation_menu** | `focus-ring` ×3; named `<nav>` landmark; disclosure aria; fail-loud `align`; hover-driven nav owns its controller (not the shared `menu`) |

## Proofs
- **0a render tests:** sidebar 9 · bottom_nav 8 · speed_dial 12 · mega_menu 13 · navigation_menu 12.
- Template-backed previews each. **Full gem suite 680/0**, RuboCop clean.

App-side adoption + **0b axe-AAA** proofs ride in the paired app PR.