### PR TITLE
feat(select): style the native picker via appearance: base-select

### DIFF
--- a/lib/generators/modelrails_ui/add/templates/select/select_component.rb.tt
+++ b/lib/generators/modelrails_ui/add/templates/select/select_component.rb.tt
@@ -23,6 +23,13 @@ module UI
   #   labeled by a separate form label). On error, pass `invalid: true` and point
   #   `describedby:` at the error element's id.
   #
+  # ## Customizable Select (progressive enhancement)
+  # In browsers that support `appearance: base-select` (Chromium, Safari 26+) the
+  # `.ui-select` hook restyles the OPEN picker to match the design system — the same
+  # overlay/border/shadow as the combobox, a tinted checkmark on the selected row,
+  # and a flipping picker-icon. Everywhere else it falls back to the untouched native
+  # control. Pure CSS + one class; no JS, no markup change. See `modelrails_ui.css`.
+  #
   # No fail-loud guard — there's no enum axis to validate.
   class SelectComponent < ApplicationComponent
     BASE = "flex min-h-[var(--form-input-height)] w-full rounded-md border border-border-strong bg-transparent px-3 py-1 text-sm shadow-sm " \
@@ -56,7 +63,10 @@ module UI
     private
 
     def select_attrs
-      attrs = @html_attrs.merge(id: @id, class: cn(BASE, @extra_class))
+      # `ui-select` is the stable hook the customizable-select CSS targets
+      # (`@supports (appearance: base-select)` → `.ui-select::picker(select)` etc.);
+      # it carries no utilities of its own, so the native fallback is untouched.
+      attrs = @html_attrs.merge(id: @id, class: cn("ui-select", BASE, @extra_class))
       attrs["aria-invalid"] = "true" if @invalid
       attrs["aria-describedby"] = @describedby if @describedby.present?
       attrs

--- a/lib/generators/modelrails_ui/install/templates/modelrails_ui.css
+++ b/lib/generators/modelrails_ui/install/templates/modelrails_ui.css
@@ -503,6 +503,61 @@
 }
 
 /* ==========================================================================
+   Customizable Select (progressive enhancement)
+   Opt UI::Select (`.ui-select`) into a fully styleable native picker where
+   supported (Chromium, Safari 26+); browsers without `appearance: base-select`
+   ignore this whole block and fall back to the untouched native control. The
+   picker renders in the top layer (escapes overflow/stacking, like the menus).
+   Every color is a semantic token, so light/dark + AAA come for free. String
+   options + picker chrome only; rich `<selectedcontent>` is a later enhancement.
+   See the WWDC26 "Customizable Select" session.
+   ========================================================================== */
+
+@supports (appearance: base-select) {
+  .ui-select,
+  .ui-select::picker(select) {
+    appearance: base-select;
+  }
+
+  .ui-select::picker-icon {
+    color: var(--color-text-body);
+    transition: rotate 0.2s ease;
+  }
+  .ui-select:open::picker-icon {
+    rotate: 180deg;
+  }
+
+  .ui-select::picker(select) {
+    border: 1px solid var(--color-border);
+    border-radius: 0.5rem;
+    background: var(--color-surface-overlay);
+    box-shadow: 0 10px 24px oklch(0% 0 0 / 0.14);
+    padding: 0.25rem;
+    margin-top: 0.25rem;
+  }
+
+  .ui-select option {
+    display: flex;
+    align-items: center;
+    gap: 0.5rem;
+    padding: 0.5rem 0.625rem;
+    border-radius: 0.3125rem;
+    color: var(--color-text-body);
+  }
+  .ui-select option:hover,
+  .ui-select option:focus {
+    background: var(--color-surface-sunken);
+    color: var(--color-text-heading);
+  }
+  .ui-select option:checked {
+    font-weight: 600;
+  }
+  .ui-select option::checkmark {
+    color: var(--color-interactive);
+  }
+}
+
+/* ==========================================================================
    OKLCH Hue-based Background Utilities
    Used with style="--hue: <value>" to apply dynamic colors without full
    inline background-color declarations (CSP-safer).


### PR DESCRIPTION
Progressive enhancement for the **Select** component — the gem-template side of a companion change in the consuming app (`dschmura/modelrails_base`, validated end-to-end at 3333/0).

## What
In browsers that support `appearance: base-select` (Chromium, Safari 26+) the open `<select>` picker now matches the design system — the combobox's overlay/border/shadow language, a brand-tinted checkmark on the selected row, roomy options, and a flipping picker-icon. Browsers without support **fall back to the untouched native control**. Pure CSS + one hook class: no JS, no markup change, so the native a11y / keyboard / forced-colors contract is preserved everywhere.

## Changes
- `add/templates/select/select_component.rb.tt` — add the stable `ui-select` hook class (carries no utilities of its own).
- `install/templates/modelrails_ui.css` — `@supports (appearance: base-select)` block using semantic tokens, so light/dark + AAA come for free; the picker renders in the top layer (escapes overflow/stacking, like the menus). String options + picker chrome only; rich `<selectedcontent>` options are a later enhancement.

## Validation
- Generator + structural tests **871/0**, RuboCop **202/0** (the generator tests exercise the `.tt`).
- The generated output is byte-for-byte the code the consuming app proved at **3333/0** and a 0b axe audit (Playwright Chromium 145, both themes).
- Browser support confirmed in our own Chromium 145; degrades cleanly everywhere else.

See the WWDC26 "Customizable Select" session.