### PR TITLE
release: v0.3.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.3.1] - 2026-06-15
+
+### Fixed
+- Calendar: a day that is both today and selected rendered low-contrast heading text on the selected fill (dark-mode AAA failure); today's text emphasis now yields to the selected on-color.
+
 ## [0.3.0] - 2026-06-11
 
 ### Added

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    modelrails_ui (0.3.0)
+    modelrails_ui (0.3.1)
       railties (>= 7.1)
       view_component (>= 4.0)
 
@@ -362,7 +362,7 @@ CHECKSUMS
   matrix (0.4.3) sha256=a0d5ab7ddcc1973ff690ab361b67f359acbb16958d1dc072b8b956a286564c5b
   mini_mime (1.1.5) sha256=8681b7e2e4215f2a159f9400b5816d85e9d8c6c6b491e96a12797e798f8bccef
   minitest (6.0.6) sha256=153ea36d1d987a62942382b61075745042a2b3123b1cd48f4c3675af9cc7d6f1
-  modelrails_ui (0.3.0)
+  modelrails_ui (0.3.1)
   net-imap (0.6.4.1) sha256=29f0360d75a7efd3539f16ac1957dea5c0a51ddeceb348db4553c3120914ea0d
   net-pop (0.1.2) sha256=848b4e982013c15b2f0382792268763b748cce91c9e91e36b0f27ed26420dff3
   net-protocol (0.2.2) sha256=aa73e0cba6a125369de9837b8d8ef82a61849360eba0521900e2c3713aa162a8

--- a/lib/modelrails_ui/version.rb
+++ b/lib/modelrails_ui/version.rb
@@ -2,5 +2,5 @@
 
 module ModelrailsUi
   # modelrails_ui's own SemVer line (forked from view_primitives 0.1.0). See MODELRAILS_STATUS.md.
-  VERSION = "0.3.0"
+  VERSION = "0.3.1"
 end


### PR DESCRIPTION
Patch release. Cuts the `[Unreleased]` calendar fix into a tagged version so scaffolding consumers (`modelrails_ui:add calendar`) pick it up — the `v0.3.0` tag predates #55 and still ships the buggy template.

### Fixed
- Calendar: a day that is both today and selected rendered low-contrast heading text on the selected fill (dark-mode AAA failure); today's text emphasis now yields to the selected on-color. (#55)

### Release mechanics
- `version.rb` 0.3.0 → 0.3.1; `Gemfile.lock` self-version bumped (only those two lines).
- Full `rake` green: render 487 / structural 871 / 0 failures, RuboCop 202 files / 0 offenses.
- Tag `v0.3.1` (annotated, on the merge commit) to follow once this merges — mirrors how `v0.3.0` was tagged on #54's merge.