### PR TITLE
feat(lookbook): carry the six choosing decision pages + fix Overview embeds under grouping

### DIFF
--- a/lib/generators/modelrails_ui/lookbook/templates/previews/pages/00_overview.md.erb
+++ b/lib/generators/modelrails_ui/lookbook/templates/previews/pages/00_overview.md.erb
@@ -28,9 +28,9 @@ Before reaching for a component, prefer the framework primitive:
 
 ## Live examples
 
-<%= embed UI::ButtonComponentPreview, :primary %>
-<%= embed UI::BannerComponentPreview, :info %>
-<%= embed UI::CardComponentPreview, :default %>
+<%= embed UI::ButtonComponentPreview %>
+<%= embed UI::BannerComponentPreview %>
+<%= embed UI::CardComponentPreview %>
 
 ## Browse
 

--- a/lib/generators/modelrails_ui/lookbook/templates/previews/pages/choosing/00_forms.md.erb
+++ b/lib/generators/modelrails_ui/lookbook/templates/previews/pages/choosing/00_forms.md.erb
@@ -1,0 +1,73 @@
+---
+label: Forms & Inputs
+---
+
+# Choosing a form control
+
+Inside a `form_with`, reach for the form builder first — `f.text_field`, `f.select`,
+`f.file_field` already render these primitives with label/hint/error wiring. Reach for a
+primitive directly when you're outside a form or building something custom.
+
+## Free text
+
+| Component        | Reach for it when                                                      | Otherwise →       |
+|------------------|------------------------------------------------------------------------|-------------------|
+| `input`          | a one-off single-line text control outside `form_with`                 | `textarea`        |
+| `textarea`       | multi-line free text — comments, descriptions, notes                   | `input`           |
+| `floating_label` | a compact field whose label starts inside and floats on focus/value    | `input` + `label` |
+| `search_input`   | a standalone search/filter box with a built-in accessible name         | `input`           |
+| `wysiwyg`        | a rich-text editing surface (Trix/Quill adapter)                       | `textarea`        |
+
+<%= embed UI::InputComponentPreview %>
+
+## Numbers & codes
+
+| Component      | Reach for it when                                                       | Otherwise →               |
+|----------------|--------------------------------------------------------------------------|---------------------------|
+| `number_input` | an exact numeric entry with `min` / `max` / `step`                       | `range`                   |
+| `range`        | an approximate pick from a continuous, bounded range                     | `number_input`            |
+| `input_otp`    | confirming an out-of-band code — cells auto-advance and accept paste     | `input` (type: password)  |
+| `rating_input` | a 1..max star score submitted in a form                                  | `rating` (display-only)   |
+
+<%= embed UI::RangeComponentPreview %>
+
+## Choosing from a list
+
+| Component     | Reach for it when                                          | Otherwise →             |
+|---------------|-------------------------------------------------------------|-------------------------|
+| `select`      | a single choice from a short, known list                    | `combobox`              |
+| `combobox`    | a long list that needs type-to-filter                       | `select`; `command` (Actions section, ⌘K launcher) |
+| `radio_group` | a small fixed set where every option stays visible          | `select`                |
+
+<%= embed UI::SelectComponentPreview %>
+
+## On / off
+
+| Component      | Reach for it when                                             | Otherwise →            |
+|----------------|----------------------------------------------------------------|------------------------|
+| `checkbox`     | an on/off choice submitted with a form                         | `switch`               |
+| `switch`       | an immediate-effect on/off setting                             | `checkbox`             |
+| `toggle`       | a standalone pressed/unpressed action button                   | `checkbox` / `switch`  |
+| `toggle_group` | related toggles with single- or multi-active enforcement       | `toggle`               |
+
+<%= embed UI::SwitchComponentPreview %>
+
+## Date & time
+
+| Component     | Reach for it when                                        | Otherwise →    |
+|---------------|-----------------------------------------------------------|----------------|
+| `date_picker` | a disclosure button opening a calendar popover            | `calendar`     |
+| `calendar`    | an inline, always-visible month grid                      | `date_picker`  |
+| `timepicker`  | an hour/minute spinbutton popover                         | `date_picker`  |
+
+<%= embed UI::DatePickerComponentPreview %>
+
+## Field wiring & uploads
+
+| Component    | Reach for it when                                                            | Otherwise →               |
+|--------------|-------------------------------------------------------------------------------|---------------------------|
+| `label`      | captioning a control via `for:` (self-labelling `checkbox`/`radio_group` don't need it) | —              |
+| `form_field` | hand-composing a one-off labelled field with hint/error ARIA wiring           | `form_with` (the Rails form builder) |
+| `file_input` | an upload control with AAA styling + ARIA (inside `form_with`: `f.file_field`) | —                        |
+
+<%= embed UI::FormFieldComponentPreview %>

--- a/lib/generators/modelrails_ui/lookbook/templates/previews/pages/choosing/01_overlays.md.erb
+++ b/lib/generators/modelrails_ui/lookbook/templates/previews/pages/choosing/01_overlays.md.erb
@@ -1,0 +1,40 @@
+---
+label: Overlays
+---
+
+# Choosing an overlay
+
+Pick the family first: does it **block the page** (modal surfaces), **anchor to a trigger**
+without blocking (floating panels), or present a **list of commands** (menus)? Each component
+below is one sidebar click from its full preview.
+
+## Modal surfaces — block the page with a scrim
+
+| Component      | Reach for it when                                                    | Otherwise →        |
+|----------------|----------------------------------------------------------------------|--------------------|
+| `dialog`       | a focused task (form, detail, confirm) needs a focus-trapped modal    | `drawer` / `sheet` |
+| `alert_dialog` | a destructive or irreversible action must be confirmed before it runs | `dialog`           |
+| `sheet`        | a side panel — navigation, filters, a secondary form — slides in from an edge | `drawer`   |
+| `drawer`       | a mobile-friendly bottom sheet of secondary actions slides up         | `sheet`            |
+
+<%= embed UI::DialogComponentPreview %>
+
+## Floating — anchored to a trigger, no scrim
+
+| Component    | Reach for it when                                                          | Otherwise →            |
+|--------------|----------------------------------------------------------------------------|------------------------|
+| `popover`    | interactive content sits in a panel anchored to a trigger button (click toggles) | `tooltip` / `hover_card` |
+| `hover_card` | a rich preview enhances a link on hover or focus (not the only path to it)  | `popover`              |
+| `tooltip`    | a short text hint describes an element on hover or focus                    | `hover_card`           |
+
+<%= embed UI::PopoverComponentPreview %>
+
+## Menus — a list of commands
+
+| Component       | Reach for it when                                                     | Otherwise →     |
+|-----------------|----------------------------------------------------------------------|-----------------|
+| `dropdown_menu` | actions launch from a button trigger (the WAI-ARIA menu-button)       | `context_menu`  |
+| `context_menu`  | actions open from a right-click / long-press / Shift+F10 on a region  | `dropdown_menu` |
+| `menubar`       | a persistent app menu bar (File / Edit / View) exposes grouped commands | `dropdown_menu` |
+
+<%= embed UI::DropdownMenuComponentPreview %>

--- a/lib/generators/modelrails_ui/lookbook/templates/previews/pages/choosing/02_navigation.md.erb
+++ b/lib/generators/modelrails_ui/lookbook/templates/previews/pages/choosing/02_navigation.md.erb
@@ -1,0 +1,38 @@
+---
+label: Navigation
+---
+
+# Choosing navigation
+
+Page chrome frames the whole screen; link flyouts reveal grouped destinations; the last
+fork answers "where am I". Action menus (`dropdown_menu` / `context_menu` / `menubar`)
+are commands, not navigation — see *Choosing › Overlays*.
+
+## Page chrome
+
+| Component    | Reach for it when                                                  | Otherwise →  |
+|--------------|---------------------------------------------------------------------|--------------|
+| `navbar`     | a responsive top bar — links collapse behind a hamburger on mobile  | `sidebar`    |
+| `sidebar`    | a collapsible application rail with grouped items                   | `navbar`     |
+| `bottom_nav` | fixed mobile bottom destinations (icon + label)                     | `navbar`     |
+| `footer`     | the closing contentinfo landmark with link columns                  | —            |
+
+<%= embed UI::NavbarComponentPreview %>
+
+## Link flyouts
+
+| Component         | Reach for it when                                                          | Otherwise →        |
+|-------------------|------------------------------------------------------------------------------|--------------------|
+| `navigation_menu` | a horizontal site nav with disclosure flyouts (APG navigation, not `role="menu"`) | `mega_menu`    |
+| `mega_menu`       | a full-width panel of grouped links behind one disclosure button             | `navigation_menu`  |
+
+<%= embed UI::NavigationMenuComponentPreview %>
+
+## Where am I
+
+| Component    | Reach for it when                                          | Otherwise →           |
+|--------------|-------------------------------------------------------------|-----------------------|
+| `breadcrumb` | a hierarchy trail — the last item is the current page       | `tabs`                |
+| `tabs`       | switching between in-page panels (APG tabs)                 | `breadcrumb` / `navbar` |
+
+<%= embed UI::TabsComponentPreview %>

--- a/lib/generators/modelrails_ui/lookbook/templates/previews/pages/choosing/03_feedback.md.erb
+++ b/lib/generators/modelrails_ui/lookbook/templates/previews/pages/choosing/03_feedback.md.erb
@@ -1,0 +1,38 @@
+---
+label: Feedback & Status
+---
+
+# Choosing feedback & status
+
+Messages speak to the user; status markers annotate other elements; the last fork covers
+waiting. Ephemeral flashes are neither — use the app's toast system (`shared/_toasts`).
+
+## Messages
+
+| Component | Reach for it when                                                       | Otherwise →  |
+|-----------|---------------------------------------------------------------------------|--------------|
+| `alert`   | an inline message tied to surrounding content (form error summary)        | `banner`     |
+| `banner`  | a page-level announcement strip — promo, cookie notice, system notice     | `alert`      |
+| `toaster` | stacked ephemeral toast notifications                                     | `alert` / `banner` |
+
+<%= embed UI::AlertComponentPreview %>
+
+## Status markers
+
+| Component   | Reach for it when                                                     | Otherwise →  |
+|-------------|-------------------------------------------------------------------------|--------------|
+| `badge`     | a compact label pill classifying nearby content (a link when `href:`)   | `indicator`  |
+| `indicator` | a corner dot or count anchored on an icon/avatar/button                 | `badge`      |
+
+<%= embed UI::BadgeComponentPreview %>
+
+## Progress & loading
+
+| Component  | Reach for it when                                              | Otherwise →  |
+|------------|------------------------------------------------------------------|--------------|
+| `progress` | determinate progress toward a known max                          | `spinner`    |
+| `spinner`  | an indeterminate wait, announced to assistive tech               | `progress`   |
+| `skeleton` | loading placeholder blocks while content arrives                 | `spinner`    |
+| `stepper`  | where-you-are in a multi-step flow (display, not links)          | `progress`   |
+
+<%= embed UI::ProgressComponentPreview %>

--- a/lib/generators/modelrails_ui/lookbook/templates/previews/pages/choosing/04_data_display.md.erb
+++ b/lib/generators/modelrails_ui/lookbook/templates/previews/pages/choosing/04_data_display.md.erb
@@ -1,0 +1,47 @@
+---
+label: Data Display
+---
+
+# Choosing data display
+
+Pick by the shape of the data: grouped content, disclosed sections, people & messages,
+or ordered sequences and values.
+
+## Containers & rows
+
+| Component    | Reach for it when                                                     | Otherwise →                |
+|--------------|-------------------------------------------------------------------------|----------------------------|
+| `card`       | grouping related content on a bordered, raised surface                  | `list_group` / `data_table` |
+| `list_group` | a short set of related rows or links (a real `<ul>` of `<li>`)          | `data_table` / `timeline`  |
+| `data_table` | a bounded, already-loaded set of rows worth sorting/filtering client-side | server-side pages (Pagy) |
+
+<%= embed UI::CardComponentPreview %>
+
+## Disclosure
+
+| Component     | Reach for it when                                                   | Otherwise →   |
+|---------------|----------------------------------------------------------------------|---------------|
+| `accordion`   | a stack of independent `<details>` rows (FAQs, settings groups)       | `collapsible` |
+| `collapsible` | a single CSS-only disclosure behind your own trigger                  | `accordion`   |
+
+<%= embed UI::AccordionComponentPreview %>
+
+## People & messages
+
+| Component     | Reach for it when                                                          | Otherwise →   |
+|---------------|------------------------------------------------------------------------------|---------------|
+| `avatar`      | a non-user avatar or explicit photo/initials (for `User` records: `avatar_for`) | —          |
+| `chat_bubble` | one message in a chat or comment transcript (sent vs received)               | `list_group`  |
+
+<%= embed UI::ChatBubbleComponentPreview %>
+
+## Sequences & values
+
+| Component  | Reach for it when                                                            | Otherwise →                 |
+|------------|--------------------------------------------------------------------------------|-----------------------------|
+| `timeline` | dated, ordered events — activity feed, audit trail, release history            | `list_group`                |
+| `rating`   | displaying a fixed star score the user can't change                            | `rating_input` (user picks) |
+| `chart`    | plotting a small set of series on a canvas (pin Chart.js; describe the data)   | `data_table`                |
+| `kbd`      | an inline keyboard-key chip ("Press ⌘K")                                       | `badge`                     |
+
+<%= embed UI::TimelineComponentPreview %>

--- a/lib/generators/modelrails_ui/lookbook/templates/previews/pages/choosing/05_media.md.erb
+++ b/lib/generators/modelrails_ui/lookbook/templates/previews/pages/choosing/05_media.md.erb
@@ -1,0 +1,42 @@
+---
+label: Media
+---
+
+# Choosing media
+
+Three families: first-party images, playback surfaces, and third-party embeds with
+their framing helpers.
+
+## Images
+
+| Component | Reach for it when                                                      | Otherwise →           |
+|-----------|--------------------------------------------------------------------------|-----------------------|
+| `image`   | content imagery with a forced `alt` decision, lazy loading, `srcset`      | `picture`             |
+| `picture` | art direction or format fallbacks (AVIF/WebP → JPEG)                      | `image`               |
+| `figure`  | content that needs a visible caption                                      | `image`               |
+| `gallery` | an image grid with a lightbox (reuses the modal `<dialog>`)               | `image` / `carousel`  |
+| `qr_code` | a scannable payload — pre-rendered image or rqrcode output                | `image`               |
+
+<%= embed UI::ImageComponentPreview %>
+
+## Playback
+
+| Component  | Reach for it when                                                   | Otherwise →            |
+|------------|------------------------------------------------------------------------|------------------------|
+| `video`    | native video with `<source>` fallbacks and caption `<track>`s          | `embed` (third-party)  |
+| `audio`    | native audio with `<source>` fallbacks                                 | `video`                |
+| `carousel` | a slide deck with prev/next/dots and a pause control (APG)             | `gallery`              |
+
+<%= embed UI::CarouselComponentPreview %>
+
+## Embeds & framing
+
+| Component       | Reach for it when                                                  | Otherwise →  |
+|-----------------|----------------------------------------------------------------------|--------------|
+| `embed`         | third-party content by URL — the provider is auto-detected           | `iframe`     |
+| `iframe`        | a raw sandboxed, responsive frame for anything else                  | `embed`      |
+| `aspect_ratio`  | holding media to a fixed ratio regardless of width                   | —            |
+| `device_mockup` | a decorative phone/tablet/browser shell around a screenshot          | —            |
+| `map_area`      | a legacy image map (prefer overlaid links or SVG regions when you can) | —          |
+
+<%= embed UI::DeviceMockupComponentPreview %>

--- a/test/test_lookbook_choosing_pages.rb
+++ b/test/test_lookbook_choosing_pages.rb
@@ -1,0 +1,64 @@
+# frozen_string_literal: true
+
+require "test_helper"
+
+# The "choosing" decision pages must exist for every section with real sibling overlap,
+# route every sibling in their section, and embed only in the scenario-less form (a
+# `embed Klass, :leaf` resolves nil under the catalog-wide @!group grouping and 500s).
+class TestLookbookChoosingPages < Minitest::Test
+  GEN_ROOT = File.expand_path("../lib/generators/modelrails_ui/lookbook/templates", __dir__)
+  PAGES_ROOT = File.join(GEN_ROOT, "previews/pages")
+  PREVIEW_ROOT = File.join(GEN_ROOT, "previews/ui")
+
+  # Layout and Actions get no decision page by design (too little sibling overlap).
+  SECTION_BY_PAGE = {
+    "choosing/00_forms.md.erb" => "Forms & Inputs",
+    "choosing/01_overlays.md.erb" => "Overlays",
+    "choosing/02_navigation.md.erb" => "Navigation",
+    "choosing/03_feedback.md.erb" => "Feedback & Status",
+    "choosing/04_data_display.md.erb" => "Data Display",
+    "choosing/05_media.md.erb" => "Media"
+  }.freeze
+
+  def test_no_unmapped_choosing_pages
+    actual = Dir.glob(File.join(PAGES_ROOT, "choosing/*.md.erb")).map { |p| p.sub("#{PAGES_ROOT}/", "") }.sort
+
+    assert_equal SECTION_BY_PAGE.keys.sort, actual
+  end
+
+  def test_embeds_use_the_scenario_less_form
+    Dir.glob(File.join(PAGES_ROOT, "**/*.md.erb")).sort.each do |page|
+      offenders = File.read(page).scan(/embed\s+UI::\w+ComponentPreview\s*,\s*:\w+/)
+
+      assert_empty offenders, "#{page}: use the scenario-less embed form"
+    end
+  end
+
+  def test_every_embed_target_exists
+    Dir.glob(File.join(PAGES_ROOT, "choosing/*.md.erb")).sort.each do |page|
+      File.read(page).scan(/embed\s+UI::(\w+)ComponentPreview\b/).flatten.each do |klass|
+        file = File.join(PREVIEW_ROOT, "#{klass.gsub(/([a-z])([A-Z])/, '\1_\2').downcase}_component_preview.rb")
+
+        assert_path_exists file, "#{page} embeds missing preview #{klass}"
+      end
+    end
+  end
+
+  def test_every_section_sibling_is_routed
+    SECTION_BY_PAGE.each do |rel, section|
+      page = File.join(PAGES_ROOT, rel)
+
+      assert_path_exists page
+      source = File.read(page)
+      siblings = Dir.glob(File.join(PREVIEW_ROOT, "*_component_preview.rb")).select do |path|
+        File.read(path).match?(/^\s*#\s*@logical_path\s+#{Regexp.escape(section)}\s*$/)
+      end.map { |path| File.basename(path, "_component_preview.rb") }.sort
+
+      refute_empty siblings, "#{section}: no previews carry this @logical_path"
+      # Backtick-delimited match so `dialog` is not falsely covered by `alert_dialog`.
+      missing = siblings.reject { |name| source.match?(/`#{Regexp.escape(name)}`/) }
+
+      assert_empty missing, "#{rel} is missing: #{missing.join(", ")}"
+    end
+  end
+end

--- a/test/test_lookbook_overview_page.rb
+++ b/test/test_lookbook_overview_page.rb
@@ -33,14 +33,21 @@ class TestLookbookOverviewPage < Minitest::Test
   end
 
   def test_every_embed_target_exists
-    embeds = page_src.scan(/embed\s+UI::(\w+)ComponentPreview,\s*:(\w+)/)
+    # Scenario-less embeds only: the catalog-wide @!group grouping nests leaf scenarios
+    # inside groups, so `embed Klass, :leaf` resolves nil at runtime (Lookbook looks up
+    # top-level scenario names, which are now the group names) and 500s the page.
+    offenders = page_src.scan(/embed\s+UI::\w+ComponentPreview\s*,\s*:\w+/)
+
+    assert_empty offenders, "use the scenario-less embed form: #{offenders.join(", ")}"
+
+    embeds = page_src.scan(/embed\s+UI::(\w+)ComponentPreview\b/).flatten
 
     assert_operator embeds.size, :>=, 3, "page should embed at least 3 live hero scenarios"
-    embeds.each do |klass, scenario|
+    embeds.each do |klass|
       file = File.join(PREVIEW_ROOT, "#{klass.gsub(/([a-z])([A-Z])/, '\1_\2').downcase}_component_preview.rb")
 
       assert_path_exists file, "embed references missing preview #{klass}"
-      assert_match(/def #{scenario}\b/, File.read(file), "embed references missing scenario :#{scenario} on #{klass}")
+      assert_match(/^\s+def [a-z_]/, File.read(file), "#{klass} has no scenarios to embed")
     end
   end
 


### PR DESCRIPTION
## What

- Carries the six **choosing decision pages** (authored + proven in the host app) into the Lookbook generator templates under `previews/pages/choosing/` — the generator's recursive `directory "previews"` copy picks them up, so a fresh `rails g modelrails_ui:lookbook` now scaffolds the full teaching catalog.
- Adds the two **gem-only rows**: `wysiwyg` (Forms & Inputs › Free text) and `toaster` (Feedback & Status › Messages), sourced from their preview doc-comments. Each repo's guard derives sibling sets from its own previews (semantic parity).
- **Fixes the Overview template's broken embeds**: `embed Klass, :scenario` resolves nil under the catalog-wide `@!group` grouping (leaf scenarios are nested inside groups) and 500s the landing page of every freshly generated app. Now scenario-less.
- Updates `test_lookbook_overview_page.rb#test_every_embed_target_exists` for the scenario-less form (it would otherwise fail), and adds `test_lookbook_choosing_pages.rb`: no-strays allowlist, scenario-less-embed rule over all pages, embed-target existence, and per-section sibling routing with backtick-delimited matching.

## Verification

`bundle exec rake` (CI form): 870 runs, 0 failures, 0 errors; RuboCop 200 files, no offenses. TDD: the new guard was red first (it caught the Overview leaf-embeds before the fix).

## Notes

- The app guard additionally enforces "≥ 3 embeds per choosing page"; the gem guard intentionally stays lighter (file-level invariants) — noted divergence, not an oversight.
- Pre-existing on `modelrails/harden`: bare `rake` crashes on a standard↔rubocop version conflict; `bundle exec rake` (what CI runs) is clean. Untouched here.
- App twin PR: dschmura/modelrails_base#286.