### PR TITLE
feat(lookbook): per-preview backgrounds — sunken containers, full-bleed chrome (Tier 3 Cycle 3)

### DIFF
--- a/lib/generators/modelrails_ui/lookbook/templates/component_preview.html.erb
+++ b/lib/generators/modelrails_ui/lookbook/templates/component_preview.html.erb
@@ -8,7 +8,15 @@
     <%= stylesheet_link_tag :app, "data-turbo-track": "reload" %>
     <%= javascript_importmap_tags %>
   </head>
-  <body class="bg-surface-raised text-text-body p-6">
+  <%# Background is driven by a per-preview `@display background <value>` tag (space-separated — a colon makes the parser read `background:` as the key and the option silently never applies) (sunken ·
+      surface · bleed); default is the raised host surface. Raised containers (card,
+      data_table) opt into `sunken` so their edges are visible; page chrome (navbar,
+      footer, …) opts into `bleed` for edge-to-edge rendering. %>
+  <body class="<%= {
+        "sunken" => "bg-surface-sunken p-6",
+        "surface" => "bg-surface p-6",
+        "bleed" => "bg-surface p-0"
+      }.fetch(params.dig(:lookbook, :display, :background), "bg-surface-raised p-6") %> text-text-body">
     <%= yield %>
   </body>
 </html>

--- a/lib/generators/modelrails_ui/lookbook/templates/previews/ui/banner_component_preview.rb
+++ b/lib/generators/modelrails_ui/lookbook/templates/previews/ui/banner_component_preview.rb
@@ -24,6 +24,7 @@ module UI
   #
   # ## Variants
   # `default` · `info` · `success` · `warning` · `destructive`
+  # @display background bleed
   # @logical_path Feedback & Status
   class BannerComponentPreview < ViewComponent::Preview
     include UIHelper

--- a/lib/generators/modelrails_ui/lookbook/templates/previews/ui/bottom_nav_component_preview.rb
+++ b/lib/generators/modelrails_ui/lookbook/templates/previews/ui/bottom_nav_component_preview.rb
@@ -11,6 +11,7 @@ module UI
   #   override via `label:`), the AAA `focus-ring` on every item, and
   #   `aria-current="page"` on the active item.
   # - **You supply:** `items:` (`[{ label:, href:, active:, icon: }]`).
+  # @display background bleed
   # @logical_path Navigation
   class BottomNavComponentPreview < ViewComponent::Preview
     include UIHelper

--- a/lib/generators/modelrails_ui/lookbook/templates/previews/ui/card_component_preview.rb
+++ b/lib/generators/modelrails_ui/lookbook/templates/previews/ui/card_component_preview.rb
@@ -25,6 +25,7 @@ module UI
   #
   # ## Related
   # `list_group` · `avatar` · `badge`
+  # @display background sunken
   # @logical_path Data Display
   class CardComponentPreview < ViewComponent::Preview
     include UIHelper

--- a/lib/generators/modelrails_ui/lookbook/templates/previews/ui/data_table_component_preview.rb
+++ b/lib/generators/modelrails_ui/lookbook/templates/previews/ui/data_table_component_preview.rb
@@ -22,6 +22,7 @@ module UI
   #   targets on every control, and fully localized strings.
   # - **You supply:** a `caption:` — the table's accessible name. Pass one whenever
   #   practical so screen-reader users get context.
+  # @display background sunken
   # @logical_path Data Display
   class DataTableComponentPreview < ViewComponent::Preview
     include UIHelper

--- a/lib/generators/modelrails_ui/lookbook/templates/previews/ui/footer_component_preview.rb
+++ b/lib/generators/modelrails_ui/lookbook/templates/previews/ui/footer_component_preview.rb
@@ -23,6 +23,7 @@ module UI
   #   `copyright:`, optional block content, and `label:` (i18n) to name the landmark
   #   when a page has more than one footer. Every link needs a readable `label:` (its
   #   accessible name) and an `href:`.
+  # @display background bleed
   # @logical_path Navigation
   class FooterComponentPreview < ViewComponent::Preview
     include UIHelper

--- a/lib/generators/modelrails_ui/lookbook/templates/previews/ui/mega_menu_component_preview.rb
+++ b/lib/generators/modelrails_ui/lookbook/templates/previews/ui/mega_menu_component_preview.rb
@@ -14,6 +14,7 @@ module UI
   #   landmark named by the trigger label; AAA `focus-ring` on the trigger and every
   #   link; a decorative (`aria-hidden`) chevron; outside-click dismissal.
   # - **You supply:** a `label:` and one or more `with_column(heading:, items:)` blocks.
+  # @display background bleed
   # @logical_path Navigation
   class MegaMenuComponentPreview < ViewComponent::Preview
     include UIHelper

--- a/lib/generators/modelrails_ui/lookbook/templates/previews/ui/navbar_component_preview.rb
+++ b/lib/generators/modelrails_ui/lookbook/templates/previews/ui/navbar_component_preview.rb
@@ -19,6 +19,7 @@ module UI
   #   behind a hamburger disclosure (`aria-expanded`/`aria-controls`, Escape and
   #   outside-click close, focus returns to the trigger).
   # - **You supply:** the brand slot and the link items.
+  # @display background bleed
   # @logical_path Navigation
   class NavbarComponentPreview < ViewComponent::Preview
     include UIHelper

--- a/lib/generators/modelrails_ui/lookbook/templates/previews/ui/navigation_menu_component_preview.rb
+++ b/lib/generators/modelrails_ui/lookbook/templates/previews/ui/navigation_menu_component_preview.rb
@@ -16,6 +16,7 @@ module UI
   #   active link; the chevron is decorative.
   # - **You supply:** items (label, optional href, optional active) and — for flyout
   #   items — the panel links via the slot block.
+  # @display background bleed
   # @logical_path Navigation
   class NavigationMenuComponentPreview < ViewComponent::Preview
     include UIHelper

--- a/lib/generators/modelrails_ui/lookbook/templates/previews/ui/sidebar_component_preview.rb
+++ b/lib/generators/modelrails_ui/lookbook/templates/previews/ui/sidebar_component_preview.rb
@@ -12,6 +12,7 @@ module UI
   #   an i18n-labelled toggle, AAA `focus-ring` on the toggle and every item, and
   #   `aria-current="page"` on the active item.
   # - **You supply:** groups/items (label, href, optional icon, active).
+  # @display background bleed
   # @logical_path Navigation
   class SidebarComponentPreview < ViewComponent::Preview
     include UIHelper

--- a/test/test_lookbook_display_backgrounds.rb
+++ b/test/test_lookbook_display_backgrounds.rb
@@ -1,0 +1,38 @@
+# frozen_string_literal: true
+
+require "test_helper"
+
+# Per-preview `@display background <value>` tags (SPACE-separated — Lookbook's tag
+# parser reads `background:` WITH a colon as the key name, which never matches) drive the preview-layout body background
+# (raised default · sunken · surface · bleed). Guard the vocabulary and require the
+# two tagged families to exist (raised containers + page chrome).
+class TestLookbookDisplayBackgrounds < Minitest::Test
+  GEN_ROOT = File.expand_path("../lib/generators/modelrails_ui/lookbook/templates", __dir__)
+  PREVIEW_ROOT = File.join(GEN_ROOT, "previews/ui")
+  LAYOUT = File.join(GEN_ROOT, "component_preview.html.erb")
+  ALLOWED = %w[sunken surface bleed].freeze
+
+  def tags
+    Dir.glob(File.join(PREVIEW_ROOT, "*_component_preview.rb")).each_with_object({}) do |path, acc|
+      value = File.read(path)[/^\s*#\s*@display background\s+(\S+)/, 1]
+      acc[File.basename(path, "_component_preview.rb")] = value if value
+    end
+  end
+
+  def test_background_values_are_in_vocabulary
+    bad = tags.reject { |_c, v| ALLOWED.include?(v) }
+
+    assert_empty bad, "unknown @display background values: #{bad.inspect} (allowed: #{ALLOWED.join(", ")})"
+  end
+
+  def test_tagged_families_exist
+    refute_empty tags, "no @display background tags found"
+    assert_includes tags.keys, "card", "card must opt into the sunken background"
+    assert_includes tags.keys, "navbar", "navbar must opt into the bleed background"
+  end
+
+  def test_layout_consumes_the_background_param
+    assert_match(/lookbook.*display.*background/m, File.read(LAYOUT),
+      "component_preview layout must read params.dig(:lookbook, :display, :background)")
+  end
+end


### PR DESCRIPTION
## What

Gem twin of the app Cycle 3 PR: `component_preview.html.erb` template maps `params.dig(:lookbook, :display, :background)` → body classes (`raised` default · `sunken` · `surface` · `bleed`); 9 preview templates tagged via `@display background <value>`.

**Syntax matters:** the tag is SPACE-separated. The colon form (`@display background: x`) parses the key as `"background:"` and silently never applies — caught by the app-side browser proof, fixed here, documented in the guard (`test_lookbook_display_backgrounds.rb`) and layout comment.

## Verification

`bundle exec rake`: 870 runs / 0 failures, 201 files / 0 offenses. App-side browser proof: card `bg-surface-sunken`, navbar `p-0`, untagged default unchanged.

## Merge order

**Stacked on #52 (Cycle 2)** — merge #52 first.