### PR TITLE
feat(lookbook): teaching Overview page + 8-section sidebar grouping

### DIFF
--- a/lib/generators/modelrails_ui/lookbook/templates/lookbook.rb
+++ b/lib/generators/modelrails_ui/lookbook/templates/lookbook.rb
@@ -10,4 +10,5 @@ if Rails.env.development?
   vc.previews.default_layout = "component_preview"
   # Lookbook keeps its OWN preview_paths (separate from ViewComponent's).
   Rails.application.config.lookbook.preview_paths = [preview_dir]
+  Rails.application.config.lookbook.page_paths = [Rails.root.join("spec/components/previews/pages").to_s]
 end

--- a/lib/generators/modelrails_ui/lookbook/templates/previews/pages/00_overview.md.erb
+++ b/lib/generators/modelrails_ui/lookbook/templates/previews/pages/00_overview.md.erb
@@ -1,0 +1,47 @@
+---
+label: Overview
+---
+
+# modelrails_ui
+
+An **AAA-proven** (7:1 contrast, verified in CI) · **OKLCH-themed** · **Hotwire-native**
+ViewComponent library. Call every component through the `ui()` facade:
+
+```erb
+<%%= ui :button, "Save changes", variant: :solid, tone: :primary %>
+```
+
+## Reach for the Rails built-in first
+
+Before reaching for a component, prefer the framework primitive:
+
+- **`f.submit`** — form submits (already styled primary)
+- **`f.text_field`** &c. — form inputs
+- **`button_to`** — destructive / non-GET actions (CSRF-protected)
+
+## The four laws
+
+1. **Semantic tokens, never raw values** — `bg-surface`, `text-text-body`, `bg-hue-*`; no hex.
+2. **Two-axis variants** — `variant:` (shape) × `tone:` (signal).
+3. **`data-slot` is the contract** — compound parts tag their roles; spacing + ARIA key off it.
+4. **Focus is an offset `outline`** — the `focus-ring` utility, never a `ring`.
+
+## Live examples
+
+<%= embed UI::ButtonComponentPreview, :primary %>
+<%= embed UI::BannerComponentPreview, :info %>
+<%= embed UI::CardComponentPreview, :default %>
+
+## Browse
+
+The sidebar groups all components into eight sections. Start typing in the sidebar
+filter to jump to any component by name.
+
+- **Forms & Inputs** — text fields, selection controls, pickers, field wrappers
+- **Actions** — buttons and command launchers
+- **Overlays** — dialogs, drawers, sheets, popovers, menus
+- **Navigation** — bars, sidebars, breadcrumbs, tabs
+- **Feedback & Status** — alerts, banners, badges, progress
+- **Data Display** — cards, tables, timelines, avatars
+- **Media** — images, audio, video, embeds
+- **Layout** — separators, scroll areas, resizables

--- a/lib/generators/modelrails_ui/lookbook/templates/previews/ui/accordion_component_preview.rb
+++ b/lib/generators/modelrails_ui/lookbook/templates/previews/ui/accordion_component_preview.rb
@@ -17,6 +17,7 @@ module UI
   #
   # ## Modes
   # Independent (default) · `exclusive: true` (one open at a time, via Stimulus).
+  # @logical_path Data Display
   class AccordionComponentPreview < ViewComponent::Preview
     include UIHelper
 

--- a/lib/generators/modelrails_ui/lookbook/templates/previews/ui/alert_component_preview.rb
+++ b/lib/generators/modelrails_ui/lookbook/templates/previews/ui/alert_component_preview.rb
@@ -21,6 +21,7 @@ module UI
   # ## Variants
   # `default` · `info` · `success` · `warning` · `danger`
   # (`destructive` is a non-breaking alias for `danger`.)
+  # @logical_path Feedback & Status
   class AlertComponentPreview < ViewComponent::Preview
     include UIHelper
 

--- a/lib/generators/modelrails_ui/lookbook/templates/previews/ui/alert_dialog_component_preview.rb
+++ b/lib/generators/modelrails_ui/lookbook/templates/previews/ui/alert_dialog_component_preview.rb
@@ -28,6 +28,7 @@ module UI
   #   via the `modal` Stimulus controller.
   # - **You supply:** a `title:` (required — the accessible name) and footer action
   #   buttons in the `with_footer` slot. The `with_trigger` slot provides the open button.
+  # @logical_path Overlays
   class AlertDialogComponentPreview < ViewComponent::Preview
     include UIHelper
 

--- a/lib/generators/modelrails_ui/lookbook/templates/previews/ui/aspect_ratio_component_preview.rb
+++ b/lib/generators/modelrails_ui/lookbook/templates/previews/ui/aspect_ratio_component_preview.rb
@@ -21,6 +21,7 @@ module UI
   #   focus ring — it adds nothing for assistive tech to announce.
   # - **You supply:** slotted media that carries its own a11y (an `<img>` with `alt`,
   #   an `<iframe>` with `title`, etc.). The wrapper does not speak for it.
+  # @logical_path Media
   class AspectRatioComponentPreview < ViewComponent::Preview
     include UIHelper
 

--- a/lib/generators/modelrails_ui/lookbook/templates/previews/ui/audio_component_preview.rb
+++ b/lib/generators/modelrails_ui/lookbook/templates/previews/ui/audio_component_preview.rb
@@ -9,6 +9,7 @@ module UI
   # ## Accessibility contract
   # - **Guarantees:** native browser controls (keyboard-operable, labelled by the UA).
   # - **You supply:** at least one playable `source`.
+  # @logical_path Media
   class AudioComponentPreview < ViewComponent::Preview
     include UIHelper
 

--- a/lib/generators/modelrails_ui/lookbook/templates/previews/ui/avatar_component_preview.rb
+++ b/lib/generators/modelrails_ui/lookbook/templates/previews/ui/avatar_component_preview.rb
@@ -27,6 +27,7 @@ module UI
   # - **You supply:** an `aria_label:` when the avatar must be announced by assistive
   #   technology — for example, when it is the sole content of an interactive control
   #   such as a button or link. For image avatars, `aria_label:` also sets `alt`.
+  # @logical_path Data Display
   class AvatarComponentPreview < ViewComponent::Preview
     include UIHelper
 

--- a/lib/generators/modelrails_ui/lookbook/templates/previews/ui/badge_component_preview.rb
+++ b/lib/generators/modelrails_ui/lookbook/templates/previews/ui/badge_component_preview.rb
@@ -24,6 +24,7 @@ module UI
   # soft `*-surface` + saturated `text-<level>`, matching the alert + toast cards).
   # Style levels: `default` · `secondary` · `outline` · `ghost` · `link`.
   # (`destructive` is a non-breaking alias for `danger`.)
+  # @logical_path Feedback & Status
   class BadgeComponentPreview < ViewComponent::Preview
     include UIHelper
 

--- a/lib/generators/modelrails_ui/lookbook/templates/previews/ui/banner_component_preview.rb
+++ b/lib/generators/modelrails_ui/lookbook/templates/previews/ui/banner_component_preview.rb
@@ -24,6 +24,7 @@ module UI
   #
   # ## Variants
   # `default` · `info` · `success` · `warning` · `destructive`
+  # @logical_path Feedback & Status
   class BannerComponentPreview < ViewComponent::Preview
     include UIHelper
 

--- a/lib/generators/modelrails_ui/lookbook/templates/previews/ui/bottom_nav_component_preview.rb
+++ b/lib/generators/modelrails_ui/lookbook/templates/previews/ui/bottom_nav_component_preview.rb
@@ -11,6 +11,7 @@ module UI
   #   override via `label:`), the AAA `focus-ring` on every item, and
   #   `aria-current="page"` on the active item.
   # - **You supply:** `items:` (`[{ label:, href:, active:, icon: }]`).
+  # @logical_path Navigation
   class BottomNavComponentPreview < ViewComponent::Preview
     include UIHelper
 

--- a/lib/generators/modelrails_ui/lookbook/templates/previews/ui/breadcrumb_component_preview.rb
+++ b/lib/generators/modelrails_ui/lookbook/templates/previews/ui/breadcrumb_component_preview.rb
@@ -4,6 +4,7 @@ module UI
   # # Breadcrumb
   #
   # A breadcrumb trail. The last item is the current page (aria-current=page, not a link).
+  # @logical_path Navigation
   class BreadcrumbComponentPreview < ViewComponent::Preview
     include UIHelper
 

--- a/lib/generators/modelrails_ui/lookbook/templates/previews/ui/button_component_preview.rb
+++ b/lib/generators/modelrails_ui/lookbook/templates/previews/ui/button_component_preview.rb
@@ -23,6 +23,7 @@ module UI
   #
   # ## Variants
   # `primary` · `secondary` · `danger` · `text` · `text_interactive` · `text_danger`
+  # @logical_path Actions
   class ButtonComponentPreview < ViewComponent::Preview
     include UIHelper
 

--- a/lib/generators/modelrails_ui/lookbook/templates/previews/ui/button_group_component_preview.rb
+++ b/lib/generators/modelrails_ui/lookbook/templates/previews/ui/button_group_component_preview.rb
@@ -16,6 +16,7 @@ module UI
   # - **Guarantees:** a `role="group"` boundary and the segmented styling.
   # - **You supply:** the child controls (each with its own accessible name) and,
   #   optionally, an `aria_label:` to name the group when context doesn't already.
+  # @logical_path Actions
   class ButtonGroupComponentPreview < ViewComponent::Preview
     include UIHelper
 

--- a/lib/generators/modelrails_ui/lookbook/templates/previews/ui/calendar_component_preview.rb
+++ b/lib/generators/modelrails_ui/lookbook/templates/previews/ui/calendar_component_preview.rb
@@ -16,6 +16,7 @@ module UI
   #   tabindex) with arrow-key navigation; i18n-labelled prev/next buttons; and
   #   the AAA offset `focus-ring` on every control.
   # - **You supply:** `selected:`/`month:` Dates and optional `min:`/`max:` bounds.
+  # @logical_path Forms & Inputs
   class CalendarComponentPreview < ViewComponent::Preview
     include UIHelper
 

--- a/lib/generators/modelrails_ui/lookbook/templates/previews/ui/card_component_preview.rb
+++ b/lib/generators/modelrails_ui/lookbook/templates/previews/ui/card_component_preview.rb
@@ -22,6 +22,7 @@ module UI
   #   is non-interactive and adds no ARIA role.
   # - **You supply:** the heading via `card_title` (set `level:` so it sits correctly
   #   in the page outline) and any focusable controls inside the regions.
+  # @logical_path Data Display
   class CardComponentPreview < ViewComponent::Preview
     include UIHelper
 

--- a/lib/generators/modelrails_ui/lookbook/templates/previews/ui/carousel_component_preview.rb
+++ b/lib/generators/modelrails_ui/lookbook/templates/previews/ui/carousel_component_preview.rb
@@ -14,6 +14,7 @@ module UI
   #   `focus-ring` utility, and (with autoplay) a 2.2.2 pause mechanism that flips
   #   the live region to `polite` when stopped.
   # - **You supply:** an accessible `label:` and the slide content.
+  # @logical_path Media
   class CarouselComponentPreview < ViewComponent::Preview
     include UIHelper
 

--- a/lib/generators/modelrails_ui/lookbook/templates/previews/ui/chart_component_preview.rb
+++ b/lib/generators/modelrails_ui/lookbook/templates/previews/ui/chart_component_preview.rb
@@ -23,6 +23,7 @@ module UI
   #   complex-image text alternative. Series default to an AAA-tuned OKLCH palette
   #   (never raw hex). An unknown `type:` fails loud.
   # - **You supply:** a meaningful `label:`, `labels:`, and `datasets:` (each named).
+  # @logical_path Data Display
   class ChartComponentPreview < ViewComponent::Preview
     include UIHelper
 

--- a/lib/generators/modelrails_ui/lookbook/templates/previews/ui/chat_bubble_component_preview.rb
+++ b/lib/generators/modelrails_ui/lookbook/templates/previews/ui/chat_bubble_component_preview.rb
@@ -24,6 +24,7 @@ module UI
   #   avatar.
   # - **You supply:** the body via slot content; optionally `author:`, `timestamp:`,
   #   and an `avatar:` URL (received only).
+  # @logical_path Data Display
   class ChatBubbleComponentPreview < ViewComponent::Preview
     include UIHelper
 

--- a/lib/generators/modelrails_ui/lookbook/templates/previews/ui/checkbox_component_preview.rb
+++ b/lib/generators/modelrails_ui/lookbook/templates/previews/ui/checkbox_component_preview.rb
@@ -17,6 +17,7 @@ module UI
   # - **Guarantees:** a labelled, keyboard-operable checkbox with an AAA focus ring;
   #   the clickable label provides the larger AAA target.
   # - **You supply:** a `label` and, on error, `invalid: true` + `describedby:`.
+  # @logical_path Forms & Inputs
   class CheckboxComponentPreview < ViewComponent::Preview
     include UIHelper
 

--- a/lib/generators/modelrails_ui/lookbook/templates/previews/ui/collapsible_component_preview.rb
+++ b/lib/generators/modelrails_ui/lookbook/templates/previews/ui/collapsible_component_preview.rb
@@ -17,6 +17,7 @@ module UI
   #
   # ## Modes
   # Closed (default) · `open: true` (render pre-expanded).
+  # @logical_path Data Display
   class CollapsibleComponentPreview < ViewComponent::Preview
     include UIHelper
 

--- a/lib/generators/modelrails_ui/lookbook/templates/previews/ui/combobox_component_preview.rb
+++ b/lib/generators/modelrails_ui/lookbook/templates/previews/ui/combobox_component_preview.rb
@@ -31,6 +31,7 @@ module UI
   #
   # ## Sizes
   # `sm` · `md` · `lg` — the input height.
+  # @logical_path Forms & Inputs
   class ComboboxComponentPreview < ViewComponent::Preview
     include UIHelper
 

--- a/lib/generators/modelrails_ui/lookbook/templates/previews/ui/command_component_preview.rb
+++ b/lib/generators/modelrails_ui/lookbook/templates/previews/ui/command_component_preview.rb
@@ -28,6 +28,7 @@ module UI
   #
   # ## Sizes
   # `sm` · `md` · `lg` — the centered panel's max width.
+  # @logical_path Actions
   class CommandComponentPreview < ViewComponent::Preview
     include UIHelper
 

--- a/lib/generators/modelrails_ui/lookbook/templates/previews/ui/context_menu_component_preview.rb
+++ b/lib/generators/modelrails_ui/lookbook/templates/previews/ui/context_menu_component_preview.rb
@@ -12,6 +12,7 @@ module UI
   #   `contextmenu` + Shift+F10 open; `role="menu"` named by the host; `role="menuitem"`
   #   items with roving tabindex.
   # - **You supply:** a `with_trigger` host slot and `with_item` slots.
+  # @logical_path Overlays
   class ContextMenuComponentPreview < ViewComponent::Preview
     include UIHelper
 

--- a/lib/generators/modelrails_ui/lookbook/templates/previews/ui/data_table_component_preview.rb
+++ b/lib/generators/modelrails_ui/lookbook/templates/previews/ui/data_table_component_preview.rb
@@ -22,6 +22,7 @@ module UI
   #   targets on every control, and fully localized strings.
   # - **You supply:** a `caption:` — the table's accessible name. Pass one whenever
   #   practical so screen-reader users get context.
+  # @logical_path Data Display
   class DataTableComponentPreview < ViewComponent::Preview
     include UIHelper
 

--- a/lib/generators/modelrails_ui/lookbook/templates/previews/ui/date_picker_component_preview.rb
+++ b/lib/generators/modelrails_ui/lookbook/templates/previews/ui/date_picker_component_preview.rb
@@ -17,6 +17,7 @@ module UI
   #   decorative calendar icon is `aria-hidden`.
   # - **You supply:** an optional `label:` (caption + accessible name), `name:` (to post
   #   back), and `format:` (the display + hint pattern).
+  # @logical_path Forms & Inputs
   class DatePickerComponentPreview < ViewComponent::Preview
     include UIHelper
 

--- a/lib/generators/modelrails_ui/lookbook/templates/previews/ui/device_mockup_component_preview.rb
+++ b/lib/generators/modelrails_ui/lookbook/templates/previews/ui/device_mockup_component_preview.rb
@@ -18,6 +18,7 @@ module UI
   #   bit is `aria-hidden`, and AAA semantic tokens throughout (no raw palette).
   # - **You supply:** the framed content with its own a11y — real `alt` text on a
   #   meaningful screenshot, or `alt: ""` for a decorative one.
+  # @logical_path Media
   class DeviceMockupComponentPreview < ViewComponent::Preview
     include UIHelper
 

--- a/lib/generators/modelrails_ui/lookbook/templates/previews/ui/dialog_component_preview.rb
+++ b/lib/generators/modelrails_ui/lookbook/templates/previews/ui/dialog_component_preview.rb
@@ -32,6 +32,7 @@ module UI
   #   When using `wrapper: true` (the default), the `with_trigger` slot provides the
   #   open button; `wrapper: false` requires you to supply `data-controller="modal"` on
   #   a parent element and wire your own trigger.
+  # @logical_path Overlays
   class DialogComponentPreview < ViewComponent::Preview
     include UIHelper
 

--- a/lib/generators/modelrails_ui/lookbook/templates/previews/ui/drawer_component_preview.rb
+++ b/lib/generators/modelrails_ui/lookbook/templates/previews/ui/drawer_component_preview.rb
@@ -23,6 +23,7 @@ module UI
   #   controller, and native Escape via the controller's cancel handler.
   # - **You supply:** a `title:` (required — the accessible name). Actions belong in
   #   the `with_footer` slot. The `with_trigger` slot provides the open button.
+  # @logical_path Overlays
   class DrawerComponentPreview < ViewComponent::Preview
     include UIHelper
 

--- a/lib/generators/modelrails_ui/lookbook/templates/previews/ui/dropdown_menu_component_preview.rb
+++ b/lib/generators/modelrails_ui/lookbook/templates/previews/ui/dropdown_menu_component_preview.rb
@@ -12,6 +12,7 @@ module UI
   #   named by the trigger; `role="menuitem"` items with roving tabindex.
   # - **You supply:** a `with_trigger` slot and `with_item` slots; `aria_label:` for
   #   icon-only triggers.
+  # @logical_path Overlays
   class DropdownMenuComponentPreview < ViewComponent::Preview
     include UIHelper
 

--- a/lib/generators/modelrails_ui/lookbook/templates/previews/ui/embed_component_preview.rb
+++ b/lib/generators/modelrails_ui/lookbook/templates/previews/ui/embed_component_preview.rb
@@ -11,6 +11,7 @@ module UI
   # - **Guarantees:** every iframe carries a non-blank `title` (i18n, per-provider
   #   default) so screen readers announce the embedded region.
   # - **You supply:** a recognised provider `url:` (or a maps `query:`).
+  # @logical_path Media
   class EmbedComponentPreview < ViewComponent::Preview
     include UIHelper
 

--- a/lib/generators/modelrails_ui/lookbook/templates/previews/ui/figure_component_preview.rb
+++ b/lib/generators/modelrails_ui/lookbook/templates/previews/ui/figure_component_preview.rb
@@ -18,6 +18,7 @@ module UI
   # - **Guarantees:** semantic figure/figcaption; caption rendered only when given.
   #   Caption uses `text-text-muted` (AAA — same neutral as body in this token system).
   # - **You supply:** real `alt` on any inner image.
+  # @logical_path Media
   class FigureComponentPreview < ViewComponent::Preview
     include UIHelper
 

--- a/lib/generators/modelrails_ui/lookbook/templates/previews/ui/file_input_component_preview.rb
+++ b/lib/generators/modelrails_ui/lookbook/templates/previews/ui/file_input_component_preview.rb
@@ -28,6 +28,7 @@ module UI
   #   were absent on the legacy plain `file_field` — this component fills that gap.
   # - **You supply:** a visible `<label>` associated via `for:/id:`. The form builder
   #   supplies it automatically.
+  # @logical_path Forms & Inputs
   class FileInputComponentPreview < ViewComponent::Preview
     include UIHelper
 

--- a/lib/generators/modelrails_ui/lookbook/templates/previews/ui/floating_label_component_preview.rb
+++ b/lib/generators/modelrails_ui/lookbook/templates/previews/ui/floating_label_component_preview.rb
@@ -26,6 +26,7 @@ module UI
   #   `invalid: true`; `aria-describedby` wired when `describedby:` is supplied.
   # - **You supply:** a `label` (it doubles as the placeholder the float needs) and,
   #   on error, `invalid: true` + `describedby:` pointing at a sibling error element.
+  # @logical_path Forms & Inputs
   class FloatingLabelComponentPreview < ViewComponent::Preview
     include UIHelper
 

--- a/lib/generators/modelrails_ui/lookbook/templates/previews/ui/footer_component_preview.rb
+++ b/lib/generators/modelrails_ui/lookbook/templates/previews/ui/footer_component_preview.rb
@@ -23,6 +23,7 @@ module UI
   #   `copyright:`, optional block content, and `label:` (i18n) to name the landmark
   #   when a page has more than one footer. Every link needs a readable `label:` (its
   #   accessible name) and an `href:`.
+  # @logical_path Navigation
   class FooterComponentPreview < ViewComponent::Preview
     include UIHelper
 

--- a/lib/generators/modelrails_ui/lookbook/templates/previews/ui/form_field_component_preview.rb
+++ b/lib/generators/modelrails_ui/lookbook/templates/previews/ui/form_field_component_preview.rb
@@ -17,6 +17,7 @@ module UI
   #   ids, and `input_attrs` carrying id + describedby + invalid + required. The
   #   required `*` is a decorative aria-hidden mark on the label.
   # - **You supply:** the control inside the block, spread with `**f.input_attrs`.
+  # @logical_path Forms & Inputs
   class FormFieldComponentPreview < ViewComponent::Preview
     include UIHelper
 

--- a/lib/generators/modelrails_ui/lookbook/templates/previews/ui/gallery_component_preview.rb
+++ b/lib/generators/modelrails_ui/lookbook/templates/previews/ui/gallery_component_preview.rb
@@ -13,6 +13,7 @@ module UI
   #   accessible name ("Enlarge %{alt}") and the `focus-ring` utility; the lightbox
   #   is a native focus-trapped `<dialog>` with an accessible close button.
   # - **You supply:** a non-blank `alt:` per image when lightbox is on (fail-loud).
+  # @logical_path Media
   class GalleryComponentPreview < ViewComponent::Preview
     include UIHelper
 

--- a/lib/generators/modelrails_ui/lookbook/templates/previews/ui/hover_card_component_preview.rb
+++ b/lib/generators/modelrails_ui/lookbook/templates/previews/ui/hover_card_component_preview.rb
@@ -11,6 +11,7 @@ module UI
   # - **Guarantees:** hover + focus-within reveal; card content Tab-reachable while open;
   #   Escape-dismiss; `role="group"` + `aria-label` when `label:` given.
   # - **You supply:** a `with_trigger` slot (a focusable link/button) and card content.
+  # @logical_path Overlays
   class HoverCardComponentPreview < ViewComponent::Preview
     include UIHelper
 

--- a/lib/generators/modelrails_ui/lookbook/templates/previews/ui/iframe_component_preview.rb
+++ b/lib/generators/modelrails_ui/lookbook/templates/previews/ui/iframe_component_preview.rb
@@ -20,6 +20,7 @@ module UI
   # - **You supply:** a real `title:` describing the embedded content. Unlike an
   #   image there is no "decorative" iframe — a title-less iframe is a hard WCAG
   #   failure.
+  # @logical_path Media
   class IframeComponentPreview < ViewComponent::Preview
     include UIHelper
 

--- a/lib/generators/modelrails_ui/lookbook/templates/previews/ui/image_component_preview.rb
+++ b/lib/generators/modelrails_ui/lookbook/templates/previews/ui/image_component_preview.rb
@@ -17,6 +17,7 @@ module UI
   # - **Guarantees:** `alt:` is required; invalid `loading:` falls back to `:lazy`.
   # - **You supply:** real `alt:` for meaningful images, `alt: ""` for decorative.
   #   `alt` is not a caption — use `figure` for those.
+  # @logical_path Media
   class ImageComponentPreview < ViewComponent::Preview
     include UIHelper
 

--- a/lib/generators/modelrails_ui/lookbook/templates/previews/ui/indicator_component_preview.rb
+++ b/lib/generators/modelrails_ui/lookbook/templates/previews/ui/indicator_component_preview.rb
@@ -17,6 +17,7 @@ module UI
   #   `text-white`); a valid `variant` is required.
   # - **You supply:** an accessible name on the anchor when the dot is a color-only
   #   signal; the count via `count:`.
+  # @logical_path Feedback & Status
   class IndicatorComponentPreview < ViewComponent::Preview
     include UIHelper
 

--- a/lib/generators/modelrails_ui/lookbook/templates/previews/ui/input_component_preview.rb
+++ b/lib/generators/modelrails_ui/lookbook/templates/previews/ui/input_component_preview.rb
@@ -27,6 +27,7 @@ module UI
   #   `aria-describedby` wired when `describedby:` is supplied.
   # - **You supply (when standalone):** a visible `<label>` associated via `for:/id:`,
   #   and a `name:` attribute. The form builder supplies both automatically.
+  # @logical_path Forms & Inputs
   class InputComponentPreview < ViewComponent::Preview
     include UIHelper
 

--- a/lib/generators/modelrails_ui/lookbook/templates/previews/ui/input_otp_component_preview.rb
+++ b/lib/generators/modelrails_ui/lookbook/templates/previews/ui/input_otp_component_preview.rb
@@ -23,6 +23,7 @@ module UI
   #   non-positive value fails loud.
   # - **You supply:** the field `name:`, the digit `length:`, an optional group
   #   `label:`, and an optional `separator:`.
+  # @logical_path Forms & Inputs
   class InputOtpComponentPreview < ViewComponent::Preview
     include UIHelper
 

--- a/lib/generators/modelrails_ui/lookbook/templates/previews/ui/kbd_component_preview.rb
+++ b/lib/generators/modelrails_ui/lookbook/templates/previews/ui/kbd_component_preview.rb
@@ -19,6 +19,7 @@ module UI
   # - **Guarantees:** AAA-contrast text on `bg-surface-sunken` and a
   #   non-interactive, unselectable chip.
   # - **You supply:** the key text (positional arg, `label:`, or slot content).
+  # @logical_path Data Display
   class KbdComponentPreview < ViewComponent::Preview
     include UIHelper
 

--- a/lib/generators/modelrails_ui/lookbook/templates/previews/ui/label_component_preview.rb
+++ b/lib/generators/modelrails_ui/lookbook/templates/previews/ui/label_component_preview.rb
@@ -19,6 +19,7 @@ module UI
   #   `required:` `*` is decorative (aria-hidden) — the requirement lives on the
   #   input, never the caption.
   # - **You supply:** the caption text and, to bind it, the control's `id` via `for:`.
+  # @logical_path Forms & Inputs
   class LabelComponentPreview < ViewComponent::Preview
     include UIHelper
 

--- a/lib/generators/modelrails_ui/lookbook/templates/previews/ui/list_group_component_preview.rb
+++ b/lib/generators/modelrails_ui/lookbook/templates/previews/ui/list_group_component_preview.rb
@@ -21,6 +21,7 @@ module UI
   #   carries `aria-current="page"`; static rows are never made focusable.
   # - **You supply:** the rows via `list_group_item` (text or block content),
   #   `href:` for navigable rows, and `active: true` on the current page.
+  # @logical_path Data Display
   class ListGroupComponentPreview < ViewComponent::Preview
     include UIHelper
 

--- a/lib/generators/modelrails_ui/lookbook/templates/previews/ui/map_area_component_preview.rb
+++ b/lib/generators/modelrails_ui/lookbook/templates/previews/ui/map_area_component_preview.rb
@@ -21,6 +21,7 @@ module UI
   #   `<map name>`; every interactive `<area href>` is forced to carry a non-blank
   #   `alt` (its accessible name) — an unnamed hotspot raises (WCAG 2.4.4 / 4.1.2).
   # - **You supply:** real `alt:` for the image and an `alt:` for every linked area.
+  # @logical_path Media
   class MapAreaComponentPreview < ViewComponent::Preview
     include UIHelper
 

--- a/lib/generators/modelrails_ui/lookbook/templates/previews/ui/mega_menu_component_preview.rb
+++ b/lib/generators/modelrails_ui/lookbook/templates/previews/ui/mega_menu_component_preview.rb
@@ -14,6 +14,7 @@ module UI
   #   landmark named by the trigger label; AAA `focus-ring` on the trigger and every
   #   link; a decorative (`aria-hidden`) chevron; outside-click dismissal.
   # - **You supply:** a `label:` and one or more `with_column(heading:, items:)` blocks.
+  # @logical_path Navigation
   class MegaMenuComponentPreview < ViewComponent::Preview
     include UIHelper
 

--- a/lib/generators/modelrails_ui/lookbook/templates/previews/ui/menubar_component_preview.rb
+++ b/lib/generators/modelrails_ui/lookbook/templates/previews/ui/menubar_component_preview.rb
@@ -5,6 +5,7 @@ module UI
   #
   # An app menubar (WAI-ARIA APG). Tab to it (one stop), ←/→ between items, ↓/Enter to open a
   # submenu, ↑/↓ within, Escape to close. Submenus reuse the shared `menu` controller.
+  # @logical_path Overlays
   class MenubarComponentPreview < ViewComponent::Preview
     include UIHelper
 

--- a/lib/generators/modelrails_ui/lookbook/templates/previews/ui/navbar_component_preview.rb
+++ b/lib/generators/modelrails_ui/lookbook/templates/previews/ui/navbar_component_preview.rb
@@ -6,6 +6,7 @@ module UI
   # A responsive nav. On a narrow viewport the links collapse behind a hamburger that discloses
   # a stacked menu (aria-expanded/controls + Escape + outside-click). Resize the Lookbook frame
   # narrow to see the mobile disclosure.
+  # @logical_path Navigation
   class NavbarComponentPreview < ViewComponent::Preview
     include UIHelper
 

--- a/lib/generators/modelrails_ui/lookbook/templates/previews/ui/navigation_menu_component_preview.rb
+++ b/lib/generators/modelrails_ui/lookbook/templates/previews/ui/navigation_menu_component_preview.rb
@@ -16,6 +16,7 @@ module UI
   #   active link; the chevron is decorative.
   # - **You supply:** items (label, optional href, optional active) and — for flyout
   #   items — the panel links via the slot block.
+  # @logical_path Navigation
   class NavigationMenuComponentPreview < ViewComponent::Preview
     include UIHelper
 

--- a/lib/generators/modelrails_ui/lookbook/templates/previews/ui/number_input_component_preview.rb
+++ b/lib/generators/modelrails_ui/lookbook/templates/previews/ui/number_input_component_preview.rb
@@ -29,6 +29,7 @@ module UI
   #   `required` + `aria-required="true"` when `required: true`.
   # - **You supply (when standalone):** a visible `<label>` associated via `for:/id:`,
   #   and a `name:` attribute. The form builder supplies both automatically.
+  # @logical_path Forms & Inputs
   class NumberInputComponentPreview < ViewComponent::Preview
     include UIHelper
 

--- a/lib/generators/modelrails_ui/lookbook/templates/previews/ui/picture_component_preview.rb
+++ b/lib/generators/modelrails_ui/lookbook/templates/previews/ui/picture_component_preview.rb
@@ -18,6 +18,7 @@ module UI
   # - **Guarantees:** `alt:` is required on the base `<img>`; `<source>`s carry no
   #   `alt`, so the name comes solely from the `<img>`. Invalid `loading:` → `:lazy`.
   # - **You supply:** real `alt:` for meaningful images, `alt: ""` for decorative.
+  # @logical_path Media
   class PictureComponentPreview < ViewComponent::Preview
     include UIHelper
 

--- a/lib/generators/modelrails_ui/lookbook/templates/previews/ui/popover_component_preview.rb
+++ b/lib/generators/modelrails_ui/lookbook/templates/previews/ui/popover_component_preview.rb
@@ -12,6 +12,7 @@ module UI
   #   `aria-expanded`, and `aria-controls`; a `role="dialog"` panel named by `label:`.
   #   Non-modal — focus is not trapped.
   # - **You supply:** `label:` (the panel's accessible name) and a `with_trigger` slot.
+  # @logical_path Overlays
   class PopoverComponentPreview < ViewComponent::Preview
     include UIHelper
 

--- a/lib/generators/modelrails_ui/lookbook/templates/previews/ui/progress_component_preview.rb
+++ b/lib/generators/modelrails_ui/lookbook/templates/previews/ui/progress_component_preview.rb
@@ -16,6 +16,7 @@ module UI
   # ## Accessibility contract
   # - **Guarantees:** `role="progressbar"` + `aria-valuenow`/`min`/`max`, value clamped.
   # - **You supply:** `label:` when no visible text names the bar.
+  # @logical_path Feedback & Status
   class ProgressComponentPreview < ViewComponent::Preview
     include UIHelper
 

--- a/lib/generators/modelrails_ui/lookbook/templates/previews/ui/qr_code_component_preview.rb
+++ b/lib/generators/modelrails_ui/lookbook/templates/previews/ui/qr_code_component_preview.rb
@@ -21,6 +21,7 @@ module UI
   #   unlabelled `<svg>` (WCAG 1.1.1 / 4.1.2). The inner `<img>` is decorative
   #   (`alt=""`) so the code is announced once. Caller html_attrs can't strip the name.
   # - **You supply:** an `alt:` that describes what the code encodes, not a bare "QR code".
+  # @logical_path Media
   class QrCodeComponentPreview < ViewComponent::Preview
     include UIHelper
 

--- a/lib/generators/modelrails_ui/lookbook/templates/previews/ui/radio_group_component_preview.rb
+++ b/lib/generators/modelrails_ui/lookbook/templates/previews/ui/radio_group_component_preview.rb
@@ -21,6 +21,7 @@ module UI
   # - **You supply:** a group `label:` (or `labelledby:`), `items:` as
   #   `[{ value:, label:, checked?:, disabled?: }]`, and on error `invalid:` +
   #   `describedby:`.
+  # @logical_path Forms & Inputs
   class RadioGroupComponentPreview < ViewComponent::Preview
     include UIHelper
 

--- a/lib/generators/modelrails_ui/lookbook/templates/previews/ui/range_component_preview.rb
+++ b/lib/generators/modelrails_ui/lookbook/templates/previews/ui/range_component_preview.rb
@@ -29,6 +29,7 @@ module UI
   # Pass `show_value: true` to render an associated `<output>` (an implicit
   # `role="status"` live region) that mirrors the slider, kept in sync by the
   # `range` Stimulus controller. The default stays a bare native slider.
+  # @logical_path Forms & Inputs
   class RangeComponentPreview < ViewComponent::Preview
     include UIHelper
 

--- a/lib/generators/modelrails_ui/lookbook/templates/previews/ui/rating_component_preview.rb
+++ b/lib/generators/modelrails_ui/lookbook/templates/previews/ui/rating_component_preview.rb
@@ -21,6 +21,7 @@ module UI
   #   `aria-hidden` star glyphs, and filled stars on the AAA-tuned semantic
   #   `text-warning-icon` token (3:1 graphic contrast, WCAG 1.4.11).
   # - **You supply:** the `value:` to display and the `max:` star count.
+  # @logical_path Data Display
   class RatingComponentPreview < ViewComponent::Preview
     include UIHelper
 

--- a/lib/generators/modelrails_ui/lookbook/templates/previews/ui/rating_input_component_preview.rb
+++ b/lib/generators/modelrails_ui/lookbook/templates/previews/ui/rating_input_component_preview.rb
@@ -22,6 +22,7 @@ module UI
   #   contrast, WCAG 1.4.11), and a hidden input carrying the value in a form.
   # - **You supply:** an optional group `label:`, the initial `value:`, `max:`, and
   #   either `name:` (form post) or `url:` (direct submit).
+  # @logical_path Forms & Inputs
   class RatingInputComponentPreview < ViewComponent::Preview
     include UIHelper
 

--- a/lib/generators/modelrails_ui/lookbook/templates/previews/ui/resizable_component_preview.rb
+++ b/lib/generators/modelrails_ui/lookbook/templates/previews/ui/resizable_component_preview.rb
@@ -14,6 +14,7 @@ module UI
   #   valuemax` range. Arrow keys resize it (← → horizontal, ↑ ↓ vertical);
   #   Home/End jump to its min/max.
   # - **You supply:** panels with optional `min`/`max`/`default` percentages.
+  # @logical_path Layout
   class ResizableComponentPreview < ViewComponent::Preview
     include UIHelper
 

--- a/lib/generators/modelrails_ui/lookbook/templates/previews/ui/scroll_area_component_preview.rb
+++ b/lib/generators/modelrails_ui/lookbook/templates/previews/ui/scroll_area_component_preview.rb
@@ -19,6 +19,7 @@ module UI
   #   with a `focus-ring` indicator and a `role="region"` accessible name, so
   #   keyboard-only users can focus and arrow-scroll it and AT announces it.
   # - **You supply:** an accessible name via `aria_label:` or `aria_labelledby:`.
+  # @logical_path Layout
   class ScrollAreaComponentPreview < ViewComponent::Preview
     include UIHelper
 

--- a/lib/generators/modelrails_ui/lookbook/templates/previews/ui/search_input_component_preview.rb
+++ b/lib/generators/modelrails_ui/lookbook/templates/previews/ui/search_input_component_preview.rb
@@ -20,6 +20,7 @@ module UI
   #   (`h-11`), and AAA border/focus-ring tokens.
   # - **You supply:** on error, `invalid: true` + `describedby:`; a custom `label:`
   #   when "Search" is the wrong accessible name.
+  # @logical_path Forms & Inputs
   class SearchInputComponentPreview < ViewComponent::Preview
     include UIHelper
 

--- a/lib/generators/modelrails_ui/lookbook/templates/previews/ui/select_component_preview.rb
+++ b/lib/generators/modelrails_ui/lookbook/templates/previews/ui/select_component_preview.rb
@@ -19,6 +19,7 @@ module UI
   #   `describedby:` is supplied.
   # - **You supply:** the visible label as an external `<label for="<id>">` — unlike
   #   checkbox, this component does NOT bundle a label.
+  # @logical_path Forms & Inputs
   class SelectComponentPreview < ViewComponent::Preview
     include UIHelper
 

--- a/lib/generators/modelrails_ui/lookbook/templates/previews/ui/separator_component_preview.rb
+++ b/lib/generators/modelrails_ui/lookbook/templates/previews/ui/separator_component_preview.rb
@@ -18,6 +18,7 @@ module UI
   # - **Guarantees:** `aria-orientation` is emitted ONLY on a semantic separator;
   #   omitted on a decorative one (where it would be invalid).
   # - **You supply:** `decorative: false` when the divide conveys grouping.
+  # @logical_path Layout
   class SeparatorComponentPreview < ViewComponent::Preview
     include UIHelper
 

--- a/lib/generators/modelrails_ui/lookbook/templates/previews/ui/sheet_component_preview.rb
+++ b/lib/generators/modelrails_ui/lookbook/templates/previews/ui/sheet_component_preview.rb
@@ -24,6 +24,7 @@ module UI
   # - **You supply:** a `title:` (required — the accessible name). Actions belong in
   #   the `with_footer` slot. The `with_trigger` slot provides the open button. Pass
   #   `side:` to choose which edge the panel slides in from (`:right` default).
+  # @logical_path Overlays
   class SheetComponentPreview < ViewComponent::Preview
     include UIHelper
 

--- a/lib/generators/modelrails_ui/lookbook/templates/previews/ui/sidebar_component_preview.rb
+++ b/lib/generators/modelrails_ui/lookbook/templates/previews/ui/sidebar_component_preview.rb
@@ -12,6 +12,7 @@ module UI
   #   an i18n-labelled toggle, AAA `focus-ring` on the toggle and every item, and
   #   `aria-current="page"` on the active item.
   # - **You supply:** groups/items (label, href, optional icon, active).
+  # @logical_path Navigation
   class SidebarComponentPreview < ViewComponent::Preview
     include UIHelper
 

--- a/lib/generators/modelrails_ui/lookbook/templates/previews/ui/skeleton_component_preview.rb
+++ b/lib/generators/modelrails_ui/lookbook/templates/previews/ui/skeleton_component_preview.rb
@@ -16,6 +16,7 @@ module UI
   # ## Accessibility contract
   # - **Guarantees:** `aria-hidden="true"` and `motion-reduce:animate-none`.
   # - **You supply:** an `aria-busy`/live region on the container; size via `class:`.
+  # @logical_path Feedback & Status
   class SkeletonComponentPreview < ViewComponent::Preview
     include UIHelper
 

--- a/lib/generators/modelrails_ui/lookbook/templates/previews/ui/speed_dial_component_preview.rb
+++ b/lib/generators/modelrails_ui/lookbook/templates/previews/ui/speed_dial_component_preview.rb
@@ -15,6 +15,7 @@ module UI
   # - **You supply:** actions (label + optional href; an href renders an `<a>`,
   #   otherwise a `<button>`).
   # - **Fail-loud:** an unknown `position:` raises in dev.
+  # @logical_path Actions
   class SpeedDialComponentPreview < ViewComponent::Preview
     include UIHelper
 

--- a/lib/generators/modelrails_ui/lookbook/templates/previews/ui/spinner_component_preview.rb
+++ b/lib/generators/modelrails_ui/lookbook/templates/previews/ui/spinner_component_preview.rb
@@ -16,6 +16,7 @@ module UI
   # ## Accessibility contract
   # - **Guarantees:** `role="status"` + sr-only i18n loading label.
   # - **You supply:** nothing; override copy via `modelrails_ui.spinner.loading`.
+  # @logical_path Feedback & Status
   class SpinnerComponentPreview < ViewComponent::Preview
     include UIHelper
 

--- a/lib/generators/modelrails_ui/lookbook/templates/previews/ui/stepper_component_preview.rb
+++ b/lib/generators/modelrails_ui/lookbook/templates/previews/ui/stepper_component_preview.rb
@@ -17,6 +17,7 @@ module UI
   #
   # ## Modes
   # `orientation: :horizontal` (default) · `orientation: :vertical`.
+  # @logical_path Feedback & Status
   class StepperComponentPreview < ViewComponent::Preview
     include UIHelper
 

--- a/lib/generators/modelrails_ui/lookbook/templates/previews/ui/switch_component_preview.rb
+++ b/lib/generators/modelrails_ui/lookbook/templates/previews/ui/switch_component_preview.rb
@@ -19,6 +19,7 @@ module UI
   #   and a >=44px clickable target (AAA 2.5.5) even though the visual track is smaller.
   # - **You supply:** an accessible name (`label:` or `aria-label:`), the initial
   #   `checked:` state, and a `name:` so the value posts.
+  # @logical_path Forms & Inputs
   class SwitchComponentPreview < ViewComponent::Preview
     include UIHelper
 

--- a/lib/generators/modelrails_ui/lookbook/templates/previews/ui/tabs_component_preview.rb
+++ b/lib/generators/modelrails_ui/lookbook/templates/previews/ui/tabs_component_preview.rb
@@ -5,6 +5,7 @@ module UI
   #
   # APG tabs (automatic activation). Tab to the active tab, ←/→ to move + reveal panels,
   # Home/End to jump; the disabled tab is skipped. Tab again to enter the active panel.
+  # @logical_path Navigation
   class TabsComponentPreview < ViewComponent::Preview
     include UIHelper
 

--- a/lib/generators/modelrails_ui/lookbook/templates/previews/ui/textarea_component_preview.rb
+++ b/lib/generators/modelrails_ui/lookbook/templates/previews/ui/textarea_component_preview.rb
@@ -26,6 +26,7 @@ module UI
   #   `aria-describedby` wired when `describedby:` is supplied.
   # - **You supply (when standalone):** a visible `<label>` associated via `for:/id:`,
   #   and a `name:` attribute. The form builder supplies both automatically.
+  # @logical_path Forms & Inputs
   class TextareaComponentPreview < ViewComponent::Preview
     include UIHelper
 

--- a/lib/generators/modelrails_ui/lookbook/templates/previews/ui/timeline_component_preview.rb
+++ b/lib/generators/modelrails_ui/lookbook/templates/previews/ui/timeline_component_preview.rb
@@ -23,6 +23,7 @@ module UI
   #   unknown item `variant` raises in development.
   # - **You supply:** each event's `title:` (and optional `date:`/`datetime:`,
   #   `description:`, block body, and dot `variant:`).
+  # @logical_path Data Display
   class TimelineComponentPreview < ViewComponent::Preview
     include UIHelper
 

--- a/lib/generators/modelrails_ui/lookbook/templates/previews/ui/timepicker_component_preview.rb
+++ b/lib/generators/modelrails_ui/lookbook/templates/previews/ui/timepicker_component_preview.rb
@@ -18,6 +18,7 @@ module UI
   # - **You supply:** an optional `label:` (accessible name), `name:` (to post back),
   #   and `format:` (`:h24` | `:h12`, drives the hour range + the hint; fails loud on an
   #   unknown key).
+  # @logical_path Forms & Inputs
   class TimepickerComponentPreview < ViewComponent::Preview
     include UIHelper
 

--- a/lib/generators/modelrails_ui/lookbook/templates/previews/ui/toaster_component_preview.rb
+++ b/lib/generators/modelrails_ui/lookbook/templates/previews/ui/toaster_component_preview.rb
@@ -33,6 +33,7 @@ module UI
   # — each tinted (`bg-<signal>-surface` + `border-<signal>-border` + `text-<signal>`).
   # Aliases: `:destructive`/`:error` → `:danger`, `:alert` → `:warning` (the latter two
   # smooth the app `shared/_toasts` flash-key collision, where `:alert` means warning).
+  # @logical_path Feedback & Status
   class ToasterComponentPreview < ViewComponent::Preview
     include UIHelper
 

--- a/lib/generators/modelrails_ui/lookbook/templates/previews/ui/toggle_component_preview.rb
+++ b/lib/generators/modelrails_ui/lookbook/templates/previews/ui/toggle_component_preview.rb
@@ -21,6 +21,7 @@ module UI
   #
   # ## Sizes
   # `default` · `sm` · `lg` — all >=44px tall.
+  # @logical_path Forms & Inputs
   class ToggleComponentPreview < ViewComponent::Preview
     include UIHelper
 

--- a/lib/generators/modelrails_ui/lookbook/templates/previews/ui/toggle_group_component_preview.rb
+++ b/lib/generators/modelrails_ui/lookbook/templates/previews/ui/toggle_group_component_preview.rb
@@ -19,6 +19,7 @@ module UI
   #
   # ## Modes
   # Single-select (`type: :single`) · multi-select (`type: :multiple`).
+  # @logical_path Forms & Inputs
   class ToggleGroupComponentPreview < ViewComponent::Preview
     include UIHelper
 

--- a/lib/generators/modelrails_ui/lookbook/templates/previews/ui/tooltip_component_preview.rb
+++ b/lib/generators/modelrails_ui/lookbook/templates/previews/ui/tooltip_component_preview.rb
@@ -11,6 +11,7 @@ module UI
   # - **Guarantees:** hover + focus reveal; `role="tooltip"` + `aria-describedby`;
   #   Escape-dismiss; `pointer-events-none` bubble.
   # - **You supply:** `text:` (the hint) and the trigger content.
+  # @logical_path Overlays
   class TooltipComponentPreview < ViewComponent::Preview
     include UIHelper
 

--- a/lib/generators/modelrails_ui/lookbook/templates/previews/ui/video_component_preview.rb
+++ b/lib/generators/modelrails_ui/lookbook/templates/previews/ui/video_component_preview.rb
@@ -10,6 +10,7 @@ module UI
   # - **Guarantees:** native browser controls (keyboard-operable, UA-labelled);
   #   a `<track kind="captions">` is exposed to the UA's captions menu.
   # - **You supply:** at least one playable `source` and — for AAA media — captions.
+  # @logical_path Media
   class VideoComponentPreview < ViewComponent::Preview
     include UIHelper
 

--- a/lib/generators/modelrails_ui/lookbook/templates/previews/ui/wysiwyg_component_preview.rb
+++ b/lib/generators/modelrails_ui/lookbook/templates/previews/ui/wysiwyg_component_preview.rb
@@ -25,6 +25,7 @@ module UI
   #   buttons carrying `aria-pressed` + the AAA `focus-ring`, and semantic tokens.
   # - **You supply:** a form-field `name:`, an optional initial `value:`, and a
   #   valid `adapter:` (`:trix` | `:quill` — an unknown value raises).
+  # @logical_path Forms & Inputs
   class WysiwygComponentPreview < ViewComponent::Preview
     include UIHelper
 

--- a/test/test_lookbook_logical_paths.rb
+++ b/test/test_lookbook_logical_paths.rb
@@ -1,0 +1,74 @@
+# frozen_string_literal: true
+
+require "test_helper"
+
+# Every Lookbook preview must declare a @logical_path that buckets it into one of the
+# 8 canonical catalog sections. Guards against a new/renamed component landing ungrouped
+# or in the wrong section. EXPECTED is the single source of truth for the taxonomy.
+# Tag form is UNQUOTED: `# @logical_path Forms & Inputs` (lookbook consumes it verbatim).
+class TestLookbookLogicalPaths < Minitest::Test
+  PREVIEW_ROOT = File.expand_path(
+    "../lib/generators/modelrails_ui/lookbook/templates/previews/ui", __dir__
+  )
+
+  SECTIONS = [
+    "Forms & Inputs", "Actions", "Overlays", "Navigation",
+    "Feedback & Status", "Data Display", "Media", "Layout"
+  ].freeze
+
+  EXPECTED = {
+    "input" => "Forms & Inputs", "textarea" => "Forms & Inputs", "select" => "Forms & Inputs",
+    "checkbox" => "Forms & Inputs", "radio_group" => "Forms & Inputs", "switch" => "Forms & Inputs",
+    "toggle" => "Forms & Inputs", "toggle_group" => "Forms & Inputs", "range" => "Forms & Inputs",
+    "number_input" => "Forms & Inputs", "search_input" => "Forms & Inputs",
+    "file_input" => "Forms & Inputs", "input_otp" => "Forms & Inputs", "combobox" => "Forms & Inputs",
+    "date_picker" => "Forms & Inputs", "timepicker" => "Forms & Inputs", "calendar" => "Forms & Inputs",
+    "rating_input" => "Forms & Inputs", "floating_label" => "Forms & Inputs", "label" => "Forms & Inputs",
+    "form_field" => "Forms & Inputs", "wysiwyg" => "Forms & Inputs",
+    "button" => "Actions", "button_group" => "Actions", "speed_dial" => "Actions", "command" => "Actions",
+    "dialog" => "Overlays", "alert_dialog" => "Overlays", "drawer" => "Overlays", "sheet" => "Overlays",
+    "popover" => "Overlays", "tooltip" => "Overlays", "hover_card" => "Overlays",
+    "dropdown_menu" => "Overlays", "context_menu" => "Overlays", "menubar" => "Overlays",
+    "navbar" => "Navigation", "sidebar" => "Navigation", "breadcrumb" => "Navigation",
+    "tabs" => "Navigation", "bottom_nav" => "Navigation", "mega_menu" => "Navigation",
+    "navigation_menu" => "Navigation", "footer" => "Navigation",
+    "alert" => "Feedback & Status", "banner" => "Feedback & Status", "badge" => "Feedback & Status",
+    "progress" => "Feedback & Status", "spinner" => "Feedback & Status", "skeleton" => "Feedback & Status",
+    "indicator" => "Feedback & Status", "stepper" => "Feedback & Status", "toaster" => "Feedback & Status",
+    "card" => "Data Display", "list_group" => "Data Display", "data_table" => "Data Display",
+    "timeline" => "Data Display", "accordion" => "Data Display", "collapsible" => "Data Display",
+    "chat_bubble" => "Data Display", "avatar" => "Data Display", "kbd" => "Data Display",
+    "rating" => "Data Display", "chart" => "Data Display",
+    "image" => "Media", "picture" => "Media", "figure" => "Media", "gallery" => "Media",
+    "audio" => "Media", "video" => "Media", "embed" => "Media", "iframe" => "Media",
+    "carousel" => "Media", "qr_code" => "Media", "device_mockup" => "Media",
+    "map_area" => "Media", "aspect_ratio" => "Media",
+    "separator" => "Layout", "scroll_area" => "Layout", "resizable" => "Layout"
+  }.freeze
+
+  def all_preview_components
+    Dir.glob(File.join(PREVIEW_ROOT, "*_component_preview.rb"))
+      .map { |p| File.basename(p, "_component_preview.rb") }
+  end
+
+  def declared_logical_path(component)
+    src = File.read(File.join(PREVIEW_ROOT, "#{component}_component_preview.rb"))
+    src[/^\s*#\s*@logical_path\s+(.+?)\s*$/, 1]
+  end
+
+  def test_every_preview_is_in_the_expected_map
+    extra = all_preview_components - EXPECTED.keys
+    missing = EXPECTED.keys - all_preview_components
+    assert_empty extra, "previews with no EXPECTED section (add them to the map): #{extra.sort}"
+    assert_empty missing, "EXPECTED components with no preview file: #{missing.sort}"
+  end
+
+  def test_every_preview_declares_its_expected_logical_path
+    all_preview_components.each do |component|
+      actual = declared_logical_path(component)
+      refute_nil actual, "#{component}: missing `@logical_path` tag"
+      assert_includes SECTIONS, actual, "#{component}: `#{actual}` is not a canonical section"
+      assert_equal EXPECTED[component], actual, "#{component}: expected `#{EXPECTED[component]}`, got `#{actual}`"
+    end
+  end
+end

--- a/test/test_lookbook_logical_paths.rb
+++ b/test/test_lookbook_logical_paths.rb
@@ -59,6 +59,7 @@ class TestLookbookLogicalPaths < Minitest::Test
   def test_every_preview_is_in_the_expected_map
     extra = all_preview_components - EXPECTED.keys
     missing = EXPECTED.keys - all_preview_components
+
     assert_empty extra, "previews with no EXPECTED section (add them to the map): #{extra.sort}"
     assert_empty missing, "EXPECTED components with no preview file: #{missing.sort}"
   end
@@ -66,6 +67,7 @@ class TestLookbookLogicalPaths < Minitest::Test
   def test_every_preview_declares_its_expected_logical_path
     all_preview_components.each do |component|
       actual = declared_logical_path(component)
+
       refute_nil actual, "#{component}: missing `@logical_path` tag"
       assert_includes SECTIONS, actual, "#{component}: `#{actual}` is not a canonical section"
       assert_equal EXPECTED[component], actual, "#{component}: expected `#{EXPECTED[component]}`, got `#{actual}`"

--- a/test/test_lookbook_overview_page.rb
+++ b/test/test_lookbook_overview_page.rb
@@ -1,0 +1,48 @@
+# frozen_string_literal: true
+
+require "test_helper"
+
+# The Overview landing page must exist, teach the core conventions, and embed only
+# scenarios that actually exist (a broken embed target would 500 the page at runtime).
+class TestLookbookOverviewPage < Minitest::Test
+  GEN_ROOT = File.expand_path("../lib/generators/modelrails_ui/lookbook/templates", __dir__)
+  PAGE = File.join(GEN_ROOT, "previews/pages/00_overview.md.erb")
+  PREVIEW_ROOT = File.join(GEN_ROOT, "previews/ui")
+  INITIALIZER = File.join(GEN_ROOT, "lookbook.rb")
+
+  SECTIONS = [
+    "Forms & Inputs", "Actions", "Overlays", "Navigation",
+    "Feedback & Status", "Data Display", "Media", "Layout"
+  ].freeze
+
+  def page_src
+    File.read(PAGE)
+  end
+
+  def test_page_exists_and_sorts_first
+    assert_path_exists PAGE, "Overview page must exist at previews/pages/00_overview.md.erb"
+    assert_match(/label:\s*Overview/, page_src, "page needs a front-matter `label: Overview`")
+  end
+
+  def test_page_teaches_core_conventions
+    assert_includes page_src, "ui :button", "page must show the ui() facade call"
+    assert_includes page_src, "f.submit", "page must teach 'reach for the Rails built-in first'"
+    SECTIONS.each do |section|
+      assert_includes page_src, section, "page BROWSE index must list the `#{section}` section"
+    end
+  end
+
+  def test_every_embed_target_exists
+    embeds = page_src.scan(/embed\s+UI::(\w+)ComponentPreview,\s*:(\w+)/)
+    assert_operator embeds.size, :>=, 3, "page should embed at least 3 live hero scenarios"
+    embeds.each do |klass, scenario|
+      file = File.join(PREVIEW_ROOT, "#{klass.gsub(/([a-z])([A-Z])/, '\1_\2').downcase}_component_preview.rb")
+      assert_path_exists file, "embed references missing preview #{klass}"
+      assert_match(/def #{scenario}\b/, File.read(file), "embed references missing scenario :#{scenario} on #{klass}")
+    end
+  end
+
+  def test_initializer_wires_page_paths
+    assert_match(/page_paths\s*=/, File.read(INITIALIZER), "lookbook.rb must set config.lookbook.page_paths")
+  end
+end

--- a/test/test_lookbook_overview_page.rb
+++ b/test/test_lookbook_overview_page.rb
@@ -34,9 +34,11 @@ class TestLookbookOverviewPage < Minitest::Test
 
   def test_every_embed_target_exists
     embeds = page_src.scan(/embed\s+UI::(\w+)ComponentPreview,\s*:(\w+)/)
+
     assert_operator embeds.size, :>=, 3, "page should embed at least 3 live hero scenarios"
     embeds.each do |klass, scenario|
       file = File.join(PREVIEW_ROOT, "#{klass.gsub(/([a-z])([A-Z])/, '\1_\2').downcase}_component_preview.rb")
+
       assert_path_exists file, "embed references missing preview #{klass}"
       assert_match(/def #{scenario}\b/, File.read(file), "embed references missing scenario :#{scenario} on #{klass}")
     end


### PR DESCRIPTION
## Summary

Tier 1 of the post-hardening Lookbook panel review (Adam Wathan / Steve Schoger / Jason Fried / DHH / Chris Oliver / Brad Frost). Gives the catalog a **front door** and a **map**:

- **Teaching Overview landing page** (`previews/pages/00_overview.md.erb`) — sorts first, becomes the default `/lookbook` view. Covers the `ui()` facade, "reach for the Rails built-in first" (`f.submit`/`f.text_field`/`button_to`), the four token laws, 3 live hero embeds (button/banner/card), and an 8-section browse index. Wires `config.lookbook.page_paths` in the initializer template.
- **8-section sidebar grouping** — every preview gets one unquoted `@logical_path <Section>` magic comment (Forms & Inputs · Actions · Overlays · Navigation · Feedback & Status · Data Display · Media · Layout). No file moves, no class renames.

Sections derived job-to-be-done, not atomic level. Ratified edge cases: stepper→Feedback (its own doc says it's not navigation), rating→Data Display vs rating_input→Forms, command→Actions, chart→Data Display, footer→Navigation, aspect_ratio→Media. `toaster`/`wysiwyg` are grouped here (gem-only; superseded in the reference app).

## Why unquoted

lookbook-2.3.14 consumes the `@logical_path` tag text verbatim (`PathUtils.to_path` just string-joins), so a quoted value leaks quotes into the nav label + URL. The exemplar (button) proved this live; all 8 names round-trip cleanly through `name.titleize`.

## Test plan

- [x] `test/test_lookbook_logical_paths.rb` — taxonomy guard (80-entry expected map; fails loud on ungrouped/mis-bucketed/added-without-map)
- [x] `test/test_lookbook_overview_page.rb` — page exists, teaches conventions, all 8 sections present, every `embed` target + scenario exists, `page_paths` wired
- [x] Full gem suite green (870 examples, 0 failures)
- [x] Live-verified in the reference app: `/lookbook` redirects to Overview; 8 nav groups; grouped routes resolve; old flat route 404s