### PR TITLE
release: v0.4.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.4.0] - 2026-06-30
+
+### Added
+- Customizable Select: `UI::Select`'s native `<select>` picker now opts into `appearance: base-select` where supported (Chromium, Safari 26+), rendering a fully styled picker that matches the design system — the combobox's overlay/border/shadow, a brand-tinted checkmark on the selected row, roomy options, and a flipping picker-icon. Browsers without support fall back to the untouched native control. Pure CSS + one `ui-select` hook class; no JS, no markup change.
+
 ## [0.3.1] - 2026-06-15
 
 ### Fixed

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    modelrails_ui (0.3.1)
+    modelrails_ui (0.4.0)
       railties (>= 7.1)
       view_component (>= 4.0)
 
@@ -362,7 +362,7 @@ CHECKSUMS
   matrix (0.4.3) sha256=a0d5ab7ddcc1973ff690ab361b67f359acbb16958d1dc072b8b956a286564c5b
   mini_mime (1.1.5) sha256=8681b7e2e4215f2a159f9400b5816d85e9d8c6c6b491e96a12797e798f8bccef
   minitest (6.0.6) sha256=153ea36d1d987a62942382b61075745042a2b3123b1cd48f4c3675af9cc7d6f1
-  modelrails_ui (0.3.1)
+  modelrails_ui (0.4.0)
   net-imap (0.6.4.1) sha256=29f0360d75a7efd3539f16ac1957dea5c0a51ddeceb348db4553c3120914ea0d
   net-pop (0.1.2) sha256=848b4e982013c15b2f0382792268763b748cce91c9e91e36b0f27ed26420dff3
   net-protocol (0.2.2) sha256=aa73e0cba6a125369de9837b8d8ef82a61849360eba0521900e2c3713aa162a8

--- a/lib/modelrails_ui/version.rb
+++ b/lib/modelrails_ui/version.rb
@@ -2,5 +2,5 @@
 
 module ModelrailsUi
   # modelrails_ui's own SemVer line (forked from view_primitives 0.1.0). See MODELRAILS_STATUS.md.
-  VERSION = "0.3.1"
+  VERSION = "0.4.0"
 end


### PR DESCRIPTION
Cuts **v0.4.0** — minor bump for the Customizable Select feature merged in #59.

- `version.rb`: 0.3.1 → 0.4.0
- `CHANGELOG.md`: new `## [0.4.0] - 2026-06-30` section (### Added — customizable-select picker)

`rake` green: render 487/0, structural 871/0, rubocop 202/0.

After merge: tag `v0.4.0` on main, then the consuming app (`modelrails_base`) bumps its gem pin from v0.3.1 → v0.4.0.