### PR TITLE
feat(lookbook): Tier 2 showcase — all-variants scenarios (button/badge/alert/banner)

### DIFF
--- a/lib/generators/modelrails_ui/lookbook/templates/previews/ui/alert_component_preview.rb
+++ b/lib/generators/modelrails_ui/lookbook/templates/previews/ui/alert_component_preview.rb
@@ -50,6 +50,10 @@ module UI
     def with_slots
     end
 
+    # Every AAA-proven tone on one screen.
+    def showcase
+    end
+
     # ## Don't — an empty alert
     #
     # An alert with no title and no description renders an empty live region —

--- a/lib/generators/modelrails_ui/lookbook/templates/previews/ui/alert_component_preview.rb
+++ b/lib/generators/modelrails_ui/lookbook/templates/previews/ui/alert_component_preview.rb
@@ -25,6 +25,16 @@ module UI
   class AlertComponentPreview < ViewComponent::Preview
     include UIHelper
 
+    # @!group Overview
+
+    # Every AAA-proven tone on one screen.
+    def showcase
+    end
+
+    # @!endgroup
+
+    # @!group Examples
+
     # Neutral, informational message — announced politely (role=status).
     def default
     end
@@ -50,9 +60,9 @@ module UI
     def with_slots
     end
 
-    # Every AAA-proven tone on one screen.
-    def showcase
-    end
+    # @!endgroup
+
+    # @!group Reference
 
     # ## Don't — an empty alert
     #
@@ -61,5 +71,7 @@ module UI
     # @label Don't · empty alert
     def dont_empty
     end
+
+    # @!endgroup
   end
 end

--- a/lib/generators/modelrails_ui/lookbook/templates/previews/ui/alert_component_preview/showcase.html.erb
+++ b/lib/generators/modelrails_ui/lookbook/templates/previews/ui/alert_component_preview/showcase.html.erb
@@ -1,0 +1,6 @@
+<%# locals: () -%>
+<div data-showcase="alert" class="flex flex-col gap-4 max-w-xl">
+  <% %i[neutral info success warning danger].each do |tone| %>
+    <%= ui :alert, tone: tone, title: tone.to_s.capitalize, description: "A #{tone} alert message." %>
+  <% end %>
+</div>

--- a/lib/generators/modelrails_ui/lookbook/templates/previews/ui/badge_component_preview.rb
+++ b/lib/generators/modelrails_ui/lookbook/templates/previews/ui/badge_component_preview.rb
@@ -82,6 +82,10 @@ module UI
       ui :badge, label, variant: variant.to_sym, tone: tone.to_sym
     end
 
+    # Every AAA-proven variant × tone cell on one screen.
+    def showcase
+    end
+
     # ## Don't — a badge as an action
     #
     # A badge is presentational. Don't wire a click handler onto a bare badge to fake

--- a/lib/generators/modelrails_ui/lookbook/templates/previews/ui/badge_component_preview.rb
+++ b/lib/generators/modelrails_ui/lookbook/templates/previews/ui/badge_component_preview.rb
@@ -28,6 +28,16 @@ module UI
   class BadgeComponentPreview < ViewComponent::Preview
     include UIHelper
 
+    # @!group Overview
+
+    # Every AAA-proven variant × tone cell on one screen.
+    def showcase
+    end
+
+    # @!endgroup
+
+    # @!group Examples
+
     # The default, high-emphasis label.
     def default
     end
@@ -72,6 +82,10 @@ module UI
     def link_href
     end
 
+    # @!endgroup
+
+    # @!group Reference
+
     # Edit `label` and the two-axis `variant`/`tone` cell live. Only the 9 AAA-proven
     # cells are offered (signals live on the SOFT variant as tinted chips; an unproven
     # pairing raises in dev).
@@ -82,10 +96,6 @@ module UI
       ui :badge, label, variant: variant.to_sym, tone: tone.to_sym
     end
 
-    # Every AAA-proven variant × tone cell on one screen.
-    def showcase
-    end
-
     # ## Don't — a badge as an action
     #
     # A badge is presentational. Don't wire a click handler onto a bare badge to fake
@@ -94,5 +104,7 @@ module UI
     # @label Don't · badge as an action
     def dont_action
     end
+
+    # @!endgroup
   end
 end

--- a/lib/generators/modelrails_ui/lookbook/templates/previews/ui/badge_component_preview/showcase.html.erb
+++ b/lib/generators/modelrails_ui/lookbook/templates/previews/ui/badge_component_preview/showcase.html.erb
@@ -1,0 +1,9 @@
+<%# locals: () -%>
+<div data-showcase="badge" class="flex flex-wrap items-start gap-4">
+  <% [%w[solid primary], %w[soft primary], %w[soft info], %w[soft success], %w[soft warning], %w[soft danger], %w[outline neutral], %w[ghost neutral], %w[link primary]].each do |variant, tone| %>
+    <div class="flex flex-col items-center gap-1">
+      <%= ui :badge, "Badge", variant: variant.to_sym, tone: tone.to_sym %>
+      <span class="text-xs text-text-muted"><%= variant %> / <%= tone %></span>
+    </div>
+  <% end %>
+</div>

--- a/lib/generators/modelrails_ui/lookbook/templates/previews/ui/banner_component_preview.rb
+++ b/lib/generators/modelrails_ui/lookbook/templates/previews/ui/banner_component_preview.rb
@@ -42,6 +42,10 @@ module UI
     def dismissible
     end
 
+    # Every AAA-proven variant on one screen.
+    def showcase
+    end
+
     # ## Don't — a dismiss control without an accessible name
     #
     # An icon-only close button with no `aria-label` is an unnamed button to screen

--- a/lib/generators/modelrails_ui/lookbook/templates/previews/ui/banner_component_preview.rb
+++ b/lib/generators/modelrails_ui/lookbook/templates/previews/ui/banner_component_preview.rb
@@ -28,6 +28,16 @@ module UI
   class BannerComponentPreview < ViewComponent::Preview
     include UIHelper
 
+    # @!group Overview
+
+    # Every AAA-proven variant on one screen.
+    def showcase
+    end
+
+    # @!endgroup
+
+    # @!group Examples
+
     # Neutral page-level announcement on the raised surface.
     def default
     end
@@ -42,9 +52,9 @@ module UI
     def dismissible
     end
 
-    # Every AAA-proven variant on one screen.
-    def showcase
-    end
+    # @!endgroup
+
+    # @!group Reference
 
     # ## Don't — a dismiss control without an accessible name
     #
@@ -54,5 +64,7 @@ module UI
     # @label Don't · dismiss with no label
     def dont_dismiss_no_label
     end
+
+    # @!endgroup
   end
 end

--- a/lib/generators/modelrails_ui/lookbook/templates/previews/ui/banner_component_preview/showcase.html.erb
+++ b/lib/generators/modelrails_ui/lookbook/templates/previews/ui/banner_component_preview/showcase.html.erb
@@ -1,0 +1,6 @@
+<%# locals: () -%>
+<div data-showcase="banner" class="flex flex-col gap-4">
+  <% %i[default info success warning destructive].each do |variant| %>
+    <%= ui :banner, "This is a #{variant} banner.", variant: variant, label: "#{variant.to_s.capitalize} announcement" %>
+  <% end %>
+</div>

--- a/lib/generators/modelrails_ui/lookbook/templates/previews/ui/button_component_preview.rb
+++ b/lib/generators/modelrails_ui/lookbook/templates/previews/ui/button_component_preview.rb
@@ -56,6 +56,10 @@ module UI
       ui :button, label, variant: variant.to_sym, tone: tone.to_sym
     end
 
+    # Every AAA-proven variant × tone cell on one screen.
+    def showcase
+    end
+
     # ## Don't — icon-only button with no accessible name
     #
     # An icon-only button **must** carry an `aria-label:`, or screen-reader users hear nothing.

--- a/lib/generators/modelrails_ui/lookbook/templates/previews/ui/button_component_preview.rb
+++ b/lib/generators/modelrails_ui/lookbook/templates/previews/ui/button_component_preview.rb
@@ -27,6 +27,16 @@ module UI
   class ButtonComponentPreview < ViewComponent::Preview
     include UIHelper
 
+    # @!group Overview
+
+    # Every AAA-proven variant × tone cell on one screen.
+    def showcase
+    end
+
+    # @!endgroup
+
+    # @!group Examples
+
     # The default, high-emphasis action. Aim for one primary per view.
     def primary
     end
@@ -47,6 +57,10 @@ module UI
     def link
     end
 
+    # @!endgroup
+
+    # @!group Reference
+
     # Edit `label` and the two-axis `variant`/`tone` cell live. Only the AAA-proven
     # cells are offered (an unproven pairing raises in dev).
     # @param label text
@@ -54,10 +68,6 @@ module UI
     def playground(label: "Button", cell: "solid/primary")
       variant, tone = cell.split("/")
       ui :button, label, variant: variant.to_sym, tone: tone.to_sym
-    end
-
-    # Every AAA-proven variant × tone cell on one screen.
-    def showcase
     end
 
     # ## Don't — icon-only button with no accessible name
@@ -68,5 +78,7 @@ module UI
     # @label Don't · icon-only without a label
     def dont_icon_only_without_label
     end
+
+    # @!endgroup
   end
 end

--- a/lib/generators/modelrails_ui/lookbook/templates/previews/ui/button_component_preview/showcase.html.erb
+++ b/lib/generators/modelrails_ui/lookbook/templates/previews/ui/button_component_preview/showcase.html.erb
@@ -1,0 +1,9 @@
+<%# locals: () -%>
+<div data-showcase="button" class="flex flex-wrap items-start gap-4">
+  <% [%w[solid primary], %w[solid danger], %w[outline neutral], %w[text primary], %w[text danger]].each do |variant, tone| %>
+    <div class="flex flex-col items-center gap-1">
+      <%= ui :button, "Button", variant: variant.to_sym, tone: tone.to_sym %>
+      <span class="text-xs text-text-muted"><%= variant %> / <%= tone %></span>
+    </div>
+  <% end %>
+</div>


### PR DESCRIPTION
## Summary

Tier 2 (PR-B, showcase) — adds an all-variants `showcase` scenario to the rich-family components, so a developer can see a component's whole variant family on one screen.

- **4 showcases:** `button` (5 variant×tone cells), `badge` (9), `alert` (5 tones), `banner` (5 variants). Each is a template-backed `showcase.html.erb` wrapping the proven cells in a `data-showcase=<name>` scope.
- **Scope refined 6 → 4:** dropped `indicator` (already ships a `variants` all-variants scenario) and `chat_bubble` (2-state `sent:` boolean, already shown together) — building those would duplicate existing coverage.

## Real bug caught by the showcase 0b proof

The `banner` showcase failed AAA: 5 `role="region"` landmarks sharing one `aria-label="Announcement"` tripped axe `landmark-unique` — invisible to single-scenario tests. Fixed by passing a distinct `label:` per banner.

## Test plan

- [x] Each showcase 0b spec passes axe at AAA in **both themes** (CI=true), scoped to its `data-showcase` subtree
- [x] button gets a new `button_component_spec.rb` (it had none); alert/banner extend their existing specs
- [x] Full app suite green; gem `rake` (tests + RuboCop) green