### PR TITLE
fix(ui): make chart's Chart.js a lazy opt-in dependency (not a top-level import)

### DIFF
--- a/docs/components/chart.md
+++ b/docs/components/chart.md
@@ -10,7 +10,7 @@ Add Chart.js to your importmap before using this component:
 
 ```ruby
 # config/importmap.rb
-pin "chart.js", to: "https://esm.sh/chart.js@4"
+pin "chart.js", to: "https://cdn.jsdelivr.net/npm/chart.js@4/+esm"
 ```
 
 ## Installation

--- a/lib/generators/modelrails_ui/add/templates/chart/chart_component.rb.tt
+++ b/lib/generators/modelrails_ui/add/templates/chart/chart_component.rb.tt
@@ -8,7 +8,7 @@ module UI
   # itself is NOT bundled; add it to your importmap before use:
   #
   #   # config/importmap.rb
-  #   pin "chart.js", to: "https://esm.sh/chart.js@4"
+  #   pin "chart.js", to: "https://cdn.jsdelivr.net/npm/chart.js@4/+esm"
   #
   # ## Usage
   #   ui :chart, type: :bar, label: "Quarterly revenue vs. costs",

--- a/lib/generators/modelrails_ui/add/templates/chart/chart_controller.js
+++ b/lib/generators/modelrails_ui/add/templates/chart/chart_controller.js
@@ -1,9 +1,10 @@
-// Requires Chart.js — add to your importmap before use:
-//   pin "chart.js", to: "https://esm.sh/chart.js@4"
+// Chart.js is an OPT-IN dependency — pin it only when you use the chart component:
+//   pin "chart.js", to: "https://cdn.jsdelivr.net/npm/chart.js@4/+esm"
+// It is imported lazily (inside connect), so this controller is inert until a chart
+// is on the page: an app that adopts the component but never renders one pays nothing,
+// and an app that hasn't pinned Chart.js gets a one-line hint, not a per-page error.
+// The accessible data table renders server-side regardless.
 import { Controller } from "@hotwired/stimulus"
-import { Chart, registerables } from "chart.js"
-
-Chart.register(...registerables)
 
 export default class extends Controller {
   static values = {
@@ -13,7 +14,20 @@ export default class extends Controller {
 
   #chart = null
 
-  connect() {
+  async connect() {
+    let Chart, registerables
+    try {
+      ({ Chart, registerables } = await import("chart.js"))
+    } catch {
+      console.info(
+        '[ui:chart] Chart.js is not pinned — the chart will not draw. Add to config/importmap.rb:\n' +
+        '  pin "chart.js", to: "https://cdn.jsdelivr.net/npm/chart.js@4/+esm"\n' +
+        "The accessible data table renders without it."
+      )
+      return
+    }
+    Chart.register(...registerables)
+
     const { labels, datasets, options = {} } = JSON.parse(this.configValue)
     this.#chart = new Chart(this.element, {
       type: this.typeValue,

--- a/lib/generators/modelrails_ui/components.rb
+++ b/lib/generators/modelrails_ui/components.rb
@@ -23,7 +23,7 @@ module ModelrailsUi
           Chart requires Chart.js. Add it to your importmap:
 
             # config/importmap.rb
-            pin "chart.js", to: "https://esm.sh/chart.js@4"
+            pin "chart.js", to: "https://cdn.jsdelivr.net/npm/chart.js@4/+esm"
 
           Then use the component:
 

--- a/lib/generators/modelrails_ui/lookbook/templates/previews/ui/chart_component_preview.rb
+++ b/lib/generators/modelrails_ui/lookbook/templates/previews/ui/chart_component_preview.rb
@@ -5,7 +5,7 @@ module UI
   #
   # A data-visualization wrapper: a `<canvas>` wired to `chart_controller.js` (a
   # thin Chart.js adapter). Chart.js is NOT bundled — pin it in your importmap
-  # (`pin "chart.js", to: "https://esm.sh/chart.js@4"`) before use.
+  # (`pin "chart.js", to: "https://cdn.jsdelivr.net/npm/chart.js@4/+esm"`) before use.
   #
   # ## Use when
   # - You're plotting a small set of series (bar/line/pie/…) and can summarize the

--- a/test/test_generator_components.rb
+++ b/test/test_generator_components.rb
@@ -547,7 +547,10 @@ class TestGeneratorComponents < Minitest::Test
   def test_chart_controller_uses_chartjs_adapter
     js = File.read(File.join(TEMPLATE_ROOT, "chart", "chart_controller.js"))
 
-    assert_includes js, "import { Chart"
+    # Chart.js is a lazy opt-in dependency: imported inside connect(), NOT at the
+    # module top level (which would make every eager-loaded page resolve it).
+    assert_includes js, 'await import("chart.js")'
+    refute_includes js, 'import { Chart, registerables } from "chart.js"'
     assert_includes js, "connect("
     assert_includes js, "disconnect("
     assert_includes js, "destroy"


### PR DESCRIPTION
Follow-up to the final band. The chart controller imported `chart.js` at module top-level, so under eager-loading every page tried to resolve it — an app that **adopts** the component but hasn't **pinned** Chart.js got a per-page `Failed to autoload controller: chart` warning. 

- Move the import into `connect()` behind try/catch → the module is **inert until a chart renders**; unpinned apps get a one-line hint, not a recurring warning; the accessible data table renders regardless.
- Re-point the pin `esm.sh` → `cdn.jsdelivr.net/npm/chart.js@4/+esm` (CSP-friendly; jsdelivr is already in the reference host's `script_src`).

Makes the chart component genuinely opt-in: a downstream app carries no Chart.js dependency until it reaches for `ui :chart`. 0a unchanged (13/31).