### PR TITLE
fix(calendar): keep on-color text on a today+selected cell (dark-mode contrast)

### DIFF
--- a/lib/generators/modelrails_ui/add/templates/calendar/calendar_component.rb.tt
+++ b/lib/generators/modelrails_ui/add/templates/calendar/calendar_component.rb.tt
@@ -48,7 +48,7 @@ module UI
     CELL_CLS   = "contents"
     DAY_BASE   = "h-11 w-11 rounded-md text-center text-sm transition-colors focus-ring"
     DAY_NORMAL = "hover:bg-surface-sunken hover:text-text-heading"
-    DAY_TODAY  = "font-semibold text-text-heading ring-1 ring-border"
+    DAY_TODAY  = "font-semibold ring-1 ring-border"
     DAY_SEL    = "bg-interactive text-text-on-interactive hover:bg-interactive-hover"
     DAY_MUTED  = "text-text-muted"
     DAY_DISABLED = "pointer-events-none opacity-30"
@@ -166,6 +166,10 @@ module UI
       classes = cn(DAY_BASE,
         selected ? DAY_SEL : DAY_NORMAL,
         is_today ? DAY_TODAY : nil,
+        # Today's heading-weight text emphasis applies only off a fill: on a
+        # selected (bg-interactive) cell, DAY_SEL's text-text-on-interactive must
+        # win, else heading text on the fill fails dark-mode contrast.
+        (is_today && !selected) ? "text-text-heading" : nil,
         outside  ? DAY_MUTED : nil,
         disabled ? DAY_DISABLED : nil)
 

--- a/test/render/calendar_render_test.rb
+++ b/test/render/calendar_render_test.rb
@@ -64,6 +64,7 @@ class CalendarRenderTest < ViewComponent::TestCase
     end
 
     today = page.find("button[aria-current='date']")
+
     assert_includes today[:class], "bg-interactive"
     assert_includes today[:class], "text-text-on-interactive"
     refute_includes today[:class], "text-text-heading"

--- a/test/render/calendar_render_test.rb
+++ b/test/render/calendar_render_test.rb
@@ -10,6 +10,8 @@ load_component "calendar", "calendar_component.rb.tt"
 # APG date-grid scaffolding the controller relies on, plus the focus/label
 # contract, never the runtime behavior itself.
 class CalendarRenderTest < ViewComponent::TestCase
+  include ActiveSupport::Testing::TimeHelpers
+
   # A fixed month so the grid layout is deterministic. June 2026 begins on a
   # Monday; the 15th is a Monday in the second visible week.
   JUNE = Date.new(2026, 6, 15)
@@ -47,6 +49,24 @@ class CalendarRenderTest < ViewComponent::TestCase
     assert_selector "[role='grid'] [role='row']", count: 7
     assert_selector "[role='gridcell']", count: 42
     assert_selector "[role='gridcell'] button[type='button']", count: 42
+  end
+
+  # --- Today + selected must keep on-color text ------------------------------
+
+  # Regression: when the selected day IS today, the today indicator must not
+  # override the selected fill's on-color text. The today cell carried
+  # `text-text-heading`, which won the cascade over DAY_SEL's
+  # `text-text-on-interactive` and put heading text on the bg-interactive fill —
+  # a dark-mode contrast failure the app's preview-host axe spec caught.
+  def test_today_when_also_selected_keeps_on_interactive_text
+    travel_to(JUNE) do # JUNE is today, so today == the selected day
+      render_inline(UI::CalendarComponent.new(month: JUNE, selected: JUNE))
+    end
+
+    today = page.find("button[aria-current='date']")
+    assert_includes today[:class], "bg-interactive"
+    assert_includes today[:class], "text-text-on-interactive"
+    refute_includes today[:class], "text-text-heading"
   end
 
   # --- Day buttons carry a full-date accessible name -------------------------


### PR DESCRIPTION
## Problem

When the **selected** day is also **today**, the calendar day-cell combined `DAY_SEL` (`bg-interactive text-text-on-interactive`) with `DAY_TODAY` (`... text-text-heading ring ...`). Both set `color`, and Tailwind resolves by CSS source order — `text-text-heading` won. So the cell rendered **heading-weight near-white text on the light-cyan interactive fill** in dark mode: contrast **1.52:1** (needs 4.5:1).

It slipped through the calendar's structural render tests because they use a fixed month with no `today == selected` state, so the bad combination never rendered. A downstream app's preview-host axe spec (current month, today highlighted) caught it.

## Fix

- `DAY_TODAY` is now the ring + weight indicator only (no text color).
- The today heading-text emphasis is applied **only when the cell is not selected** — so on a selected (today) cell, `DAY_SEL`'s `text-text-on-interactive` wins.

Today-not-selected is unchanged (still `text-text-heading` + ring + bold).

## Test

Adds `test_today_when_also_selected_keeps_on_interactive_text` — freezes to the fixed `JUNE` date so `today == selected`, then asserts the today cell carries `text-text-on-interactive` and **not** `text-text-heading`. Verified it fails on the old code and passes on the fix. Full gem suite green (render 487/0, structural 871/0).