### PR TITLE
fix(ui): wysiwyg Quill opt-in — guard the lazy import + esm.sh→jsdelivr

### DIFF
--- a/docs/components/wysiwyg.md
+++ b/docs/components/wysiwyg.md
@@ -15,12 +15,12 @@ rails action_text:install
 
 ```ruby
 # config/importmap.rb
-pin "quill", to: "https://esm.sh/quill@2"
+pin "quill", to: "https://cdn.jsdelivr.net/npm/quill@2/+esm"
 ```
 
 ```css
 /* your CSS entry point */
-@import url("https://esm.sh/quill@2/dist/quill.snow.css");
+@import url("https://cdn.jsdelivr.net/npm/quill@2/dist/quill.snow.css");
 ```
 
 ## Usage

--- a/lib/generators/modelrails_ui/add/templates/wysiwyg/wysiwyg_component.rb.tt
+++ b/lib/generators/modelrails_ui/add/templates/wysiwyg/wysiwyg_component.rb.tt
@@ -22,9 +22,9 @@ module UI
     #
     # Quill setup:
     #   # config/importmap.rb
-    #   pin "quill", to: "https://esm.sh/quill@2"
+    #   pin "quill", to: "https://cdn.jsdelivr.net/npm/quill@2/+esm"
     #   # In your CSS entry point:
-    #   @import url("https://esm.sh/quill@2/dist/quill.snow.css");
+    #   @import url("https://cdn.jsdelivr.net/npm/quill@2/dist/quill.snow.css");
     #
     # Options:
     #   name:        form field name (required)

--- a/lib/generators/modelrails_ui/add/templates/wysiwyg/wysiwyg_controller.js
+++ b/lib/generators/modelrails_ui/add/templates/wysiwyg/wysiwyg_controller.js
@@ -1,7 +1,9 @@
-// Quill adapter — requires Quill v2 in your importmap:
-//   pin "quill", to: "https://esm.sh/quill@2"
+// Quill is an OPT-IN dependency — pin it only if you use `adapter: "quill"`:
+//   pin "quill", to: "https://cdn.jsdelivr.net/npm/quill@2/+esm"
 // Also add Quill's stylesheet to your CSS entry point:
-//   @import url("https://esm.sh/quill@2/dist/quill.snow.css");
+//   @import url("https://cdn.jsdelivr.net/npm/quill@2/dist/quill.snow.css");
+// It is imported lazily (only when the quill adapter is active), so the default
+// Trix adapter never pulls it in and an unpinned app gets a hint, not an error.
 import { Controller } from "@hotwired/stimulus"
 
 export default class extends Controller {
@@ -24,7 +26,19 @@ export default class extends Controller {
   }
 
   async #initQuill() {
-    const { default: Quill } = await import("quill")
+    let Quill
+    try {
+      ({ default: Quill } = await import("quill"))
+    } catch {
+      console.info(
+        '[ui:wysiwyg] Quill is not pinned — the editor will not initialize. Add to config/importmap.rb:\n' +
+        '  pin "quill", to: "https://cdn.jsdelivr.net/npm/quill@2/+esm"\n' +
+        'and import its stylesheet in your CSS:\n' +
+        '  @import url("https://cdn.jsdelivr.net/npm/quill@2/dist/quill.snow.css");'
+      )
+      return
+    }
+
     this.#quill = new Quill(this.editorTarget, {
       theme: "snow",
       placeholder: this.placeholderValue,

--- a/lib/generators/modelrails_ui/components.rb
+++ b/lib/generators/modelrails_ui/components.rb
@@ -40,11 +40,11 @@ module ModelrailsUi
           To use Quill (adapter: :quill), add it to your importmap:
 
             # config/importmap.rb
-            pin "quill", to: "https://esm.sh/quill@2"
+            pin "quill", to: "https://cdn.jsdelivr.net/npm/quill@2/+esm"
 
           Also add Quill's stylesheet to your CSS entry point:
 
-            @import url("https://esm.sh/quill@2/dist/quill.snow.css");
+            @import url("https://cdn.jsdelivr.net/npm/quill@2/dist/quill.snow.css");
 
           Usage:
 

--- a/test/test_generator_components.rb
+++ b/test/test_generator_components.rb
@@ -607,7 +607,7 @@ class TestGeneratorComponents < Minitest::Test
 
     assert_includes components_rb, '"wysiwyg"'
     assert_includes components_rb, "actiontext"
-    assert_includes components_rb, "esm.sh/quill"
+    assert_includes components_rb, "cdn.jsdelivr.net/npm/quill"
   end
 
   def test_map_area_renders_img_and_map_elements


### PR DESCRIPTION
Parity with the chart opt-in fix (#43), for the other external-dep component.

Quill was **already** imported lazily (, only for `adapter: "quill"`) — so unlike chart it had no top-level-import bug. What it lacked: a **try/catch guard** (an unpinned app got an unhandled rejection instead of a hint) and the CSP-friendly CDN. Now:
- the lazy import is wrapped with a one-line hint; the default Trix adapter is untouched;
- pin + stylesheet guidance re-pointed `esm.sh` → `cdn.jsdelivr.net`.

**Gem-side only** — wysiwyg is superseded by Lexxy in the reference app (gem-0a-only, no adoption), so there's no app PR. Full gem suite 870/0, rubocop clean.