### PR TITLE
feat(lookbook): catalog-wide scenario grouping (Overview/Examples/Reference)

### DIFF
--- a/lib/generators/modelrails_ui/lookbook/templates/previews/ui/aspect_ratio_component_preview.rb
+++ b/lib/generators/modelrails_ui/lookbook/templates/previews/ui/aspect_ratio_component_preview.rb
@@ -25,6 +25,8 @@ module UI
   class AspectRatioComponentPreview < ViewComponent::Preview
     include UIHelper
 
+    # @!group Examples
+
     # Widescreen 16:9 framing an image.
     def default
     end
@@ -33,6 +35,10 @@ module UI
     def square
     end
 
+    # @!endgroup
+
+    # @!group Reference
+
     # ## Don't — an empty ratio box
     #
     # With no slotted content the wrapper reserves layout space for nothing and
@@ -40,5 +46,7 @@ module UI
     # @label Don't · no content
     def dont_no_content
     end
+
+    # @!endgroup
   end
 end

--- a/lib/generators/modelrails_ui/lookbook/templates/previews/ui/avatar_component_preview.rb
+++ b/lib/generators/modelrails_ui/lookbook/templates/previews/ui/avatar_component_preview.rb
@@ -31,6 +31,8 @@ module UI
   class AvatarComponentPreview < ViewComponent::Preview
     include UIHelper
 
+    # @!group Examples
+
     # Photo avatar: pass `src:` with an image URL. The element renders as `<img>`.
     def image
     end
@@ -44,6 +46,10 @@ module UI
     # with `--hue-initials`. Useful for workspace or org avatars.
     def custom_hue
     end
+
+    # @!endgroup
+
+    # @!group Reference
 
     # Explore size and initials interactively.
     # @param size select [xs, sm, md, lg, xl]
@@ -61,5 +67,7 @@ module UI
     # @label Don't · interactive avatar with no label
     def dont_interactive_no_label
     end
+
+    # @!endgroup
   end
 end

--- a/lib/generators/modelrails_ui/lookbook/templates/previews/ui/card_component_preview.rb
+++ b/lib/generators/modelrails_ui/lookbook/templates/previews/ui/card_component_preview.rb
@@ -26,6 +26,8 @@ module UI
   class CardComponentPreview < ViewComponent::Preview
     include UIHelper
 
+    # @!group Examples
+
     # Title + description in a header, with body content.
     def default
     end
@@ -33,6 +35,10 @@ module UI
     # The full composition — header, content, and a footer action bar.
     def with_footer
     end
+
+    # @!endgroup
+
+    # @!group Reference
 
     # ## Don't — skip a heading level
     #
@@ -43,5 +49,7 @@ module UI
     # @label Don't · skip a heading level
     def dont_heading_misuse
     end
+
+    # @!endgroup
   end
 end

--- a/lib/generators/modelrails_ui/lookbook/templates/previews/ui/chat_bubble_component_preview.rb
+++ b/lib/generators/modelrails_ui/lookbook/templates/previews/ui/chat_bubble_component_preview.rb
@@ -28,6 +28,8 @@ module UI
   class ChatBubbleComponentPreview < ViewComponent::Preview
     include UIHelper
 
+    # @!group Examples
+
     # An outgoing message — right-aligned interactive fill.
     def sent
     end
@@ -40,6 +42,10 @@ module UI
     def with_meta
     end
 
+    # @!endgroup
+
+    # @!group Reference
+
     # ## Don't — speaker conveyed by color/alignment only
     #
     # Sighted users read the side and fill to tell who spoke, but with no `author:`
@@ -48,5 +54,7 @@ module UI
     # @label Don't · color-only author
     def dont_color_only_author
     end
+
+    # @!endgroup
   end
 end

--- a/lib/generators/modelrails_ui/lookbook/templates/previews/ui/checkbox_component_preview.rb
+++ b/lib/generators/modelrails_ui/lookbook/templates/previews/ui/checkbox_component_preview.rb
@@ -21,6 +21,8 @@ module UI
   class CheckboxComponentPreview < ViewComponent::Preview
     include UIHelper
 
+    # @!group Examples
+
     # A labelled, unchecked checkbox.
     def default
     end
@@ -37,6 +39,10 @@ module UI
     def disabled
     end
 
+    # @!endgroup
+
+    # @!group Reference
+
     # ## Don't — an unlabelled checkbox
     #
     # No `label` and no `aria-label` leaves an unlabelled control — screen-reader
@@ -44,5 +50,7 @@ module UI
     # @label Don't · no label
     def dont_no_label
     end
+
+    # @!endgroup
   end
 end

--- a/lib/generators/modelrails_ui/lookbook/templates/previews/ui/data_table_component_preview.rb
+++ b/lib/generators/modelrails_ui/lookbook/templates/previews/ui/data_table_component_preview.rb
@@ -26,6 +26,8 @@ module UI
   class DataTableComponentPreview < ViewComponent::Preview
     include UIHelper
 
+    # @!group Examples
+
     # A few sortable + one non-sortable column, rows, and a caption (the
     # accessible name). Try Tab-ing to a header and pressing Enter to sort.
     def default
@@ -41,6 +43,10 @@ module UI
     def not_sortable
     end
 
+    # @!endgroup
+
+    # @!group Reference
+
     # ## Don't — a table with no caption
     #
     # A `<table>` with no `caption:` (and no other accessible name) leaves
@@ -49,5 +55,7 @@ module UI
     # @label Don't · no caption (no accessible name)
     def dont_no_caption
     end
+
+    # @!endgroup
   end
 end

--- a/lib/generators/modelrails_ui/lookbook/templates/previews/ui/date_picker_component_preview.rb
+++ b/lib/generators/modelrails_ui/lookbook/templates/previews/ui/date_picker_component_preview.rb
@@ -21,10 +21,16 @@ module UI
   class DatePickerComponentPreview < ViewComponent::Preview
     include UIHelper
 
+    # @!group Examples
+
     # Standard picker: a labelled disclosure button, a format hint, and the calendar
     # popover. No initial value, so the trigger shows the placeholder.
     def default
     end
+
+    # @!endgroup
+
+    # @!group Reference
 
     # Edit `label`, `format`, and `name` live. `format:` drives BOTH the initial label's
     # strftime and the human-readable hint (`:long` → MMMM D, YYYY, `:short` → M/D/YYYY,
@@ -35,5 +41,7 @@ module UI
     def playground(label: "Choose date", format: :long, name: "event[date]")
       ui :date_picker, label: label, format: format.to_sym, name: name
     end
+
+    # @!endgroup
   end
 end

--- a/lib/generators/modelrails_ui/lookbook/templates/previews/ui/device_mockup_component_preview.rb
+++ b/lib/generators/modelrails_ui/lookbook/templates/previews/ui/device_mockup_component_preview.rb
@@ -22,12 +22,26 @@ module UI
   class DeviceMockupComponentPreview < ViewComponent::Preview
     include UIHelper
 
+    # @!group Examples
+
     # Portrait phone frame with a decorative top notch (default).
     def phone
     end
 
     # Browser window with decorative traffic-light dots and a fake address bar.
     def browser
+    end
+
+    # @!endgroup
+
+    # @!group Reference
+
+    # Edit `variant` live to switch the device frame (phone/browser/tablet).
+    # @param variant select [phone, browser, tablet]
+    def playground(variant: :browser)
+      ui :device_mockup, variant: variant.to_sym, url: "https://example.com/dashboard", class: "max-w-md" do
+        '<div class="flex aspect-video items-center justify-center bg-surface-sunken text-sm text-text-body">Screen content</div>'.html_safe
+      end
     end
 
     # ## Don't — a meaningful screenshot with no alt text
@@ -39,12 +53,6 @@ module UI
     def dont_decorative_image_no_alt
     end
 
-    # Edit `variant` live to switch the device frame (phone/browser/tablet).
-    # @param variant select [phone, browser, tablet]
-    def playground(variant: :browser)
-      ui :device_mockup, variant: variant.to_sym, url: "https://example.com/dashboard", class: "max-w-md" do
-        '<div class="flex aspect-video items-center justify-center bg-surface-sunken text-sm text-text-body">Screen content</div>'.html_safe
-      end
-    end
+    # @!endgroup
   end
 end

--- a/lib/generators/modelrails_ui/lookbook/templates/previews/ui/dialog_component_preview.rb
+++ b/lib/generators/modelrails_ui/lookbook/templates/previews/ui/dialog_component_preview.rb
@@ -36,6 +36,8 @@ module UI
   class DialogComponentPreview < ViewComponent::Preview
     include UIHelper
 
+    # @!group Examples
+
     # Standard dialog: trigger button, title, description, and body content.
     # The `with_trigger` slot renders inside the `modal` controller wrapper so
     # clicking the button calls `modal#open` automatically.
@@ -46,6 +48,10 @@ module UI
     def large
     end
 
+    # @!endgroup
+
+    # @!group Reference
+
     # ## Don't — dialog without a title
     #
     # `title:` is required. It is wired to `aria-labelledby` on the `<dialog>` element,
@@ -54,5 +60,7 @@ module UI
     # @label Don't · no title (breaks aria-labelledby)
     def dont_no_title
     end
+
+    # @!endgroup
   end
 end

--- a/lib/generators/modelrails_ui/lookbook/templates/previews/ui/dropdown_menu_component_preview.rb
+++ b/lib/generators/modelrails_ui/lookbook/templates/previews/ui/dropdown_menu_component_preview.rb
@@ -16,6 +16,8 @@ module UI
   class DropdownMenuComponentPreview < ViewComponent::Preview
     include UIHelper
 
+    # @!group Examples
+
     # Standard menu: a button trigger and a labelled menu with items, a disabled item,
     # a separator, and a link item.
     def basic
@@ -25,11 +27,17 @@ module UI
     def positioned
     end
 
+    # @!endgroup
+
+    # @!group Reference
+
     # Edit `side` and `align` live to explore placement.
     # @param side select [bottom, top]
     # @param align select [start, end]
     def playground(side: :bottom, align: :start)
       render_with_template(locals: {side: side.to_sym, align: align.to_sym})
     end
+
+    # @!endgroup
   end
 end

--- a/lib/generators/modelrails_ui/lookbook/templates/previews/ui/figure_component_preview.rb
+++ b/lib/generators/modelrails_ui/lookbook/templates/previews/ui/figure_component_preview.rb
@@ -22,6 +22,8 @@ module UI
   class FigureComponentPreview < ViewComponent::Preview
     include UIHelper
 
+    # @!group Examples
+
     # An image with a caption.
     def default
     end
@@ -29,6 +31,10 @@ module UI
     # A figure with no caption.
     def no_caption
     end
+
+    # @!endgroup
+
+    # @!group Reference
 
     # ## Don't — caption used in place of alt
     #
@@ -38,5 +44,7 @@ module UI
     # @label Don't · caption replaces alt
     def dont_caption_replaces_alt
     end
+
+    # @!endgroup
   end
 end

--- a/lib/generators/modelrails_ui/lookbook/templates/previews/ui/file_input_component_preview.rb
+++ b/lib/generators/modelrails_ui/lookbook/templates/previews/ui/file_input_component_preview.rb
@@ -32,6 +32,8 @@ module UI
   class FileInputComponentPreview < ViewComponent::Preview
     include UIHelper
 
+    # @!group Examples
+
     # Generic file picker — no type restriction.
     def default
     end
@@ -45,6 +47,10 @@ module UI
     def multiple
     end
 
+    # @!endgroup
+
+    # @!group Reference
+
     # ## Don't — hand-rolled `<input type="file">` tag
     #
     # A bare `<input type="file">` in ERB skips the AAA styling tokens, the focus ring,
@@ -54,5 +60,7 @@ module UI
     # @label Don't · raw <input type="file"> tag
     def dont_raw_file_input
     end
+
+    # @!endgroup
   end
 end

--- a/lib/generators/modelrails_ui/lookbook/templates/previews/ui/floating_label_component_preview.rb
+++ b/lib/generators/modelrails_ui/lookbook/templates/previews/ui/floating_label_component_preview.rb
@@ -30,6 +30,8 @@ module UI
   class FloatingLabelComponentPreview < ViewComponent::Preview
     include UIHelper
 
+    # @!group Examples
+
     # The baseline: a floating-label text field. The label sits inside the field
     # until focus or input, then rises.
     def default
@@ -45,6 +47,10 @@ module UI
     def invalid
     end
 
+    # @!endgroup
+
+    # @!group Reference
+
     # ## Don't — a floating label with no label text
     #
     # Without a `label` there's no placeholder to drive the float AND no accessible
@@ -53,5 +59,7 @@ module UI
     # @label Don't · no label
     def dont_no_label
     end
+
+    # @!endgroup
   end
 end

--- a/lib/generators/modelrails_ui/lookbook/templates/previews/ui/footer_component_preview.rb
+++ b/lib/generators/modelrails_ui/lookbook/templates/previews/ui/footer_component_preview.rb
@@ -27,6 +27,8 @@ module UI
   class FooterComponentPreview < ViewComponent::Preview
     include UIHelper
 
+    # @!group Examples
+
     # Full footer — link columns plus a copyright row.
     def default
     end
@@ -34,6 +36,10 @@ module UI
     # Just a copyright / legal line — no columns.
     def minimal
     end
+
+    # @!endgroup
+
+    # @!group Reference
 
     # ## Don't — non-semantic link rows
     #
@@ -43,5 +49,7 @@ module UI
     # @label Don't · div link rows
     def dont_div_links
     end
+
+    # @!endgroup
   end
 end

--- a/lib/generators/modelrails_ui/lookbook/templates/previews/ui/hover_card_component_preview.rb
+++ b/lib/generators/modelrails_ui/lookbook/templates/previews/ui/hover_card_component_preview.rb
@@ -15,9 +15,15 @@ module UI
   class HoverCardComponentPreview < ViewComponent::Preview
     include UIHelper
 
+    # @!group Examples
+
     # Hover or focus the trigger to reveal the card; Tab through its links; Escape dismisses.
     def basic
     end
+
+    # @!endgroup
+
+    # @!group Reference
 
     # Edit `side` and `label` live.
     # @param label text
@@ -25,5 +31,7 @@ module UI
     def playground(label: "User card", side: :bottom)
       render_with_template(locals: {label: label, side: side.to_sym})
     end
+
+    # @!endgroup
   end
 end

--- a/lib/generators/modelrails_ui/lookbook/templates/previews/ui/iframe_component_preview.rb
+++ b/lib/generators/modelrails_ui/lookbook/templates/previews/ui/iframe_component_preview.rb
@@ -24,6 +24,8 @@ module UI
   class IframeComponentPreview < ViewComponent::Preview
     include UIHelper
 
+    # @!group Examples
+
     # A titled iframe embedding an external map.
     def default
     end
@@ -31,6 +33,10 @@ module UI
     # Aspect-ratio constrained (16/9) — the frame stays responsive at any width.
     def responsive
     end
+
+    # @!endgroup
+
+    # @!group Reference
 
     # ## Don't — iframe with no accessible name
     #
@@ -41,5 +47,7 @@ module UI
     # @label Don't · no title
     def dont_no_title
     end
+
+    # @!endgroup
   end
 end

--- a/lib/generators/modelrails_ui/lookbook/templates/previews/ui/image_component_preview.rb
+++ b/lib/generators/modelrails_ui/lookbook/templates/previews/ui/image_component_preview.rb
@@ -21,6 +21,8 @@ module UI
   class ImageComponentPreview < ViewComponent::Preview
     include UIHelper
 
+    # @!group Examples
+
     # A meaningful image with real alt text.
     def default
     end
@@ -33,6 +35,10 @@ module UI
     def decorative
     end
 
+    # @!endgroup
+
+    # @!group Reference
+
     # ## Don't — alt used as a caption
     #
     # `alt` should be a terse equivalent, not a long descriptive sentence. Stuffing a
@@ -41,5 +47,7 @@ module UI
     # @label Don't · alt as caption
     def dont_alt_as_caption
     end
+
+    # @!endgroup
   end
 end

--- a/lib/generators/modelrails_ui/lookbook/templates/previews/ui/indicator_component_preview.rb
+++ b/lib/generators/modelrails_ui/lookbook/templates/previews/ui/indicator_component_preview.rb
@@ -21,6 +21,8 @@ module UI
   class IndicatorComponentPreview < ViewComponent::Preview
     include UIHelper
 
+    # @!group Examples
+
     # A bare presence dot on an element.
     def default
     end
@@ -37,6 +39,10 @@ module UI
     def variants
     end
 
+    # @!endgroup
+
+    # @!group Reference
+
     # ## Don't — color-only signal
     #
     # This destructive dot is the only thing conveying "error" — there's no text or
@@ -45,5 +51,7 @@ module UI
     # @label Don't · color only
     def dont_color_only
     end
+
+    # @!endgroup
   end
 end

--- a/lib/generators/modelrails_ui/lookbook/templates/previews/ui/input_component_preview.rb
+++ b/lib/generators/modelrails_ui/lookbook/templates/previews/ui/input_component_preview.rb
@@ -31,6 +31,8 @@ module UI
   class InputComponentPreview < ViewComponent::Preview
     include UIHelper
 
+    # @!group Examples
+
     # Plain text input — the baseline appearance.
     def default
     end
@@ -44,6 +46,10 @@ module UI
     def invalid
     end
 
+    # @!endgroup
+
+    # @!group Reference
+
     # ## Don't — hand-rolled `<input>` tag
     #
     # Writing a bare `<input>` in ERB skips the AAA styling tokens, the focus ring,
@@ -52,5 +58,7 @@ module UI
     # @label Don't · raw <input> tag
     def dont_raw_input
     end
+
+    # @!endgroup
   end
 end

--- a/lib/generators/modelrails_ui/lookbook/templates/previews/ui/kbd_component_preview.rb
+++ b/lib/generators/modelrails_ui/lookbook/templates/previews/ui/kbd_component_preview.rb
@@ -23,6 +23,8 @@ module UI
   class KbdComponentPreview < ViewComponent::Preview
     include UIHelper
 
+    # @!group Examples
+
     # A single key.
     def default
     end
@@ -35,6 +37,10 @@ module UI
     def in_context
     end
 
+    # @!endgroup
+
+    # @!group Reference
+
     # ## Don't — non-keyboard text in a <kbd>
     #
     # `<kbd>` means "keyboard input". Using it for a button label or arbitrary text
@@ -42,5 +48,7 @@ module UI
     # @label Don't · non-key text
     def dont_non_key
     end
+
+    # @!endgroup
   end
 end

--- a/lib/generators/modelrails_ui/lookbook/templates/previews/ui/label_component_preview.rb
+++ b/lib/generators/modelrails_ui/lookbook/templates/previews/ui/label_component_preview.rb
@@ -23,6 +23,8 @@ module UI
   class LabelComponentPreview < ViewComponent::Preview
     include UIHelper
 
+    # @!group Examples
+
     # A standalone caption (no association — see `for_an_input` to bind one).
     def default
     end
@@ -35,6 +37,10 @@ module UI
     def required
     end
 
+    # @!endgroup
+
+    # @!group Reference
+
     # ## Don't — a required marker without the requirement on the input
     #
     # The `*` is decorative (aria-hidden). If the input lacks `aria-required`/
@@ -43,5 +49,7 @@ module UI
     # @label Don't · marker-only requirement
     def dont_marker_only
     end
+
+    # @!endgroup
   end
 end

--- a/lib/generators/modelrails_ui/lookbook/templates/previews/ui/list_group_component_preview.rb
+++ b/lib/generators/modelrails_ui/lookbook/templates/previews/ui/list_group_component_preview.rb
@@ -25,6 +25,8 @@ module UI
   class ListGroupComponentPreview < ViewComponent::Preview
     include UIHelper
 
+    # @!group Examples
+
     # Static rows — a plain <ul> of <li>, with a muted row for de-emphasis.
     def default
     end
@@ -34,6 +36,10 @@ module UI
     def links
     end
 
+    # @!endgroup
+
+    # @!group Reference
+
     # ## Don't — non-semantic <div> rows
     #
     # Building rows as <div>s with click handlers is invisible to assistive tech
@@ -42,5 +48,7 @@ module UI
     # @label Don't · div rows
     def dont_div_rows
     end
+
+    # @!endgroup
   end
 end

--- a/lib/generators/modelrails_ui/lookbook/templates/previews/ui/map_area_component_preview.rb
+++ b/lib/generators/modelrails_ui/lookbook/templates/previews/ui/map_area_component_preview.rb
@@ -25,9 +25,15 @@ module UI
   class MapAreaComponentPreview < ViewComponent::Preview
     include UIHelper
 
+    # @!group Examples
+
     # An image with two labeled, clickable hotspots.
     def default
     end
+
+    # @!endgroup
+
+    # @!group Reference
 
     # ## Don't — a hotspot with no accessible name
     #
@@ -37,5 +43,7 @@ module UI
     # @label Don't · area without alt
     def dont_area_no_alt
     end
+
+    # @!endgroup
   end
 end

--- a/lib/generators/modelrails_ui/lookbook/templates/previews/ui/number_input_component_preview.rb
+++ b/lib/generators/modelrails_ui/lookbook/templates/previews/ui/number_input_component_preview.rb
@@ -33,6 +33,8 @@ module UI
   class NumberInputComponentPreview < ViewComponent::Preview
     include UIHelper
 
+    # @!group Examples
+
     # A bounded numeric input with min/max/step constraints — the baseline appearance.
     def default
     end
@@ -47,6 +49,10 @@ module UI
     def invalid
     end
 
+    # @!endgroup
+
+    # @!group Reference
+
     # ## Don't — hand-rolled `<input type="number">` tag
     #
     # Writing a bare `<input type="number">` in ERB skips the AAA styling tokens, the
@@ -56,5 +62,7 @@ module UI
     # @label Don't · raw <input> tag
     def dont_raw_input
     end
+
+    # @!endgroup
   end
 end

--- a/lib/generators/modelrails_ui/lookbook/templates/previews/ui/picture_component_preview.rb
+++ b/lib/generators/modelrails_ui/lookbook/templates/previews/ui/picture_component_preview.rb
@@ -22,6 +22,8 @@ module UI
   class PictureComponentPreview < ViewComponent::Preview
     include UIHelper
 
+    # @!group Examples
+
     # Art-directed sources — a wide crop on large screens, a narrow crop on small.
     def default
     end
@@ -29,6 +31,10 @@ module UI
     # Format fallback — AVIF, then WebP, then the JPEG base <img>.
     def formats
     end
+
+    # @!endgroup
+
+    # @!group Reference
 
     # ## Don't — base <img> without alt
     #
@@ -38,5 +44,7 @@ module UI
     # @label Don't · no alt
     def dont_no_alt
     end
+
+    # @!endgroup
   end
 end

--- a/lib/generators/modelrails_ui/lookbook/templates/previews/ui/popover_component_preview.rb
+++ b/lib/generators/modelrails_ui/lookbook/templates/previews/ui/popover_component_preview.rb
@@ -16,6 +16,8 @@ module UI
   class PopoverComponentPreview < ViewComponent::Preview
     include UIHelper
 
+    # @!group Examples
+
     # Standard popover: a button trigger and a labelled dialog panel.
     def basic
     end
@@ -23,6 +25,10 @@ module UI
     # `side:` and `align:` place the panel relative to the trigger.
     def positioned
     end
+
+    # @!endgroup
+
+    # @!group Reference
 
     # Edit `side`, `align`, and `label` live to explore placement. Popover renders
     # inline (not a full-screen modal), so the param panel is the natural way to
@@ -36,5 +42,7 @@ module UI
         "Panel anchored #{side}/#{align}. Change the params to explore placement."
       end
     end
+
+    # @!endgroup
   end
 end

--- a/lib/generators/modelrails_ui/lookbook/templates/previews/ui/progress_component_preview.rb
+++ b/lib/generators/modelrails_ui/lookbook/templates/previews/ui/progress_component_preview.rb
@@ -20,6 +20,8 @@ module UI
   class ProgressComponentPreview < ViewComponent::Preview
     include UIHelper
 
+    # @!group Examples
+
     # Half-filled bar.
     def default
     end
@@ -32,6 +34,10 @@ module UI
     def complete
     end
 
+    # @!endgroup
+
+    # @!group Reference
+
     # ## Don't — unlabeled progress bar
     #
     # This bar has no `label:` and no surrounding text, so it is unnamed for screen
@@ -39,5 +45,7 @@ module UI
     # @label Don't · unlabeled
     def dont_unlabeled
     end
+
+    # @!endgroup
   end
 end

--- a/lib/generators/modelrails_ui/lookbook/templates/previews/ui/qr_code_component_preview.rb
+++ b/lib/generators/modelrails_ui/lookbook/templates/previews/ui/qr_code_component_preview.rb
@@ -25,6 +25,8 @@ module UI
   class QrCodeComponentPreview < ViewComponent::Preview
     include UIHelper
 
+    # @!group Examples
+
     # A pre-rendered QR image with a meaningful accessible name.
     def default
     end
@@ -33,6 +35,10 @@ module UI
     def block_svg
     end
 
+    # @!endgroup
+
+    # @!group Reference
+
     # ## Don't — a vague accessible name
     #
     # `alt: "QR code"` tells a screen-reader user nothing about where the code leads.
@@ -40,5 +46,7 @@ module UI
     # @label Don't · vague name
     def dont_vague_name
     end
+
+    # @!endgroup
   end
 end

--- a/lib/generators/modelrails_ui/lookbook/templates/previews/ui/radio_group_component_preview.rb
+++ b/lib/generators/modelrails_ui/lookbook/templates/previews/ui/radio_group_component_preview.rb
@@ -25,6 +25,8 @@ module UI
   class RadioGroupComponentPreview < ViewComponent::Preview
     include UIHelper
 
+    # @!group Examples
+
     # Baseline: a named group with a few options and no current selection.
     def default
     end
@@ -38,6 +40,10 @@ module UI
     def invalid
     end
 
+    # @!endgroup
+
+    # @!group Reference
+
     # ## Don't — a radiogroup with no accessible name
     #
     # A `role="radiogroup"` with neither `label:` nor `labelledby:` exposes no
@@ -46,5 +52,7 @@ module UI
     # @label Don't · no group label
     def dont_no_group_label
     end
+
+    # @!endgroup
   end
 end

--- a/lib/generators/modelrails_ui/lookbook/templates/previews/ui/rating_component_preview.rb
+++ b/lib/generators/modelrails_ui/lookbook/templates/previews/ui/rating_component_preview.rb
@@ -25,6 +25,8 @@ module UI
   class RatingComponentPreview < ViewComponent::Preview
     include UIHelper
 
+    # @!group Examples
+
     # Default — three of five stars filled; announces as "3 out of 5 stars".
     def default
     end
@@ -37,6 +39,10 @@ module UI
     def custom_scale
     end
 
+    # @!endgroup
+
+    # @!group Reference
+
     # ## Don't — never substitute a raw color for the semantic token
     #
     # Filled stars must use the AAA-tuned `text-warning-icon` token, not a raw
@@ -46,5 +52,7 @@ module UI
     # @label Don't · raw color for filled stars
     def dont_raw_color
     end
+
+    # @!endgroup
   end
 end

--- a/lib/generators/modelrails_ui/lookbook/templates/previews/ui/rating_input_component_preview.rb
+++ b/lib/generators/modelrails_ui/lookbook/templates/previews/ui/rating_input_component_preview.rb
@@ -26,6 +26,8 @@ module UI
   class RatingInputComponentPreview < ViewComponent::Preview
     include UIHelper
 
+    # @!group Examples
+
     # Default — an empty 5-star rating with the default "Rating" group name.
     def default
     end
@@ -38,6 +40,10 @@ module UI
     def in_a_form
     end
 
+    # @!endgroup
+
+    # @!group Reference
+
     # ## Don't — never substitute a raw color for the semantic token
     #
     # Filled stars must use the AAA-tuned `text-warning-icon` token, not a raw
@@ -47,5 +53,7 @@ module UI
     # @label Don't · raw color for filled stars
     def dont_raw_color
     end
+
+    # @!endgroup
   end
 end

--- a/lib/generators/modelrails_ui/lookbook/templates/previews/ui/scroll_area_component_preview.rb
+++ b/lib/generators/modelrails_ui/lookbook/templates/previews/ui/scroll_area_component_preview.rb
@@ -23,6 +23,8 @@ module UI
   class ScrollAreaComponentPreview < ViewComponent::Preview
     include UIHelper
 
+    # @!group Examples
+
     # A fixed-height vertical scroll area with long content. It is a keyboard tab
     # stop (Tab to it, then arrow to scroll) and named via `aria_label:`.
     def default
@@ -32,6 +34,10 @@ module UI
     def horizontal
     end
 
+    # @!endgroup
+
+    # @!group Reference
+
     # ## Don't — a scroll region with no keyboard access
     #
     # `focusable: false` removes the tab stop AND the accessible name. A keyboard-only
@@ -40,5 +46,7 @@ module UI
     # @label Don't · no keyboard access
     def dont_no_keyboard_access
     end
+
+    # @!endgroup
   end
 end

--- a/lib/generators/modelrails_ui/lookbook/templates/previews/ui/search_input_component_preview.rb
+++ b/lib/generators/modelrails_ui/lookbook/templates/previews/ui/search_input_component_preview.rb
@@ -24,6 +24,8 @@ module UI
   class SearchInputComponentPreview < ViewComponent::Preview
     include UIHelper
 
+    # @!group Examples
+
     # Baseline: a labelled search box. The accessible name defaults to "Search".
     def default
     end
@@ -36,6 +38,10 @@ module UI
     def invalid
     end
 
+    # @!endgroup
+
+    # @!group Reference
+
     # ## Don't — strip the accessible name
     #
     # A placeholder is only a hint, not an accessible name. Blanking `label:` (or
@@ -44,5 +50,7 @@ module UI
     # @label Don't · no accessible name
     def dont_no_accessible_name
     end
+
+    # @!endgroup
   end
 end

--- a/lib/generators/modelrails_ui/lookbook/templates/previews/ui/select_component_preview.rb
+++ b/lib/generators/modelrails_ui/lookbook/templates/previews/ui/select_component_preview.rb
@@ -23,6 +23,8 @@ module UI
   class SelectComponentPreview < ViewComponent::Preview
     include UIHelper
 
+    # @!group Examples
+
     # A native select with a sibling label — the baseline appearance.
     def default
     end
@@ -44,6 +46,10 @@ module UI
     def disabled
     end
 
+    # @!endgroup
+
+    # @!group Reference
+
     # ## Don't — a select with no associated label
     #
     # A `<select>` with no external `<label for="<id>">` has no accessible name —
@@ -52,5 +58,7 @@ module UI
     # @label Don't · no label
     def dont_no_label
     end
+
+    # @!endgroup
   end
 end

--- a/lib/generators/modelrails_ui/lookbook/templates/previews/ui/separator_component_preview.rb
+++ b/lib/generators/modelrails_ui/lookbook/templates/previews/ui/separator_component_preview.rb
@@ -22,6 +22,8 @@ module UI
   class SeparatorComponentPreview < ViewComponent::Preview
     include UIHelper
 
+    # @!group Examples
+
     # Horizontal, decorative (the default).
     def default
     end
@@ -34,6 +36,10 @@ module UI
     def semantic
     end
 
+    # @!endgroup
+
+    # @!group Reference
+
     # ## Don't — meaningful boundary left decorative
     #
     # This separator divides two distinct groups, but it's left `decorative: true`,
@@ -42,5 +48,7 @@ module UI
     # @label Don't · decorative when semantic
     def dont_decorative_when_semantic
     end
+
+    # @!endgroup
   end
 end

--- a/lib/generators/modelrails_ui/lookbook/templates/previews/ui/sheet_component_preview.rb
+++ b/lib/generators/modelrails_ui/lookbook/templates/previews/ui/sheet_component_preview.rb
@@ -28,6 +28,8 @@ module UI
   class SheetComponentPreview < ViewComponent::Preview
     include UIHelper
 
+    # @!group Examples
+
     # Default side panel sliding in from the right edge. The `with_trigger` slot
     # renders inside the `modal` controller wrapper so clicking the button calls
     # `modal#open` automatically.
@@ -45,6 +47,10 @@ module UI
     def side_bottom
     end
 
+    # @!endgroup
+
+    # @!group Reference
+
     # Edit `side` live to slide the panel in from any edge.
     # @param side select [top, right, bottom, left]
     def playground(side: :right)
@@ -53,5 +59,7 @@ module UI
         "Panel slides in from the #{side} edge. Change the param to explore placement."
       end
     end
+
+    # @!endgroup
   end
 end

--- a/lib/generators/modelrails_ui/lookbook/templates/previews/ui/skeleton_component_preview.rb
+++ b/lib/generators/modelrails_ui/lookbook/templates/previews/ui/skeleton_component_preview.rb
@@ -20,6 +20,8 @@ module UI
   class SkeletonComponentPreview < ViewComponent::Preview
     include UIHelper
 
+    # @!group Examples
+
     # A single text-line placeholder.
     def default
     end
@@ -32,6 +34,10 @@ module UI
     def circle
     end
 
+    # @!endgroup
+
+    # @!group Reference
+
     # ## Don't — no surrounding busy/live region
     #
     # These skeletons are `aria-hidden`, and nothing around them announces a loading
@@ -40,5 +46,7 @@ module UI
     # @label Don't · no busy region
     def dont_no_busy_region
     end
+
+    # @!endgroup
   end
 end

--- a/lib/generators/modelrails_ui/lookbook/templates/previews/ui/spinner_component_preview.rb
+++ b/lib/generators/modelrails_ui/lookbook/templates/previews/ui/spinner_component_preview.rb
@@ -20,6 +20,8 @@ module UI
   class SpinnerComponentPreview < ViewComponent::Preview
     include UIHelper
 
+    # @!group Examples
+
     # Default spinner.
     def default
     end
@@ -32,6 +34,10 @@ module UI
     def on_surface
     end
 
+    # @!endgroup
+
+    # @!group Reference
+
     # ## Don't — spinner with no status text
     #
     # A hand-built spinner with no `role="status"` and no sr-only text is silent to
@@ -40,5 +46,7 @@ module UI
     # @label Don't · no status text
     def dont_no_status_text
     end
+
+    # @!endgroup
   end
 end

--- a/lib/generators/modelrails_ui/lookbook/templates/previews/ui/stepper_component_preview.rb
+++ b/lib/generators/modelrails_ui/lookbook/templates/previews/ui/stepper_component_preview.rb
@@ -21,6 +21,8 @@ module UI
   class StepperComponentPreview < ViewComponent::Preview
     include UIHelper
 
+    # @!group Examples
+
     # A horizontal 3-step flow: one complete, one current, one pending.
     def default
     end
@@ -28,6 +30,10 @@ module UI
     # The same flow stacked vertically, with optional per-step descriptions.
     def vertical
     end
+
+    # @!endgroup
+
+    # @!group Reference
 
     # Edit `orientation` live to compare horizontal vs vertical layout.
     # @param orientation select [horizontal, vertical]
@@ -38,5 +44,7 @@ module UI
         {label: "Confirm", status: :pending}
       ]
     end
+
+    # @!endgroup
   end
 end

--- a/lib/generators/modelrails_ui/lookbook/templates/previews/ui/switch_component_preview.rb
+++ b/lib/generators/modelrails_ui/lookbook/templates/previews/ui/switch_component_preview.rb
@@ -23,6 +23,8 @@ module UI
   class SwitchComponentPreview < ViewComponent::Preview
     include UIHelper
 
+    # @!group Examples
+
     # Off — the default unchecked state.
     def off
     end
@@ -39,6 +41,10 @@ module UI
     def disabled
     end
 
+    # @!endgroup
+
+    # @!group Reference
+
     # ## Don't — a switch with no accessible name
     #
     # A label-less switch with no `aria-label:` has nothing to announce — screen-reader
@@ -46,5 +52,7 @@ module UI
     # @label Don't · no accessible name
     def dont_no_label
     end
+
+    # @!endgroup
   end
 end

--- a/lib/generators/modelrails_ui/lookbook/templates/previews/ui/textarea_component_preview.rb
+++ b/lib/generators/modelrails_ui/lookbook/templates/previews/ui/textarea_component_preview.rb
@@ -30,6 +30,8 @@ module UI
   class TextareaComponentPreview < ViewComponent::Preview
     include UIHelper
 
+    # @!group Examples
+
     # Multi-line input at rest — the baseline appearance.
     def default
     end
@@ -39,6 +41,10 @@ module UI
     def invalid
     end
 
+    # @!endgroup
+
+    # @!group Reference
+
     # ## Don't — hand-rolled `<textarea>` tag
     #
     # Writing a bare `<textarea>` in ERB skips the AAA styling tokens, the focus ring,
@@ -47,5 +53,7 @@ module UI
     # @label Don't · raw <textarea> tag
     def dont_raw_textarea
     end
+
+    # @!endgroup
   end
 end

--- a/lib/generators/modelrails_ui/lookbook/templates/previews/ui/timeline_component_preview.rb
+++ b/lib/generators/modelrails_ui/lookbook/templates/previews/ui/timeline_component_preview.rb
@@ -27,6 +27,8 @@ module UI
   class TimelineComponentPreview < ViewComponent::Preview
     include UIHelper
 
+    # @!group Examples
+
     # Three events with times, titles, and bodies — a plain <ol> of <li>.
     def default
     end
@@ -40,6 +42,10 @@ module UI
     def with_datetime
     end
 
+    # @!endgroup
+
+    # @!group Reference
+
     # ## Don't — non-semantic <div> steps
     #
     # Building the sequence as <div>s with a hand-drawn line gives assistive tech
@@ -48,5 +54,7 @@ module UI
     # @label Don't · div steps
     def dont_div_steps
     end
+
+    # @!endgroup
   end
 end

--- a/lib/generators/modelrails_ui/lookbook/templates/previews/ui/timepicker_component_preview.rb
+++ b/lib/generators/modelrails_ui/lookbook/templates/previews/ui/timepicker_component_preview.rb
@@ -22,6 +22,8 @@ module UI
   class TimepickerComponentPreview < ViewComponent::Preview
     include UIHelper
 
+    # @!group Examples
+
     # Standard 24-hour picker: a labelled disclosure button, a format hint, and the
     # hour/minute spinbutton popover. An initial value seeds the spinbuttons.
     def default
@@ -30,6 +32,10 @@ module UI
     # 12-hour picker: the hour spinbutton caps at 12 and an AM/PM spinbutton appears.
     def twelve_hour
     end
+
+    # @!endgroup
+
+    # @!group Reference
 
     # Edit `label`, `format`, `step`, and `name` live. `format:` drives BOTH the hour
     # spinbutton range and the human-readable hint (`:h24` → HH:MM 24-hour, `:h12` →
@@ -42,5 +48,7 @@ module UI
     def playground(label: "Pick time", format: :h24, step: 5, name: "event[time]")
       ui :timepicker, label: label, format: format.to_sym, step: step.to_i, name: name
     end
+
+    # @!endgroup
   end
 end

--- a/lib/generators/modelrails_ui/lookbook/templates/previews/ui/toaster_component_preview.rb
+++ b/lib/generators/modelrails_ui/lookbook/templates/previews/ui/toaster_component_preview.rb
@@ -37,6 +37,8 @@ module UI
   class ToasterComponentPreview < ViewComponent::Preview
     include UIHelper
 
+    # @!group Examples
+
     # A neutral default toast on the raised surface — announced politely (role=status).
     def default
     end
@@ -60,6 +62,10 @@ module UI
     def dismissible
     end
 
+    # @!endgroup
+
+    # @!group Reference
+
     # ## Don't — a raw-palette / unnamed toast
     #
     # A hand-rolled toast with raw palette colors (border-green-500) and a bare
@@ -68,5 +74,7 @@ module UI
     # @label Don't · raw palette + unnamed dismiss
     def dont_raw_palette
     end
+
+    # @!endgroup
   end
 end

--- a/lib/generators/modelrails_ui/lookbook/templates/previews/ui/toggle_component_preview.rb
+++ b/lib/generators/modelrails_ui/lookbook/templates/previews/ui/toggle_component_preview.rb
@@ -25,6 +25,8 @@ module UI
   class ToggleComponentPreview < ViewComponent::Preview
     include UIHelper
 
+    # @!group Examples
+
     # Unpressed (off) by default — aria-pressed="false", data-state="off".
     def default
     end
@@ -37,6 +39,10 @@ module UI
     # in width/padding, lg is taller.
     def sizes
     end
+
+    # @!endgroup
+
+    # @!group Reference
 
     # Edit `label`, `pressed`, and `size` live to explore the component.
     # @param label text
@@ -54,5 +60,7 @@ module UI
     # @label Don't · icon-only without a label
     def dont_icon_only_without_label
     end
+
+    # @!endgroup
   end
 end

--- a/lib/generators/modelrails_ui/lookbook/templates/previews/ui/tooltip_component_preview.rb
+++ b/lib/generators/modelrails_ui/lookbook/templates/previews/ui/tooltip_component_preview.rb
@@ -15,9 +15,15 @@ module UI
   class TooltipComponentPreview < ViewComponent::Preview
     include UIHelper
 
+    # @!group Examples
+
     # Hover or keyboard-focus the trigger to reveal the hint; Escape dismisses it.
     def basic
     end
+
+    # @!endgroup
+
+    # @!group Reference
 
     # Edit `text` and `side` live to explore placement.
     # @param text text
@@ -25,5 +31,7 @@ module UI
     def playground(text: "Saved to your library", side: :top)
       render_with_template(locals: {text: text, side: side.to_sym})
     end
+
+    # @!endgroup
   end
 end

--- a/test/test_lookbook_scenario_grouping.rb
+++ b/test/test_lookbook_scenario_grouping.rb
@@ -1,0 +1,69 @@
+# frozen_string_literal: true
+
+require "test_helper"
+
+# Every preview that has META scenarios (showcase / playground / dont_*) must group its
+# scenarios into Overview/Examples/Reference in the canonical order. Canonical-only previews
+# (no meta) are exempt and stay flat. Guards against scenario-order drift going forward.
+class TestLookbookScenarioGrouping < Minitest::Test
+  PREVIEW_ROOT = File.expand_path(
+    "../lib/generators/modelrails_ui/lookbook/templates/previews/ui", __dir__
+  )
+
+  RANK = {overview: 0, examples: 1, reference_pg: 2, reference_dont: 3}.freeze
+
+  def classify(name)
+    return :overview if name == "showcase"
+    return :reference_pg if name == "playground"
+    return :reference_dont if name.start_with?("dont_")
+    :examples
+  end
+
+  def scenario_methods(src)
+    src.scan(/^\s+def ([a-z_][a-z0-9_]*)/).flatten - %w[input_attrs]
+  end
+
+  def group_labels(src)
+    src.scan(/^\s*#\s*@!group\s+(\w+)/).flatten
+  end
+
+  def previews
+    Dir.glob(File.join(PREVIEW_ROOT, "*_component_preview.rb"))
+  end
+
+  def test_grouped_previews_are_in_canonical_order
+    previews.each do |path|
+      component = File.basename(path, "_component_preview.rb")
+      src = File.read(path)
+      methods = scenario_methods(src)
+      has_meta = methods.any? { |m| m == "showcase" || m == "playground" || m.start_with?("dont_") }
+      next unless has_meta
+
+      ranks = methods.map { |m| RANK.fetch(classify(m)) }
+
+      assert_equal ranks.sort, ranks,
+        "#{component}: scenarios out of canonical order (showcase→examples→playground→dont): #{methods.inspect}"
+
+      expected = []
+      expected << "Overview" if methods.include?("showcase")
+      expected << "Examples"
+      expected << "Reference"
+
+      assert_equal expected, group_labels(src),
+        "#{component}: @!group labels #{group_labels(src).inspect} != expected #{expected.inspect}"
+    end
+  end
+
+  def test_canonical_only_previews_stay_flat
+    previews.each do |path|
+      component = File.basename(path, "_component_preview.rb")
+      src = File.read(path)
+      methods = scenario_methods(src)
+      has_meta = methods.any? { |m| m == "showcase" || m == "playground" || m.start_with?("dont_") }
+      next if has_meta
+
+      assert_empty group_labels(src),
+        "#{component}: canonical-only preview should stay flat (no @!group), got #{group_labels(src).inspect}"
+    end
+  end
+end


### PR DESCRIPTION
## Summary

Extends the Tier 2 `@!group` divider to the whole catalog. Every component with meta scenarios now groups its scenarios into nav sections; canonical-only components stay flat.

- **Overview** (showcase) · **Examples** (canonical) · **Reference** (playground → don'ts).
- **46 previews grouped** (45 + 1 gem-only); 4 showcase components already had it; ~30 canonical-only left flat.
- **`device_mockup` ordering fixed** — Reference always orders playground before don't.

## Durable artifact: a consistency guard

`test/test_lookbook_scenario_grouping.rb` asserts every meta preview groups in canonical order (showcase→examples→playground→dont) with the right `@!group` labels, and that canonical-only previews stay flat. A future preview that drifts fails CI. (The bulk edit itself was a throwaway script.)

## Test plan

- [x] Guard green (160 assertions); `bundle exec rake` 870/0 + 0 RuboCop offenses
- [x] Diff-reviewed doc-comment preservation across shapes (dont-only / playground-only / playground+dont)
- [x] Live: a grouped component's default scenario resolves under its first group (e.g. `…/card/examples`); flat components unchanged