### PR TITLE
fix(select): base-select chevron sits inline, not on its own line

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+- Customizable Select: the styled base-select button dropped its picker-icon onto a second line (and let it drift as the picker opened), because `.form-field`/`.form-input` set `display: block`, overriding base-select's default flex button. The `@supports` block now restores `display: flex` on `.ui-select` and pins the picker-icon inline at the end.
+
 ## [0.4.0] - 2026-06-30
 
 ### Added

--- a/lib/generators/modelrails_ui/install/templates/modelrails_ui.css
+++ b/lib/generators/modelrails_ui/install/templates/modelrails_ui.css
@@ -519,7 +519,21 @@
     appearance: base-select;
   }
 
+  /* Button layout: selected text at the start, picker-icon pinned to the
+     inline-end on the SAME row. `.form-field`/`.form-input` apply `display: block`,
+     which overrides base-select's default flex button and drops the picker-icon
+     onto its own line (and lets it drift as the picker opens). Restore
+     `display: flex` here — this unlayered @supports block wins over those layered
+     field utilities — then align and pin the icon. */
+  .ui-select {
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    gap: 0.5rem;
+  }
+
   .ui-select::picker-icon {
+    flex: none;
     color: var(--color-text-body);
     transition: rotate 0.2s ease;
   }


### PR DESCRIPTION
The `.ui-select` customizable-select button inherits `display: block` from the `.form-field`/`.form-input` field utilities, which overrides base-select's default flex button — the picker-icon drops onto its own line and drifts as the picker opens. Restores `display: flex` + center / space-between in the unlayered `@supports` block (wins over the layered field utilities); `flex: none` pins the icon inline at the end.

Follow-up to the base-select feature (#59).

## Verification
Verified in a host app (modelrails_base): the same fix, applied to the app's vendored copy of this CSS, fixes the chevron across every select and the full suite is green. Layout isn't axe-testable, so the host-app browser check is the proof.

## Not included (yours to decide)
- **Version bump / tag / release** — left `version.rb` at 0.4.0 untouched; this is a patch (→ 0.4.1) whenever you want to cut it.
- Left the pre-existing uncommitted `MODELRAILS_STATUS.md` change alone.