### PR TITLE
feat(lookbook): form-control playgrounds, Related cross-links, nav-band doc contracts (Tier 3 Cycle 2)

### DIFF
--- a/lib/generators/modelrails_ui/lookbook/templates/previews/ui/alert_dialog_component_preview.rb
+++ b/lib/generators/modelrails_ui/lookbook/templates/previews/ui/alert_dialog_component_preview.rb
@@ -28,6 +28,9 @@ module UI
   #   via the `modal` Stimulus controller.
   # - **You supply:** a `title:` (required — the accessible name) and footer action
   #   buttons in the `with_footer` slot. The `with_trigger` slot provides the open button.
+  #
+  # ## Related
+  # `dialog`
   # @logical_path Overlays
   class AlertDialogComponentPreview < ViewComponent::Preview
     include UIHelper

--- a/lib/generators/modelrails_ui/lookbook/templates/previews/ui/breadcrumb_component_preview.rb
+++ b/lib/generators/modelrails_ui/lookbook/templates/previews/ui/breadcrumb_component_preview.rb
@@ -4,6 +4,18 @@ module UI
   # # Breadcrumb
   #
   # A breadcrumb trail. The last item is the current page (aria-current=page, not a link).
+  #
+  # ## Use when
+  # - Showing where the current page sits in a hierarchy, with links back up the trail.
+  #
+  # ## Don't use when
+  # - You're switching between in-page panels — use `tabs`.
+  # - It's the site's primary navigation — use `navbar`.
+  #
+  # ## Accessibility contract
+  # - **Guarantees:** a named `<nav>` landmark wrapping an ordered list; the last item
+  #   is the current page — `aria-current="page"`, rendered as text, not a link.
+  # - **You supply:** the trail items (label + href); the final item's label.
   # @logical_path Navigation
   class BreadcrumbComponentPreview < ViewComponent::Preview
     include UIHelper

--- a/lib/generators/modelrails_ui/lookbook/templates/previews/ui/calendar_component_preview.rb
+++ b/lib/generators/modelrails_ui/lookbook/templates/previews/ui/calendar_component_preview.rb
@@ -16,6 +16,9 @@ module UI
   #   tabindex) with arrow-key navigation; i18n-labelled prev/next buttons; and
   #   the AAA offset `focus-ring` on every control.
   # - **You supply:** `selected:`/`month:` Dates and optional `min:`/`max:` bounds.
+  #
+  # ## Related
+  # `date_picker`
   # @logical_path Forms & Inputs
   class CalendarComponentPreview < ViewComponent::Preview
     include UIHelper

--- a/lib/generators/modelrails_ui/lookbook/templates/previews/ui/card_component_preview.rb
+++ b/lib/generators/modelrails_ui/lookbook/templates/previews/ui/card_component_preview.rb
@@ -22,6 +22,9 @@ module UI
   #   is non-interactive and adds no ARIA role.
   # - **You supply:** the heading via `card_title` (set `level:` so it sits correctly
   #   in the page outline) and any focusable controls inside the regions.
+  #
+  # ## Related
+  # `list_group` · `avatar` · `badge`
   # @logical_path Data Display
   class CardComponentPreview < ViewComponent::Preview
     include UIHelper

--- a/lib/generators/modelrails_ui/lookbook/templates/previews/ui/checkbox_component_preview.rb
+++ b/lib/generators/modelrails_ui/lookbook/templates/previews/ui/checkbox_component_preview.rb
@@ -17,6 +17,9 @@ module UI
   # - **Guarantees:** a labelled, keyboard-operable checkbox with an AAA focus ring;
   #   the clickable label provides the larger AAA target.
   # - **You supply:** a `label` and, on error, `invalid: true` + `describedby:`.
+  #
+  # ## Related
+  # `switch` · `radio_group` · `toggle`
   # @logical_path Forms & Inputs
   class CheckboxComponentPreview < ViewComponent::Preview
     include UIHelper
@@ -42,6 +45,16 @@ module UI
     # @!endgroup
 
     # @!group Reference
+
+    # Flip the states and watch `checked` / `aria-invalid` / `disabled` rewire live.
+    # @param label text
+    # @param checked toggle
+    # @param invalid toggle
+    # @param disabled toggle
+    def playground(label: "Accept the terms", checked: false, invalid: false, disabled: false)
+      ui :checkbox, label: label, name: "pg_terms", checked: checked,
+        invalid: invalid, disabled: disabled
+    end
 
     # ## Don't — an unlabelled checkbox
     #

--- a/lib/generators/modelrails_ui/lookbook/templates/previews/ui/combobox_component_preview.rb
+++ b/lib/generators/modelrails_ui/lookbook/templates/previews/ui/combobox_component_preview.rb
@@ -31,6 +31,9 @@ module UI
   #
   # ## Sizes
   # `sm` · `md` · `lg` — the input height.
+  #
+  # ## Related
+  # `select` · `command`
   # @logical_path Forms & Inputs
   class ComboboxComponentPreview < ViewComponent::Preview
     include UIHelper

--- a/lib/generators/modelrails_ui/lookbook/templates/previews/ui/context_menu_component_preview.rb
+++ b/lib/generators/modelrails_ui/lookbook/templates/previews/ui/context_menu_component_preview.rb
@@ -12,6 +12,9 @@ module UI
   #   `contextmenu` + Shift+F10 open; `role="menu"` named by the host; `role="menuitem"`
   #   items with roving tabindex.
   # - **You supply:** a `with_trigger` host slot and `with_item` slots.
+  #
+  # ## Related
+  # `dropdown_menu` · `menubar`
   # @logical_path Overlays
   class ContextMenuComponentPreview < ViewComponent::Preview
     include UIHelper

--- a/lib/generators/modelrails_ui/lookbook/templates/previews/ui/date_picker_component_preview.rb
+++ b/lib/generators/modelrails_ui/lookbook/templates/previews/ui/date_picker_component_preview.rb
@@ -17,6 +17,9 @@ module UI
   #   decorative calendar icon is `aria-hidden`.
   # - **You supply:** an optional `label:` (caption + accessible name), `name:` (to post
   #   back), and `format:` (the display + hint pattern).
+  #
+  # ## Related
+  # `calendar` · `timepicker`
   # @logical_path Forms & Inputs
   class DatePickerComponentPreview < ViewComponent::Preview
     include UIHelper

--- a/lib/generators/modelrails_ui/lookbook/templates/previews/ui/dialog_component_preview.rb
+++ b/lib/generators/modelrails_ui/lookbook/templates/previews/ui/dialog_component_preview.rb
@@ -32,6 +32,9 @@ module UI
   #   When using `wrapper: true` (the default), the `with_trigger` slot provides the
   #   open button; `wrapper: false` requires you to supply `data-controller="modal"` on
   #   a parent element and wire your own trigger.
+  #
+  # ## Related
+  # `alert_dialog` · `drawer` · `sheet`
   # @logical_path Overlays
   class DialogComponentPreview < ViewComponent::Preview
     include UIHelper

--- a/lib/generators/modelrails_ui/lookbook/templates/previews/ui/drawer_component_preview.rb
+++ b/lib/generators/modelrails_ui/lookbook/templates/previews/ui/drawer_component_preview.rb
@@ -23,6 +23,9 @@ module UI
   #   controller, and native Escape via the controller's cancel handler.
   # - **You supply:** a `title:` (required — the accessible name). Actions belong in
   #   the `with_footer` slot. The `with_trigger` slot provides the open button.
+  #
+  # ## Related
+  # `sheet` · `dialog`
   # @logical_path Overlays
   class DrawerComponentPreview < ViewComponent::Preview
     include UIHelper

--- a/lib/generators/modelrails_ui/lookbook/templates/previews/ui/dropdown_menu_component_preview.rb
+++ b/lib/generators/modelrails_ui/lookbook/templates/previews/ui/dropdown_menu_component_preview.rb
@@ -12,6 +12,9 @@ module UI
   #   named by the trigger; `role="menuitem"` items with roving tabindex.
   # - **You supply:** a `with_trigger` slot and `with_item` slots; `aria_label:` for
   #   icon-only triggers.
+  #
+  # ## Related
+  # `context_menu` · `menubar`
   # @logical_path Overlays
   class DropdownMenuComponentPreview < ViewComponent::Preview
     include UIHelper

--- a/lib/generators/modelrails_ui/lookbook/templates/previews/ui/form_field_component_preview.rb
+++ b/lib/generators/modelrails_ui/lookbook/templates/previews/ui/form_field_component_preview.rb
@@ -17,15 +17,20 @@ module UI
   #   ids, and `input_attrs` carrying id + describedby + invalid + required. The
   #   required `*` is a decorative aria-hidden mark on the label.
   # - **You supply:** the control inside the block, spread with `**f.input_attrs`.
+  #
+  # ## Related
+  # `input` · `label` · `textarea` · `select` · `checkbox` · `radio_group`
   # @logical_path Forms & Inputs
   class FormFieldComponentPreview < ViewComponent::Preview
     include UIHelper
+
+    # @!group Examples
 
     # Label + control, no hint or error.
     def default
     end
 
-    # A hint paragraph (id #{id}-hint) referenced by the control's aria-describedby.
+    # A hint paragraph (id `{id}-hint`) referenced by the control's aria-describedby.
     def with_hint
     end
 
@@ -37,5 +42,23 @@ module UI
     # A required field — decorative `*` on the label; the control carries `required`.
     def required
     end
+
+    # @!endgroup
+
+    # @!group Reference
+
+    # The teaching playground: flip `required`, set/clear `hint` and `error`, and watch
+    # the ARIA rewire — hint/error get real ids referenced by the control's
+    # `aria-describedby`; an error also sets `aria-invalid`; required adds the
+    # decorative `*` and the control's `required`.
+    # @param label text
+    # @param hint text
+    # @param error text
+    # @param required toggle
+    def playground(label: "Email", hint: "We'll never share it.", error: "", required: false)
+      render_with_template(locals: {label: label, hint: hint, error: error, required: required})
+    end
+
+    # @!endgroup
   end
 end

--- a/lib/generators/modelrails_ui/lookbook/templates/previews/ui/form_field_component_preview/playground.html.erb
+++ b/lib/generators/modelrails_ui/lookbook/templates/previews/ui/form_field_component_preview/playground.html.erb
@@ -1,0 +1,8 @@
+<%# Template-backed: inline preview methods drop block-yielded slot content, so the
+    control would silently vanish — render through ERB like the other scenarios. %>
+<div id="field-scope" class="max-w-md">
+  <%= ui :form_field, label: label, hint: hint.presence, error: error.presence,
+        required: required, id: "pg_email" do |f| %>
+    <%= ui :input, type: "email", name: "email", **f.input_attrs %>
+  <% end %>
+</div>

--- a/lib/generators/modelrails_ui/lookbook/templates/previews/ui/gallery_component_preview.rb
+++ b/lib/generators/modelrails_ui/lookbook/templates/previews/ui/gallery_component_preview.rb
@@ -13,6 +13,9 @@ module UI
   #   accessible name ("Enlarge %{alt}") and the `focus-ring` utility; the lightbox
   #   is a native focus-trapped `<dialog>` with an accessible close button.
   # - **You supply:** a non-blank `alt:` per image when lightbox is on (fail-loud).
+  #
+  # ## Related
+  # `dialog` · `image` · `carousel`
   # @logical_path Media
   class GalleryComponentPreview < ViewComponent::Preview
     include UIHelper

--- a/lib/generators/modelrails_ui/lookbook/templates/previews/ui/hover_card_component_preview.rb
+++ b/lib/generators/modelrails_ui/lookbook/templates/previews/ui/hover_card_component_preview.rb
@@ -11,6 +11,9 @@ module UI
   # - **Guarantees:** hover + focus-within reveal; card content Tab-reachable while open;
   #   Escape-dismiss; `role="group"` + `aria-label` when `label:` given.
   # - **You supply:** a `with_trigger` slot (a focusable link/button) and card content.
+  #
+  # ## Related
+  # `popover` · `tooltip`
   # @logical_path Overlays
   class HoverCardComponentPreview < ViewComponent::Preview
     include UIHelper

--- a/lib/generators/modelrails_ui/lookbook/templates/previews/ui/input_component_preview.rb
+++ b/lib/generators/modelrails_ui/lookbook/templates/previews/ui/input_component_preview.rb
@@ -27,6 +27,9 @@ module UI
   #   `aria-describedby` wired when `describedby:` is supplied.
   # - **You supply (when standalone):** a visible `<label>` associated via `for:/id:`,
   #   and a `name:` attribute. The form builder supplies both automatically.
+  #
+  # ## Related
+  # `form_field` · `label` · `textarea` · `search_input` · `floating_label`
   # @logical_path Forms & Inputs
   class InputComponentPreview < ViewComponent::Preview
     include UIHelper
@@ -49,6 +52,17 @@ module UI
     # @!endgroup
 
     # @!group Reference
+
+    # Flip `required` / `invalid` / `disabled` and watch the attributes rewire
+    # (`required`, `aria-invalid`) live.
+    # @param placeholder text
+    # @param required toggle
+    # @param invalid toggle
+    # @param disabled toggle
+    def playground(placeholder: "you@example.com", required: false, invalid: false, disabled: false)
+      ui :input, type: "email", name: "pg_email", placeholder: placeholder,
+        required: required, invalid: invalid, disabled: disabled
+    end
 
     # ## Don't — hand-rolled `<input>` tag
     #

--- a/lib/generators/modelrails_ui/lookbook/templates/previews/ui/label_component_preview.rb
+++ b/lib/generators/modelrails_ui/lookbook/templates/previews/ui/label_component_preview.rb
@@ -19,6 +19,9 @@ module UI
   #   `required:` `*` is decorative (aria-hidden) — the requirement lives on the
   #   input, never the caption.
   # - **You supply:** the caption text and, to bind it, the control's `id` via `for:`.
+  #
+  # ## Related
+  # `form_field` · `input` · `select`
   # @logical_path Forms & Inputs
   class LabelComponentPreview < ViewComponent::Preview
     include UIHelper

--- a/lib/generators/modelrails_ui/lookbook/templates/previews/ui/menubar_component_preview.rb
+++ b/lib/generators/modelrails_ui/lookbook/templates/previews/ui/menubar_component_preview.rb
@@ -5,6 +5,22 @@ module UI
   #
   # An app menubar (WAI-ARIA APG). Tab to it (one stop), ←/→ between items, ↓/Enter to open a
   # submenu, ↑/↓ within, Escape to close. Submenus reuse the shared `menu` controller.
+  #
+  # ## Use when
+  # - A persistent application menu bar (File / Edit / View) exposing grouped commands.
+  #
+  # ## Don't use when
+  # - Actions launch from a single button — use `dropdown_menu`.
+  # - Actions open from right-click on a region — use `context_menu`.
+  #
+  # ## Accessibility contract
+  # - **Guarantees:** WAI-ARIA APG menubar — one Tab stop, roving tabindex, ←/→ moves
+  #   between top-level items (following an open submenu), ↓/Enter opens a submenu
+  #   (the shared `menu` controller: ↑/↓, type-ahead, Escape closes and restores focus).
+  # - **You supply:** `label:` (required — the bar's accessible name) and the items.
+  #
+  # ## Related
+  # `dropdown_menu` · `context_menu`
   # @logical_path Overlays
   class MenubarComponentPreview < ViewComponent::Preview
     include UIHelper

--- a/lib/generators/modelrails_ui/lookbook/templates/previews/ui/navbar_component_preview.rb
+++ b/lib/generators/modelrails_ui/lookbook/templates/previews/ui/navbar_component_preview.rb
@@ -6,6 +6,19 @@ module UI
   # A responsive nav. On a narrow viewport the links collapse behind a hamburger that discloses
   # a stacked menu (aria-expanded/controls + Escape + outside-click). Resize the Lookbook frame
   # narrow to see the mobile disclosure.
+  #
+  # ## Use when
+  # - The site's primary top navigation, responsive out of the box.
+  #
+  # ## Don't use when
+  # - You need a collapsible application rail — use `sidebar`.
+  # - The links belong at the bottom on mobile — use `bottom_nav`.
+  #
+  # ## Accessibility contract
+  # - **Guarantees:** a named `<nav>` landmark; on narrow viewports the links collapse
+  #   behind a hamburger disclosure (`aria-expanded`/`aria-controls`, Escape and
+  #   outside-click close, focus returns to the trigger).
+  # - **You supply:** the brand slot and the link items.
   # @logical_path Navigation
   class NavbarComponentPreview < ViewComponent::Preview
     include UIHelper

--- a/lib/generators/modelrails_ui/lookbook/templates/previews/ui/popover_component_preview.rb
+++ b/lib/generators/modelrails_ui/lookbook/templates/previews/ui/popover_component_preview.rb
@@ -12,6 +12,9 @@ module UI
   #   `aria-expanded`, and `aria-controls`; a `role="dialog"` panel named by `label:`.
   #   Non-modal — focus is not trapped.
   # - **You supply:** `label:` (the panel's accessible name) and a `with_trigger` slot.
+  #
+  # ## Related
+  # `tooltip` · `hover_card`
   # @logical_path Overlays
   class PopoverComponentPreview < ViewComponent::Preview
     include UIHelper

--- a/lib/generators/modelrails_ui/lookbook/templates/previews/ui/radio_group_component_preview.rb
+++ b/lib/generators/modelrails_ui/lookbook/templates/previews/ui/radio_group_component_preview.rb
@@ -21,6 +21,9 @@ module UI
   # - **You supply:** a group `label:` (or `labelledby:`), `items:` as
   #   `[{ value:, label:, checked?:, disabled?: }]`, and on error `invalid:` +
   #   `describedby:`.
+  #
+  # ## Related
+  # `select` · `checkbox`
   # @logical_path Forms & Inputs
   class RadioGroupComponentPreview < ViewComponent::Preview
     include UIHelper
@@ -43,6 +46,14 @@ module UI
     # @!endgroup
 
     # @!group Reference
+
+    # Flip `invalid` and watch the group's `aria-invalid` rewire live.
+    # @param label text
+    # @param invalid toggle
+    def playground(label: "Billing plan", invalid: false)
+      ui :radio_group, name: "pg_plan", label: label, invalid: invalid,
+        items: [{value: "free", label: "Free"}, {value: "pro", label: "Pro"}]
+    end
 
     # ## Don't — a radiogroup with no accessible name
     #

--- a/lib/generators/modelrails_ui/lookbook/templates/previews/ui/range_component_preview.rb
+++ b/lib/generators/modelrails_ui/lookbook/templates/previews/ui/range_component_preview.rb
@@ -33,6 +33,8 @@ module UI
   class RangeComponentPreview < ViewComponent::Preview
     include UIHelper
 
+    # @!group Examples
+
     # A native slider with a sibling label — the baseline appearance.
     def default
     end
@@ -55,5 +57,24 @@ module UI
     # Disabled control — passed straight through via `**html_attrs`.
     def disabled
     end
+
+    # @!endgroup
+
+    # @!group Reference
+
+    # Drag the value and flip `show_value` / `invalid` / `disabled`; the `<output>`
+    # readout and `aria-invalid` rewire live. (The slider's accessible name comes from
+    # `aria-label` here — real callers supply an external `<label for>`.)
+    # @param value select [0, 25, 50, 75, 100]
+    # @param show_value toggle
+    # @param invalid toggle
+    # @param disabled toggle
+    def playground(value: 50, show_value: true, invalid: false, disabled: false)
+      ui :range, id: "pg_volume", name: "pg_volume", min: 0, max: 100, step: 1,
+        value: value.to_i, show_value: show_value, invalid: invalid,
+        disabled: disabled, "aria-label": "Volume"
+    end
+
+    # @!endgroup
   end
 end

--- a/lib/generators/modelrails_ui/lookbook/templates/previews/ui/rating_component_preview.rb
+++ b/lib/generators/modelrails_ui/lookbook/templates/previews/ui/rating_component_preview.rb
@@ -21,6 +21,9 @@ module UI
   #   `aria-hidden` star glyphs, and filled stars on the AAA-tuned semantic
   #   `text-warning-icon` token (3:1 graphic contrast, WCAG 1.4.11).
   # - **You supply:** the `value:` to display and the `max:` star count.
+  #
+  # ## Related
+  # `rating_input`
   # @logical_path Data Display
   class RatingComponentPreview < ViewComponent::Preview
     include UIHelper

--- a/lib/generators/modelrails_ui/lookbook/templates/previews/ui/rating_input_component_preview.rb
+++ b/lib/generators/modelrails_ui/lookbook/templates/previews/ui/rating_input_component_preview.rb
@@ -22,6 +22,9 @@ module UI
   #   contrast, WCAG 1.4.11), and a hidden input carrying the value in a form.
   # - **You supply:** an optional group `label:`, the initial `value:`, `max:`, and
   #   either `name:` (form post) or `url:` (direct submit).
+  #
+  # ## Related
+  # `rating`
   # @logical_path Forms & Inputs
   class RatingInputComponentPreview < ViewComponent::Preview
     include UIHelper

--- a/lib/generators/modelrails_ui/lookbook/templates/previews/ui/select_component_preview.rb
+++ b/lib/generators/modelrails_ui/lookbook/templates/previews/ui/select_component_preview.rb
@@ -19,6 +19,9 @@ module UI
   #   `describedby:` is supplied.
   # - **You supply:** the visible label as an external `<label for="<id>">` — unlike
   #   checkbox, this component does NOT bundle a label.
+  #
+  # ## Related
+  # `combobox` · `radio_group` · `label`
   # @logical_path Forms & Inputs
   class SelectComponentPreview < ViewComponent::Preview
     include UIHelper

--- a/lib/generators/modelrails_ui/lookbook/templates/previews/ui/sheet_component_preview.rb
+++ b/lib/generators/modelrails_ui/lookbook/templates/previews/ui/sheet_component_preview.rb
@@ -24,6 +24,9 @@ module UI
   # - **You supply:** a `title:` (required — the accessible name). Actions belong in
   #   the `with_footer` slot. The `with_trigger` slot provides the open button. Pass
   #   `side:` to choose which edge the panel slides in from (`:right` default).
+  #
+  # ## Related
+  # `drawer` · `dialog`
   # @logical_path Overlays
   class SheetComponentPreview < ViewComponent::Preview
     include UIHelper

--- a/lib/generators/modelrails_ui/lookbook/templates/previews/ui/switch_component_preview.rb
+++ b/lib/generators/modelrails_ui/lookbook/templates/previews/ui/switch_component_preview.rb
@@ -19,6 +19,9 @@ module UI
   #   and a >=44px clickable target (AAA 2.5.5) even though the visual track is smaller.
   # - **You supply:** an accessible name (`label:` or `aria-label:`), the initial
   #   `checked:` state, and a `name:` so the value posts.
+  #
+  # ## Related
+  # `checkbox` · `toggle`
   # @logical_path Forms & Inputs
   class SwitchComponentPreview < ViewComponent::Preview
     include UIHelper

--- a/lib/generators/modelrails_ui/lookbook/templates/previews/ui/tabs_component_preview.rb
+++ b/lib/generators/modelrails_ui/lookbook/templates/previews/ui/tabs_component_preview.rb
@@ -5,6 +5,19 @@ module UI
   #
   # APG tabs (automatic activation). Tab to the active tab, ←/→ to move + reveal panels,
   # Home/End to jump; the disabled tab is skipped. Tab again to enter the active panel.
+  #
+  # ## Use when
+  # - Switching between a few in-page panels where one is visible at a time.
+  #
+  # ## Don't use when
+  # - The destinations are different pages — use `navbar` or plain links.
+  # - You need a hierarchy trail — use `breadcrumb`.
+  #
+  # ## Accessibility contract
+  # - **Guarantees:** APG tabs with automatic activation — `role="tablist"/"tab"/"tabpanel"`
+  #   wiring, roving tabindex (one Tab stop), ←/→ moves + reveals, Home/End jumps,
+  #   disabled tabs are skipped, `aria-selected` stays in sync.
+  # - **You supply:** tab labels and panel content.
   # @logical_path Navigation
   class TabsComponentPreview < ViewComponent::Preview
     include UIHelper

--- a/lib/generators/modelrails_ui/lookbook/templates/previews/ui/textarea_component_preview.rb
+++ b/lib/generators/modelrails_ui/lookbook/templates/previews/ui/textarea_component_preview.rb
@@ -26,6 +26,9 @@ module UI
   #   `aria-describedby` wired when `describedby:` is supplied.
   # - **You supply (when standalone):** a visible `<label>` associated via `for:/id:`,
   #   and a `name:` attribute. The form builder supplies both automatically.
+  #
+  # ## Related
+  # `form_field` · `input`
   # @logical_path Forms & Inputs
   class TextareaComponentPreview < ViewComponent::Preview
     include UIHelper

--- a/lib/generators/modelrails_ui/lookbook/templates/previews/ui/timepicker_component_preview.rb
+++ b/lib/generators/modelrails_ui/lookbook/templates/previews/ui/timepicker_component_preview.rb
@@ -18,6 +18,9 @@ module UI
   # - **You supply:** an optional `label:` (accessible name), `name:` (to post back),
   #   and `format:` (`:h24` | `:h12`, drives the hour range + the hint; fails loud on an
   #   unknown key).
+  #
+  # ## Related
+  # `date_picker`
   # @logical_path Forms & Inputs
   class TimepickerComponentPreview < ViewComponent::Preview
     include UIHelper

--- a/lib/generators/modelrails_ui/lookbook/templates/previews/ui/toggle_component_preview.rb
+++ b/lib/generators/modelrails_ui/lookbook/templates/previews/ui/toggle_component_preview.rb
@@ -21,6 +21,9 @@ module UI
   #
   # ## Sizes
   # `default` · `sm` · `lg` — all >=44px tall.
+  #
+  # ## Related
+  # `switch` · `checkbox` · `toggle_group`
   # @logical_path Forms & Inputs
   class ToggleComponentPreview < ViewComponent::Preview
     include UIHelper

--- a/lib/generators/modelrails_ui/lookbook/templates/previews/ui/toggle_group_component_preview.rb
+++ b/lib/generators/modelrails_ui/lookbook/templates/previews/ui/toggle_group_component_preview.rb
@@ -19,6 +19,9 @@ module UI
   #
   # ## Modes
   # Single-select (`type: :single`) · multi-select (`type: :multiple`).
+  #
+  # ## Related
+  # `toggle`
   # @logical_path Forms & Inputs
   class ToggleGroupComponentPreview < ViewComponent::Preview
     include UIHelper

--- a/lib/generators/modelrails_ui/lookbook/templates/previews/ui/tooltip_component_preview.rb
+++ b/lib/generators/modelrails_ui/lookbook/templates/previews/ui/tooltip_component_preview.rb
@@ -11,6 +11,9 @@ module UI
   # - **Guarantees:** hover + focus reveal; `role="tooltip"` + `aria-describedby`;
   #   Escape-dismiss; `pointer-events-none` bubble.
   # - **You supply:** `text:` (the hint) and the trigger content.
+  #
+  # ## Related
+  # `popover` · `hover_card`
   # @logical_path Overlays
   class TooltipComponentPreview < ViewComponent::Preview
     include UIHelper

--- a/test/test_lookbook_related_links.rb
+++ b/test/test_lookbook_related_links.rb
@@ -1,0 +1,36 @@
+# frozen_string_literal: true
+
+require "test_helper"
+
+# `## Related` doc-comment sections encode the sibling-relationship graph. Every
+# backticked name inside one must be a real component preview — typo/drift protection,
+# same static-analysis idiom as the other lookbook guards.
+class TestLookbookRelatedLinks < Minitest::Test
+  PREVIEW_ROOT = File.expand_path(
+    "../lib/generators/modelrails_ui/lookbook/templates/previews/ui", __dir__
+  )
+
+  def test_every_related_target_is_a_real_component
+    names = Dir.glob(File.join(PREVIEW_ROOT, "*_component_preview.rb"))
+      .map { |p| File.basename(p, "_component_preview.rb") }
+    found_any = false
+
+    Dir.glob(File.join(PREVIEW_ROOT, "*_component_preview.rb")).sort.each do |path|
+      component = File.basename(path, "_component_preview.rb")
+      lines = File.read(path).lines
+      idx = lines.index { |l| l.match?(/^\s*#\s*## Related\s*$/) }
+      next unless idx
+
+      found_any = true
+      block = lines[(idx + 1)..].take_while { |l| l.match?(/^\s*#/) && !l.match?(/^\s*#\s*(##|@)/) }.join
+      targets = block.scan(/`([a-z_]+)`/).flatten.uniq
+
+      refute_empty targets, "#{component}: empty ## Related section"
+      missing = targets - names
+
+      assert_empty missing, "#{component}: Related references unknown component(s): #{missing.join(", ")}"
+    end
+
+    assert found_any, "no ## Related sections found — the cross-link graph is missing"
+  end
+end


### PR DESCRIPTION
## What

Gem twin of dschmura/modelrails_base#287-or-pair (see app PR): the identical preview enrichment applied to the generator templates so fresh apps scaffold it.

- 5 form-control playgrounds (`form_field` template-backed: inline preview methods drop block-yielded slot content — the control silently vanished; `render_with_template(locals:)` is the reliable form).
- 28 `## Related` cross-link blocks (the sibling-relationship graph) + `test_lookbook_related_links.rb` guard (every backticked target must be a real preview).
- Doc contracts on breadcrumb / tabs / navbar / menubar — claims verified against component source (no corrections needed).

## Verification

`bundle exec rake`: 870 runs / 0 failures; RuboCop 200 files / 0 offenses. Grouping guard validates the new Examples/Reference structures (playground before dont_*).

Note: bare `rake` still crashes on the pre-existing standard↔rubocop conflict on `modelrails/harden`; `bundle exec rake` (the CI form) is clean — untouched here.