### PR TITLE
feat(lookbook): complete preview coverage — back-port 11 previews + add 3 playgrounds

### DIFF
--- a/lib/generators/modelrails_ui/lookbook/templates/previews/ui/audio_component_preview.rb
+++ b/lib/generators/modelrails_ui/lookbook/templates/previews/ui/audio_component_preview.rb
@@ -1,0 +1,23 @@
+# frozen_string_literal: true
+
+module UI
+  # # Audio
+  #
+  # A native `<audio>` player. Add one or more `<source>` elements via
+  # `a.with_source(src:, type:)`; the browser picks the first it can play.
+  #
+  # ## Accessibility contract
+  # - **Guarantees:** native browser controls (keyboard-operable, labelled by the UA).
+  # - **You supply:** at least one playable `source`.
+  class AudioComponentPreview < ViewComponent::Preview
+    include UIHelper
+
+    # Native controls with a single MP3 source.
+    def default
+    end
+
+    # Multiple sources (ogg then mp3) with looping enabled.
+    def multi_source
+    end
+  end
+end

--- a/lib/generators/modelrails_ui/lookbook/templates/previews/ui/audio_component_preview/default.html.erb
+++ b/lib/generators/modelrails_ui/lookbook/templates/previews/ui/audio_component_preview/default.html.erb
@@ -1,0 +1,7 @@
+<%# Real public audio so the player actually plays in Lookbook. The 0b spec asserts %>
+<%# the <audio> markup + axe, never media loading, so external sources are safe. %>
+<div data-test="audio">
+  <%= render(UI::AudioComponent.new) do |a| %>
+    <% a.with_source(src: "https://www.soundhelix.com/examples/mp3/SoundHelix-Song-1.mp3", type: "audio/mpeg") %>
+  <% end %>
+</div>

--- a/lib/generators/modelrails_ui/lookbook/templates/previews/ui/audio_component_preview/multi_source.html.erb
+++ b/lib/generators/modelrails_ui/lookbook/templates/previews/ui/audio_component_preview/multi_source.html.erb
@@ -1,0 +1,8 @@
+<%# Two real sources (ogg + mp3) demonstrate format fallback — the browser plays the %>
+<%# first it supports. Real public files so the player works in Lookbook. %>
+<div data-test="audio">
+  <%= render(UI::AudioComponent.new(loop: true)) do |a| %>
+    <% a.with_source(src: "https://www.w3schools.com/html/horse.ogg", type: "audio/ogg") %>
+    <% a.with_source(src: "https://www.w3schools.com/html/horse.mp3", type: "audio/mpeg") %>
+  <% end %>
+</div>

--- a/lib/generators/modelrails_ui/lookbook/templates/previews/ui/breadcrumb_component_preview.rb
+++ b/lib/generators/modelrails_ui/lookbook/templates/previews/ui/breadcrumb_component_preview.rb
@@ -1,0 +1,14 @@
+# frozen_string_literal: true
+
+module UI
+  # # Breadcrumb
+  #
+  # A breadcrumb trail. The last item is the current page (aria-current=page, not a link).
+  class BreadcrumbComponentPreview < ViewComponent::Preview
+    include UIHelper
+
+    # Home / Library / Data (Data = current page).
+    def basic
+    end
+  end
+end

--- a/lib/generators/modelrails_ui/lookbook/templates/previews/ui/breadcrumb_component_preview/basic.html.erb
+++ b/lib/generators/modelrails_ui/lookbook/templates/previews/ui/breadcrumb_component_preview/basic.html.erb
@@ -1,0 +1,7 @@
+<div class="min-h-96 p-12">
+  <%= render(UI::BreadcrumbComponent.new(items: [
+    { label: "Home", href: "#" },
+    { label: "Library", href: "#" },
+    { label: "Data" }
+  ])) %>
+</div>

--- a/lib/generators/modelrails_ui/lookbook/templates/previews/ui/carousel_component_preview.rb
+++ b/lib/generators/modelrails_ui/lookbook/templates/previews/ui/carousel_component_preview.rb
@@ -1,0 +1,28 @@
+# frozen_string_literal: true
+
+module UI
+  # # Carousel
+  #
+  # A slide carousel (WAI-ARIA APG "basic" pattern): prev/next + slide-picker dots,
+  # all real `<button>`s with ≥44px targets. Autoplay (when `autoplay:` > 0) is
+  # WCAG 2.2.2 compliant — a pause/play toggle, pause on hover/focus, and disabled
+  # under `prefers-reduced-motion`.
+  #
+  # ## Accessibility contract
+  # - **Guarantees:** a labelled `role="group"` carousel region, per-slide
+  #   `aria-roledescription="slide"` labels, ≥44px focusable controls with the
+  #   `focus-ring` utility, and (with autoplay) a 2.2.2 pause mechanism that flips
+  #   the live region to `polite` when stopped.
+  # - **You supply:** an accessible `label:` and the slide content.
+  class CarouselComponentPreview < ViewComponent::Preview
+    include UIHelper
+
+    # Manual carousel (no autoplay) with 3 slides — prev/next + dots.
+    def default
+    end
+
+    # Autoplaying carousel (3s interval) with a pause/play toggle (WCAG 2.2.2).
+    def autoplay
+    end
+  end
+end

--- a/lib/generators/modelrails_ui/lookbook/templates/previews/ui/carousel_component_preview/autoplay.html.erb
+++ b/lib/generators/modelrails_ui/lookbook/templates/previews/ui/carousel_component_preview/autoplay.html.erb
@@ -1,0 +1,7 @@
+<%# Real picsum photos; autoplaying carousel (3s) with a WCAG 2.2.2 pause/play toggle. %>
+<div data-test="carousel" class="max-w-md">
+  <%= render(UI::CarouselComponent.new(label: "Auto gallery", autoplay: 3000)) do |c| %>
+    <% c.with_slide { tag.img(src: "https://picsum.photos/id/1024/800/400", alt: "Auto one", class: "w-full") } %>
+    <% c.with_slide { tag.img(src: "https://picsum.photos/id/1043/800/400", alt: "Auto two", class: "w-full") } %>
+  <% end %>
+</div>

--- a/lib/generators/modelrails_ui/lookbook/templates/previews/ui/carousel_component_preview/default.html.erb
+++ b/lib/generators/modelrails_ui/lookbook/templates/previews/ui/carousel_component_preview/default.html.erb
@@ -1,0 +1,9 @@
+<%# Real picsum photos so the carousel demo is photo-quality; the 0b spec asserts %>
+<%# layout/behavior (flush slide, aria-current, transform), never image loading. %>
+<div data-test="carousel" class="max-w-md">
+  <%= render(UI::CarouselComponent.new(label: "Featured photos")) do |c| %>
+    <% c.with_slide { tag.img(src: "https://picsum.photos/id/1015/800/400", alt: "Slide one", class: "w-full") } %>
+    <% c.with_slide { tag.img(src: "https://picsum.photos/id/1016/800/400", alt: "Slide two", class: "w-full") } %>
+    <% c.with_slide { tag.img(src: "https://picsum.photos/id/1018/800/400", alt: "Slide three", class: "w-full") } %>
+  <% end %>
+</div>

--- a/lib/generators/modelrails_ui/lookbook/templates/previews/ui/context_menu_component_preview.rb
+++ b/lib/generators/modelrails_ui/lookbook/templates/previews/ui/context_menu_component_preview.rb
@@ -1,0 +1,22 @@
+# frozen_string_literal: true
+
+module UI
+  # # Context menu
+  #
+  # A menu of actions opened by right-clicking — or Shift+F10 / the ContextMenu key while
+  # the host has focus — on a host region, via the shared `menu` controller. No enum params
+  # (pointer-positioned), so no @param playground.
+  #
+  # ## Accessibility contract
+  # - **Guarantees:** focusable host (`aria-haspopup="menu"` + synced `aria-expanded`);
+  #   `contextmenu` + Shift+F10 open; `role="menu"` named by the host; `role="menuitem"`
+  #   items with roving tabindex.
+  # - **You supply:** a `with_trigger` host slot and `with_item` slots.
+  class ContextMenuComponentPreview < ViewComponent::Preview
+    include UIHelper
+
+    # Right-click (or focus + Shift+F10) the card to open the menu.
+    def basic
+    end
+  end
+end

--- a/lib/generators/modelrails_ui/lookbook/templates/previews/ui/context_menu_component_preview/basic.html.erb
+++ b/lib/generators/modelrails_ui/lookbook/templates/previews/ui/context_menu_component_preview/basic.html.erb
@@ -1,0 +1,14 @@
+<div class="flex min-h-96 items-center justify-center p-12">
+  <%= render(UI::ContextMenuComponent.new(label: "Card actions")) do |c| %>
+    <% c.with_trigger do %>
+      <div class="rounded-md border border-border bg-surface p-10 text-text-body">
+        Right-click me (or focus + Shift+F10)
+      </div>
+    <% end %>
+    <% c.with_item { "Edit" } %>
+    <% c.with_item { "Duplicate" } %>
+    <% c.with_item(disabled: true) { "Archive" } %>
+    <% c.with_item(separator: true) %>
+    <% c.with_item(href: "#") { "Open docs" } %>
+  <% end %>
+</div>

--- a/lib/generators/modelrails_ui/lookbook/templates/previews/ui/device_mockup_component_preview.rb
+++ b/lib/generators/modelrails_ui/lookbook/templates/previews/ui/device_mockup_component_preview.rb
@@ -37,5 +37,13 @@ module UI
     # @label Don't · content image no alt
     def dont_decorative_image_no_alt
     end
+
+    # Edit `variant` live to switch the device frame (phone/browser/tablet).
+    # @param variant select [phone, browser, tablet]
+    def playground(variant: :browser)
+      ui :device_mockup, variant: variant.to_sym, url: "https://example.com/dashboard", class: "max-w-md" do
+        '<div class="flex aspect-video items-center justify-center bg-surface-sunken text-sm text-text-body">Screen content</div>'.html_safe
+      end
+    end
   end
 end

--- a/lib/generators/modelrails_ui/lookbook/templates/previews/ui/dropdown_menu_component_preview.rb
+++ b/lib/generators/modelrails_ui/lookbook/templates/previews/ui/dropdown_menu_component_preview.rb
@@ -1,0 +1,34 @@
+# frozen_string_literal: true
+
+module UI
+  # # Dropdown menu
+  #
+  # A button that opens a menu of actions (WAI-ARIA APG menu-button), driven by the
+  # `menu` Stimulus controller. Open with the trigger; navigate with ↑/↓/Home/End or
+  # type-ahead; Enter/Space/click activates; Escape/Tab/outside-click closes.
+  #
+  # ## Accessibility contract
+  # - **Guarantees:** `aria-haspopup="menu"` + synced `aria-expanded`; `role="menu"`
+  #   named by the trigger; `role="menuitem"` items with roving tabindex.
+  # - **You supply:** a `with_trigger` slot and `with_item` slots; `aria_label:` for
+  #   icon-only triggers.
+  class DropdownMenuComponentPreview < ViewComponent::Preview
+    include UIHelper
+
+    # Standard menu: a button trigger and a labelled menu with items, a disabled item,
+    # a separator, and a link item.
+    def basic
+    end
+
+    # `side:` and `align:` edge-align the menu to the trigger.
+    def positioned
+    end
+
+    # Edit `side` and `align` live to explore placement.
+    # @param side select [bottom, top]
+    # @param align select [start, end]
+    def playground(side: :bottom, align: :start)
+      render_with_template(locals: {side: side.to_sym, align: align.to_sym})
+    end
+  end
+end

--- a/lib/generators/modelrails_ui/lookbook/templates/previews/ui/dropdown_menu_component_preview/basic.html.erb
+++ b/lib/generators/modelrails_ui/lookbook/templates/previews/ui/dropdown_menu_component_preview/basic.html.erb
@@ -1,0 +1,10 @@
+<div class="p-24 flex justify-center">
+  <%= render(UI::DropdownMenuComponent.new) do |c| %>
+    <% c.with_trigger { "Actions" } %>
+    <% c.with_item { "Edit" } %>
+    <% c.with_item { "Duplicate" } %>
+    <% c.with_item(disabled: true) { "Archive" } %>
+    <% c.with_item(separator: true) %>
+    <% c.with_item(href: "#") { "Open docs" } %>
+  <% end %>
+</div>

--- a/lib/generators/modelrails_ui/lookbook/templates/previews/ui/dropdown_menu_component_preview/playground.html.erb
+++ b/lib/generators/modelrails_ui/lookbook/templates/previews/ui/dropdown_menu_component_preview/playground.html.erb
@@ -1,0 +1,13 @@
+<%# Center the trigger in the viewport so BOTH side:top and side:bottom have room — %>
+<%# the menu is position:fixed and auto-flips to stay on-screen, so a top-anchored %>
+<%# trigger near the frame edge would otherwise flip downward and look like bottom. %>
+<div class="flex min-h-screen items-center justify-center p-12">
+  <%= render(UI::DropdownMenuComponent.new(side: side, align: align)) do |c| %>
+    <% c.with_trigger { "Menu (#{side}/#{align})" } %>
+    <% c.with_item { "First action" } %>
+    <% c.with_item { "Second action" } %>
+    <% c.with_item(disabled: true) { "Disabled action" } %>
+    <% c.with_item(separator: true) %>
+    <% c.with_item { "Last action" } %>
+  <% end %>
+</div>

--- a/lib/generators/modelrails_ui/lookbook/templates/previews/ui/dropdown_menu_component_preview/positioned.html.erb
+++ b/lib/generators/modelrails_ui/lookbook/templates/previews/ui/dropdown_menu_component_preview/positioned.html.erb
@@ -1,0 +1,8 @@
+<div class="p-24 flex justify-end">
+  <%= render(UI::DropdownMenuComponent.new(side: :bottom, align: :end)) do |c| %>
+    <% c.with_trigger { "Filters" } %>
+    <% c.with_item { "Newest first" } %>
+    <% c.with_item { "Oldest first" } %>
+    <% c.with_item { "A–Z" } %>
+  <% end %>
+</div>

--- a/lib/generators/modelrails_ui/lookbook/templates/previews/ui/embed_component_preview.rb
+++ b/lib/generators/modelrails_ui/lookbook/templates/previews/ui/embed_component_preview.rb
@@ -1,0 +1,25 @@
+# frozen_string_literal: true
+
+module UI
+  # # Embed
+  #
+  # Embeds third-party content from a `url:` (provider auto-detected from the domain)
+  # or, for Google Maps, a `query:`. Renders a titled, lazy-loaded `<iframe>` inside a
+  # responsive aspect-ratio wrapper.
+  #
+  # ## Accessibility contract
+  # - **Guarantees:** every iframe carries a non-blank `title` (i18n, per-provider
+  #   default) so screen readers announce the embedded region.
+  # - **You supply:** a recognised provider `url:` (or a maps `query:`).
+  class EmbedComponentPreview < ViewComponent::Preview
+    include UIHelper
+
+    # A YouTube video embed (titled iframe, 16/9 aspect).
+    def youtube
+    end
+
+    # A Google Maps embed from a search query (titled iframe, 16/9 aspect).
+    def map
+    end
+  end
+end

--- a/lib/generators/modelrails_ui/lookbook/templates/previews/ui/embed_component_preview/map.html.erb
+++ b/lib/generators/modelrails_ui/lookbook/templates/previews/ui/embed_component_preview/map.html.erb
@@ -1,0 +1,3 @@
+<div data-test="embed" class="max-w-xl">
+  <%= render(UI::EmbedComponent.new(query: "Eiffel Tower, Paris")) %>
+</div>

--- a/lib/generators/modelrails_ui/lookbook/templates/previews/ui/embed_component_preview/youtube.html.erb
+++ b/lib/generators/modelrails_ui/lookbook/templates/previews/ui/embed_component_preview/youtube.html.erb
@@ -1,0 +1,5 @@
+<%# The full watch?v= form exercises extract_youtube_id's query-parse path %>
+<%# (URI.decode_www_form — the Ruby-4.0 CGI.parse fix, gem #36). %>
+<div data-test="embed" class="max-w-xl">
+  <%= render(UI::EmbedComponent.new(url: "https://www.youtube.com/watch?v=dQw4w9WgXcQ")) %>
+</div>

--- a/lib/generators/modelrails_ui/lookbook/templates/previews/ui/gallery_component_preview.rb
+++ b/lib/generators/modelrails_ui/lookbook/templates/previews/ui/gallery_component_preview.rb
@@ -1,0 +1,23 @@
+# frozen_string_literal: true
+
+module UI
+  # # Gallery
+  #
+  # A responsive image grid. With `lightbox: true` (default) each cell is a
+  # focusable `<button>` that opens a single shared native `<dialog>` (the reused
+  # `modal` controller — focus-trap / Escape / restore for free). The `gallery`
+  # controller swaps the dialog image's `src`/`alt` before `modal#open` runs.
+  #
+  # ## Accessibility contract
+  # - **Guarantees:** each enlargeable cell is a real `<button>` with an i18n
+  #   accessible name ("Enlarge %{alt}") and the `focus-ring` utility; the lightbox
+  #   is a native focus-trapped `<dialog>` with an accessible close button.
+  # - **You supply:** a non-blank `alt:` per image when lightbox is on (fail-loud).
+  class GalleryComponentPreview < ViewComponent::Preview
+    include UIHelper
+
+    # A 3-up lightbox grid. Click (or keyboard-activate) any cell to enlarge it.
+    def default
+    end
+  end
+end

--- a/lib/generators/modelrails_ui/lookbook/templates/previews/ui/gallery_component_preview/default.html.erb
+++ b/lib/generators/modelrails_ui/lookbook/templates/previews/ui/gallery_component_preview/default.html.erb
@@ -1,0 +1,10 @@
+<%# Real picsum photos (as the image/picture/video previews use) so the grid and %>
+<%# lightbox are photo-quality. The 0b spec asserts markup + lightbox behavior, %>
+<%# never image loading, so external images are safe here. %>
+<div data-test="gallery">
+  <%= render(UI::GalleryComponent.new(cols: 3)) do |g| %>
+    <% g.with_image(src: "https://picsum.photos/id/1018/600/600", alt: "Forest canopy") %>
+    <% g.with_image(src: "https://picsum.photos/id/1071/600/600", alt: "City street", caption: "Downtown") %>
+    <% g.with_image(src: "https://picsum.photos/id/1016/600/600", alt: "Mountain lake") %>
+  <% end %>
+</div>

--- a/lib/generators/modelrails_ui/lookbook/templates/previews/ui/menubar_component_preview.rb
+++ b/lib/generators/modelrails_ui/lookbook/templates/previews/ui/menubar_component_preview.rb
@@ -1,0 +1,15 @@
+# frozen_string_literal: true
+
+module UI
+  # # Menubar
+  #
+  # An app menubar (WAI-ARIA APG). Tab to it (one stop), ←/→ between items, ↓/Enter to open a
+  # submenu, ↑/↓ within, Escape to close. Submenus reuse the shared `menu` controller.
+  class MenubarComponentPreview < ViewComponent::Preview
+    include UIHelper
+
+    # File / Edit / View menubar with submenus.
+    def basic
+    end
+  end
+end

--- a/lib/generators/modelrails_ui/lookbook/templates/previews/ui/menubar_component_preview/basic.html.erb
+++ b/lib/generators/modelrails_ui/lookbook/templates/previews/ui/menubar_component_preview/basic.html.erb
@@ -1,0 +1,23 @@
+<div class="min-h-96 p-12">
+  <%= render(UI::MenubarComponent.new(label: "Main")) do |bar| %>
+    <% bar.with_menu(label: "File") do |m| %>
+      <% m.with_item { "New file" } %>
+      <% m.with_item { "Open…" } %>
+      <% m.with_item(disabled: true) { "Open recent" } %>
+      <% m.with_item(separator: true) %>
+      <% m.with_item(href: "#") { "Settings" } %>
+    <% end %>
+    <% bar.with_menu(label: "Edit") do |m| %>
+      <% m.with_item { "Undo" } %>
+      <% m.with_item { "Redo" } %>
+      <% m.with_item(separator: true) %>
+      <% m.with_item { "Cut" } %>
+      <% m.with_item { "Copy" } %>
+      <% m.with_item { "Paste" } %>
+    <% end %>
+    <% bar.with_menu(label: "View") do |m| %>
+      <% m.with_item { "Zoom in" } %>
+      <% m.with_item { "Zoom out" } %>
+    <% end %>
+  <% end %>
+</div>

--- a/lib/generators/modelrails_ui/lookbook/templates/previews/ui/navbar_component_preview.rb
+++ b/lib/generators/modelrails_ui/lookbook/templates/previews/ui/navbar_component_preview.rb
@@ -1,0 +1,16 @@
+# frozen_string_literal: true
+
+module UI
+  # # Navbar
+  #
+  # A responsive nav. On a narrow viewport the links collapse behind a hamburger that discloses
+  # a stacked menu (aria-expanded/controls + Escape + outside-click). Resize the Lookbook frame
+  # narrow to see the mobile disclosure.
+  class NavbarComponentPreview < ViewComponent::Preview
+    include UIHelper
+
+    # Brand + Dashboard/Pricing/Docs links + a Sign in action (Dashboard active).
+    def basic
+    end
+  end
+end

--- a/lib/generators/modelrails_ui/lookbook/templates/previews/ui/navbar_component_preview/basic.html.erb
+++ b/lib/generators/modelrails_ui/lookbook/templates/previews/ui/navbar_component_preview/basic.html.erb
@@ -1,0 +1,17 @@
+<div class="min-h-96">
+  <%= render(UI::NavbarComponent.new(
+    brand: "Acme",
+    brand_href: "#",
+    label: "Main",
+    items: [
+      { label: "Dashboard", href: "#", active: true },
+      { label: "Pricing", href: "#" },
+      { label: "Docs", href: "#" }
+    ]
+  )) do %>
+    <a href="#" class="btn-primary">Sign in</a>
+  <% end %>
+  <div class="p-12 text-text-muted">
+    <p>Page content. Resize narrow (&lt; 768px) to reveal the hamburger + mobile menu.</p>
+  </div>
+</div>

--- a/lib/generators/modelrails_ui/lookbook/templates/previews/ui/sheet_component_preview.rb
+++ b/lib/generators/modelrails_ui/lookbook/templates/previews/ui/sheet_component_preview.rb
@@ -43,5 +43,14 @@ module UI
     # @label Bottom panel
     def side_bottom
     end
+
+    # Edit `side` live to slide the panel in from any edge.
+    # @param side select [top, right, bottom, left]
+    def playground(side: :right)
+      render(UI::SheetComponent.new(title: "Filters", side: side.to_sym)) do |c|
+        c.with_trigger { "Open sheet" }
+        "Panel slides in from the #{side} edge. Change the param to explore placement."
+      end
+    end
   end
 end

--- a/lib/generators/modelrails_ui/lookbook/templates/previews/ui/stepper_component_preview.rb
+++ b/lib/generators/modelrails_ui/lookbook/templates/previews/ui/stepper_component_preview.rb
@@ -27,5 +27,15 @@ module UI
     # The same flow stacked vertically, with optional per-step descriptions.
     def vertical
     end
+
+    # Edit `orientation` live to compare horizontal vs vertical layout.
+    # @param orientation select [horizontal, vertical]
+    def playground(orientation: :horizontal)
+      ui :stepper, orientation: orientation.to_sym, steps: [
+        {label: "Account", status: :complete},
+        {label: "Profile", status: :current},
+        {label: "Confirm", status: :pending}
+      ]
+    end
   end
 end

--- a/lib/generators/modelrails_ui/lookbook/templates/previews/ui/tabs_component_preview.rb
+++ b/lib/generators/modelrails_ui/lookbook/templates/previews/ui/tabs_component_preview.rb
@@ -1,0 +1,15 @@
+# frozen_string_literal: true
+
+module UI
+  # # Tabs
+  #
+  # APG tabs (automatic activation). Tab to the active tab, ←/→ to move + reveal panels,
+  # Home/End to jump; the disabled tab is skipped. Tab again to enter the active panel.
+  class TabsComponentPreview < ViewComponent::Preview
+    include UIHelper
+
+    # Profile / Password / Notifications (Notifications disabled).
+    def basic
+    end
+  end
+end

--- a/lib/generators/modelrails_ui/lookbook/templates/previews/ui/tabs_component_preview/basic.html.erb
+++ b/lib/generators/modelrails_ui/lookbook/templates/previews/ui/tabs_component_preview/basic.html.erb
@@ -1,0 +1,22 @@
+<div class="min-h-96 p-12">
+  <%= render(UI::TabsComponent.new(label: "Account settings")) do |t| %>
+    <% t.with_tab(title: "Profile") do %>
+      <div class="rounded-md border border-border bg-surface-raised p-4 text-text-body">
+        <h3 class="font-medium text-text-heading">Profile</h3>
+        <p class="mt-1 text-sm">Manage your public profile and avatar.</p>
+      </div>
+    <% end %>
+    <% t.with_tab(title: "Password") do %>
+      <div class="rounded-md border border-border bg-surface-raised p-4 text-text-body">
+        <h3 class="font-medium text-text-heading">Password</h3>
+        <p class="mt-1 text-sm">Change your password and review active sessions.</p>
+      </div>
+    <% end %>
+    <% t.with_tab(title: "Notifications", disabled: true) do %>
+      <div class="rounded-md border border-border bg-surface-raised p-4 text-text-body">
+        <h3 class="font-medium text-text-heading">Notifications</h3>
+        <p class="mt-1 text-sm">Coming soon.</p>
+      </div>
+    <% end %>
+  <% end %>
+</div>

--- a/lib/generators/modelrails_ui/lookbook/templates/previews/ui/video_component_preview.rb
+++ b/lib/generators/modelrails_ui/lookbook/templates/previews/ui/video_component_preview.rb
@@ -1,0 +1,24 @@
+# frozen_string_literal: true
+
+module UI
+  # # Video
+  #
+  # A native `<video>` player. Add `<source>` elements via `v.with_source(src:, type:)`
+  # and caption/subtitle `<track>` elements via `v.with_track(src:, kind:, label:, srclang:)`.
+  #
+  # ## Accessibility contract
+  # - **Guarantees:** native browser controls (keyboard-operable, UA-labelled);
+  #   a `<track kind="captions">` is exposed to the UA's captions menu.
+  # - **You supply:** at least one playable `source` and — for AAA media — captions.
+  class VideoComponentPreview < ViewComponent::Preview
+    include UIHelper
+
+    # Native controls with a poster image and a single MP4 source.
+    def default
+    end
+
+    # An MP4 source with an English captions track (kind: :captions, default).
+    def captions
+    end
+  end
+end

--- a/lib/generators/modelrails_ui/lookbook/templates/previews/ui/video_component_preview/captions.html.erb
+++ b/lib/generators/modelrails_ui/lookbook/templates/previews/ui/video_component_preview/captions.html.erb
@@ -1,0 +1,10 @@
+<%# Real, loadable media + a self-contained data-URI WebVTT track, so the captions %>
+<%# demo actually plays with a working caption and zero external track dependency. %>
+<%# The 0b spec asserts the <track kind="captions"> element + axe. %>
+<div data-test="video" class="max-w-md">
+  <%= render(UI::VideoComponent.new(poster: "https://picsum.photos/id/1016/640/360")) do |v| %>
+    <% v.with_source(src: "https://www.w3schools.com/html/mov_bbb.mp4", type: "video/mp4") %>
+    <% v.with_source(src: "https://www.w3schools.com/html/mov_bbb.webm", type: "video/webm") %>
+    <% v.with_track(src: "data:text/vtt;charset=utf-8,WEBVTT%0A%0A00:00:00.000%20--%3E%2000:00:05.000%0AEnglish%20captions%20(demo).", kind: :captions, label: "English", srclang: "en", default: true) %>
+  <% end %>
+</div>

--- a/lib/generators/modelrails_ui/lookbook/templates/previews/ui/video_component_preview/default.html.erb
+++ b/lib/generators/modelrails_ui/lookbook/templates/previews/ui/video_component_preview/default.html.erb
@@ -1,0 +1,9 @@
+<%# Real poster (picsum) + two real, loadable sources (mp4 + webm) so the preview %>
+<%# shows a poster frame AND actually plays, and demonstrates format fallback. The %>
+<%# 0b spec asserts <video> markup + axe (never media loading), so this is safe. %>
+<div data-test="video" class="max-w-md">
+  <%= render(UI::VideoComponent.new(poster: "https://picsum.photos/id/1015/640/360")) do |v| %>
+    <% v.with_source(src: "https://www.w3schools.com/html/mov_bbb.mp4", type: "video/mp4") %>
+    <% v.with_source(src: "https://www.w3schools.com/html/mov_bbb.webm", type: "video/webm") %>
+  <% end %>
+</div>


### PR DESCRIPTION
Acts on the playground-coverage review.

**Back-port (the real gap):** 11 components (audio/video/carousel/embed/gallery/breadcrumb/navbar/tabs/dropdown_menu/context_menu/menubar) had previews authored only in the reference app, so a downstream `rails g modelrails_ui:lookbook` (which copies the whole previews dir) shipped **no preview** for them. Back-ported so the catalog is complete. dropdown_menu + context_menu also bring their `@param` playgrounds.

**Playgrounds:** added interactive `@param` controls to the remaining combinatorial components — `sheet` (side ×4), `device_mockup` (variant ×3), `stepper` (orientation). Skipped `toggle_group` (its 2 types are fully shown by default+multiple) and `drawer` (bottom-only). Verified all 3 render via the app preview host.

Gem suite 870/0, rubocop clean. Pure preview/Lookbook additions — no component templates touched.