### PR TITLE
fix(lookbook): button/badge playgrounds model the two-axis variant×tone API

### DIFF
--- a/lib/generators/modelrails_ui/lookbook/templates/previews/ui/badge_component_preview.rb
+++ b/lib/generators/modelrails_ui/lookbook/templates/previews/ui/badge_component_preview.rb
@@ -71,11 +71,14 @@ module UI
     def link_href
     end
 
-    # Edit `label` and `variant` live to explore the component.
+    # Edit `label` and the two-axis `variant`/`tone` cell live. Only the 9 AAA-proven
+    # cells are offered (signals live on the SOFT variant as tinted chips; an unproven
+    # pairing raises in dev).
     # @param label text
-    # @param variant select [default, secondary, info, success, warning, danger, destructive, outline, ghost, link]
-    def playground(label: "Badge", variant: :default)
-      ui :badge, label, variant: variant.to_sym
+    # @param cell select [solid/primary, soft/primary, soft/info, soft/success, soft/warning, soft/danger, outline/neutral, ghost/neutral, link/primary]
+    def playground(label: "Badge", cell: "soft/primary")
+      variant, tone = cell.split("/")
+      ui :badge, label, variant: variant.to_sym, tone: tone.to_sym
     end
 
     # ## Don't — a badge as an action

--- a/lib/generators/modelrails_ui/lookbook/templates/previews/ui/button_component_preview.rb
+++ b/lib/generators/modelrails_ui/lookbook/templates/previews/ui/button_component_preview.rb
@@ -46,11 +46,13 @@ module UI
     def link
     end
 
-    # Edit `label` and `variant` live to explore the component.
+    # Edit `label` and the two-axis `variant`/`tone` cell live. Only the AAA-proven
+    # cells are offered (an unproven pairing raises in dev).
     # @param label text
-    # @param variant select [primary, secondary, danger, text, text_interactive, text_danger]
-    def playground(label: "Button", variant: :primary)
-      ui :button, label, variant: variant.to_sym
+    # @param cell select [solid/primary, solid/danger, outline/neutral, text/primary, text/danger]
+    def playground(label: "Button", cell: "solid/primary")
+      variant, tone = cell.split("/")
+      ui :button, label, variant: variant.to_sym, tone: tone.to_sym
     end
 
     # ## Don't — icon-only button with no accessible name

--- a/test/test_lookbook_previews_template_backed.rb
+++ b/test/test_lookbook_previews_template_backed.rb
@@ -55,7 +55,9 @@ class TestLookbookPreviewsTemplateBacked < Minitest::Test
 
   def test_playground_stays_inline_where_present
     %w[button avatar].each do |component|
-      assert_match(/def playground\(.*\)\n\s+ui /, preview_rb(component),
+      # Renders inline via `ui` — optionally after a setup line (e.g. splitting a
+      # two-axis variant/tone cell). Not template-backed.
+      assert_match(/def playground\(.*\)\n(?:\s+.+\n)*?\s+ui /, preview_rb(component),
         "#{component} playground should remain an inline explorer")
     end
   end


### PR DESCRIPTION
The `button` and `badge` playgrounds still listed the **legacy flat `variant`** values (`primary/secondary/danger/text_interactive…`) — teaching the deprecated API a developer shouldn't write in new code.

Replaced each with a single `cell` select of the **AAA-proven `variant/tone` pairs** (button: 5, badge: 9, read straight from each component's `COMBOS`). This models the current two-axis API *and* only offers proven combos — two independent `variant`+`tone` dropdowns would let you pick an unproven pairing that fail-loud-raises in the preview. Verified both render. Gem suite green.