### PR TITLE
feat(alert): render tone-matched severity icons

### DIFF
--- a/docs/components/alert.md
+++ b/docs/components/alert.md
@@ -25,19 +25,24 @@ Creates `app/components/ui/alert_component.rb`.
 
 Slots take precedence over kwargs when both are provided.
 
-## Variants
+## Tones
 
-| Variant | Description |
-|---------|-------------|
-| `default` | Neutral — uses `--background` and `--foreground` |
-| `destructive` | Error or danger — uses `--destructive` colour |
+| Tone | Description |
+|------|-------------|
+| `neutral` | Default — raised surface, body text, no icon |
+| `info` | Informational signal on the info-tinted surface |
+| `success` | Confirmation on the success-tinted surface |
+| `warning` | Warning on the warning-tinted surface |
+| `danger` | Error — announced assertively (`role="alert"`) on the danger surface |
+
+`variant:` is accepted as a deprecated alias for `tone:` (`default`→`neutral`, `destructive`→`danger`, the rest 1:1).
 
 ```erb
-<%= ui :alert, variant: :default,
+<%= ui :alert, tone: :info,
                 title: "Note",
                 description: "Your free trial expires in 3 days." %>
 
-<%= ui :alert, variant: :destructive,
+<%= ui :alert, tone: :danger,
                 title: "Error",
                 description: "Your session has expired. Please log in again." %>
 ```
@@ -58,16 +63,16 @@ Use slots when the content contains HTML, links, or other components:
 <% end %>
 ```
 
-## With an icon
+## Icons
 
-Place an SVG before the slots. The component shifts content right automatically via `[&>svg~*]:pl-7`:
+Each signal tone renders a matching severity icon automatically — info circle, success check circle, warning triangle, danger circle-x (the same glyphs the toaster uses, so an alert and a toast at the same level read the same). Distinct shapes keep severity legible without relying on color alone (WCAG 1.4.1). The icon is `aria-hidden` — decorative for screen readers, which already get the urgency-matched live region and your title/description. The `neutral` tone has no icon.
 
 ```erb
-<%= ui :alert, variant: :destructive do |alert| %>
-  <svg xmlns="http://www.w3.org/2000/svg" class="h-4 w-4" ...>...</svg>
-  <% alert.with_alert_title { "Error" } %>
-  <% alert.with_alert_description { "Something went wrong." } %>
-<% end %>
+<%# Warning triangle renders automatically %>
+<%= ui :alert, tone: :warning, title: "Storage almost full" %>
+
+<%# Opt out with icon: false %>
+<%= ui :alert, tone: :warning, icon: false, title: "Storage almost full" %>
 ```
 
 ## Flash messages
@@ -75,23 +80,23 @@ Place an SVG before the slots. The component shifts content right automatically 
 ```erb
 <%# app/views/shared/_flash.html.erb %>
 <% flash.each do |type, message| %>
-  <%= ui :alert, variant: flash_variant(type), description: message %>
+  <%= ui :alert, tone: flash_tone(type), description: message %>
 <% end %>
 ```
 
 ```ruby
 # app/helpers/flash_helper.rb
 module FlashHelper
-  FLASH_VARIANTS = {
-    "notice"  => :default,
-    "success" => :default,
-    "alert"   => :destructive,
-    "error"   => :destructive,
-    "warning" => :destructive
+  FLASH_TONES = {
+    "notice"  => :neutral,
+    "success" => :success,
+    "alert"   => :warning,
+    "error"   => :danger,
+    "warning" => :warning
   }.freeze
 
-  def flash_variant(type)
-    FLASH_VARIANTS.fetch(type.to_s, :default)
+  def flash_tone(type)
+    FLASH_TONES.fetch(type.to_s, :neutral)
   end
 end
 ```
@@ -110,7 +115,9 @@ end
 
 | Option | Type | Default | Description |
 |--------|------|---------|-------------|
-| `variant` | Symbol | `:default` | Visual style — see Variants table |
+| `tone` | Symbol | `:neutral` | Severity level — see Tones table |
+| `variant` | Symbol | `nil` | Deprecated alias for `tone:` (`default`→`neutral`, `destructive`→`danger`) |
+| `icon` | Boolean | `true` | Render the tone's severity icon. `false` suppresses it |
 | `title` | String | `nil` | Plain-text title, alternative to `with_alert_title` slot |
 | `description` | String | `nil` | Plain-text description, alternative to `with_alert_description` slot |
 

--- a/lib/generators/modelrails_ui/add/templates/alert/alert_component.rb.tt
+++ b/lib/generators/modelrails_ui/add/templates/alert/alert_component.rb.tt
@@ -17,7 +17,9 @@ module UI
   # ## Accessibility contract
   # - **Guarantees:** a live region matched to urgency — `role="status"`/`aria-live="polite"`
   #   for the neutral tone (and `info`/`success`/`warning`), `role="alert"`/
-  #   `aria-live="assertive"` for `danger` — and AAA-contrast text on the banner surface.
+  #   `aria-live="assertive"` for `danger` — AAA-contrast text on the banner surface,
+  #   and a tone-matched severity icon (`aria-hidden`, a redundant non-color cue per
+  #   WCAG 1.4.1 — pass `icon: false` to suppress it).
   # - **You supply:** a title and/or description (kwargs or the `alert_title` /
   #   `alert_description` slots) and a valid `tone` (an unknown one raises in development).
   #
@@ -43,6 +45,19 @@ module UI
       danger:  "bg-danger-surface border-danger-border text-danger [&>svg]:text-current *:data-[slot=alert-description]:text-danger"
     }.freeze
 
+    # Tone → severity glyph (Lucide-style stroke paths, identical to the toaster's
+    # so an alert and a toast at the same level read the same): info circle, check
+    # circle, warning triangle, danger circle-x. Distinct shapes keep severity
+    # legible without relying on color alone (WCAG 1.4.1). `neutral` has no glyph —
+    # it isn't a signal level.
+    ICONS = {
+      neutral: nil,
+      info:    "M13 16h-1v-4h-1m1-4h.01M21 12a9 9 0 1 1-18 0 9 9 0 0 1 18 0z",
+      success: "M9 12l2 2 4-4m6 2a9 9 0 1 1-18 0 9 9 0 0 1 18 0z",
+      warning: "M12 9v4m0 4h.01M10.29 3.86L1.82 18a2 2 0 0 0 1.71 3h16.94a2 2 0 0 0 1.71-3L13.71 3.86a2 2 0 0 0-3.42 0z",
+      danger:  "M10 14l2-2m0 0l2-2m-2 2l-2-2m2 2l2 2m7-2a9 9 0 1 1-18 0 9 9 0 0 1 18 0z"
+    }.freeze
+
     # Deprecated `variant:` alias → `tone:`. The old flat `variant` enum maps 1:1 onto
     # tone except `default`→`neutral` and `destructive`→`danger`. Resolved in coerce_tone.
     VARIANT_ALIASES = { default: :neutral, destructive: :danger }.freeze
@@ -58,16 +73,18 @@ module UI
     # title: and description: are kwarg shorthands for plain-text content.
     # Use slots (with_alert_title / with_alert_description) for rich HTML.
     # Slots take precedence over kwargs when both are provided.
-    def initialize(tone: :neutral, variant: nil, title: nil, description: nil, **html_attrs)
+    # icon: true renders the tone's severity glyph (ICONS); false suppresses it.
+    def initialize(tone: :neutral, variant: nil, title: nil, description: nil, icon: true, **html_attrs)
       @tone = coerce_tone(tone, variant)
       @title = title
       @description = description
+      @icon = icon
       @extra_class = html_attrs.delete(:class)
       @html_attrs = html_attrs
     end
 
     def call
-      content_tag(:div, safe_join([resolved_title, resolved_description].compact),
+      content_tag(:div, safe_join([tone_icon, resolved_title, resolved_description].compact),
         **@html_attrs,
         role: ROLES.fetch(@tone),
         "aria-live": LIVE.fetch(@tone),
@@ -114,6 +131,21 @@ module UI
       end
 
       :neutral
+    end
+
+    # The tone's severity glyph as a direct `>svg` child of the root — OUTER_CLASSES
+    # sizes/colors it and switches the grid to the icon column via `has-[>svg]`.
+    # `aria-hidden` because the icon is decorative: severity is already conveyed
+    # programmatically (role + aria-live) and by the caller's title/description.
+    def tone_icon
+      return unless @icon && (path = ICONS.fetch(@tone))
+
+      content_tag(:svg,
+        content_tag(:path, nil, d: path,
+          "stroke-linecap": "round", "stroke-linejoin": "round"),
+        xmlns: "http://www.w3.org/2000/svg", viewBox: "0 0 24 24",
+        fill: "none", stroke: "currentColor", "stroke-width": "2",
+        "aria-hidden": "true")
     end
 
     def resolved_title

--- a/lib/generators/modelrails_ui/lookbook/templates/previews/ui/alert_component_preview.rb
+++ b/lib/generators/modelrails_ui/lookbook/templates/previews/ui/alert_component_preview.rb
@@ -15,7 +15,9 @@ module UI
   # - It's an ephemeral flash — use the app's toast system (`shared/_toasts`).
   #
   # ## Accessibility contract
-  # - **Guarantees:** an urgency-matched live region and AAA-contrast text.
+  # - **Guarantees:** an urgency-matched live region, AAA-contrast text, and a
+  #   tone-matched severity icon (`aria-hidden` — a non-color severity cue;
+  #   `icon: false` suppresses it).
   # - **You supply:** a title and/or description, and a valid `variant`.
   #
   # ## Variants

--- a/test/render/alert_render_test.rb
+++ b/test/render/alert_render_test.rb
@@ -127,4 +127,39 @@ class AlertRenderTest < ViewComponent::TestCase
       render_inline(UI::AlertComponent.new(tone: :bogus))
     end
   end
+
+  # --- Severity icons ---
+
+  # Each signal tone renders its severity glyph as a direct child of the live
+  # region — a redundant, non-color severity cue (WCAG 1.4.1). Decorative
+  # (aria-hidden): the region announces only the caller's text.
+  %i[info success warning danger].each do |tone|
+    define_method("test_tone_#{tone}_renders_a_decorative_severity_icon") do
+      render_inline(UI::AlertComponent.new(tone: tone, title: "X"))
+
+      assert_selector "div[role] > svg[aria-hidden='true']"
+      assert_selector "svg path[d='#{UI::AlertComponent::ICONS.fetch(tone)}']"
+    end
+  end
+
+  # The glyphs must stay distinct across tones — identical shapes would collapse
+  # the non-color severity cue back into color-only signaling.
+  def test_signal_tone_glyphs_are_distinct
+    paths = UI::AlertComponent::ICONS.values.compact
+    assert_equal paths.uniq, paths
+  end
+
+  # Neutral isn't a signal level — no glyph, and the grid keeps its no-icon layout.
+  def test_neutral_tone_renders_no_icon
+    render_inline(UI::AlertComponent.new(title: "X"))
+
+    assert_no_selector "svg"
+  end
+
+  def test_icon_false_suppresses_the_severity_icon
+    render_inline(UI::AlertComponent.new(tone: :danger, title: "X", icon: false))
+
+    assert_selector "div[role='alert']", text: "X"
+    assert_no_selector "svg"
+  end
 end

--- a/test/render/alert_render_test.rb
+++ b/test/render/alert_render_test.rb
@@ -146,6 +146,7 @@ class AlertRenderTest < ViewComponent::TestCase
   # the non-color severity cue back into color-only signaling.
   def test_signal_tone_glyphs_are_distinct
     paths = UI::AlertComponent::ICONS.values.compact
+
     assert_equal paths.uniq, paths
   end
 


### PR DESCRIPTION
## Summary

- Each signal tone (`info`/`success`/`warning`/`danger`) now renders its severity glyph automatically — the same Lucide-style stroke paths the toaster uses, so an alert and a toast at the same level share one glyph. Distinct shapes keep severity legible without relying on color alone (WCAG 1.4.1). `neutral` stays icon-free — it isn't a signal level.
- Icons are `aria-hidden` decorative cues rendered as a direct `>svg` child; the component's grid was already built to receive one (`has-[>svg]` column, `[&>svg]` sizing) but never emitted it. Urgency stays conveyed programmatically via the existing `role`/`aria-live` pairs.
- New `icon:` kwarg (default `true`); `icon: false` restores the pre-change rendering exactly.
- Docs: replaced the "With an icon" section (it documented passing an SVG as block content, which the component never rendered), updated the stale two-variant table to the five-tone axis, modernized the flash example to tones.

## Accessibility verification

Beyond the render tests, the output was driven through real Chrome and its accessibility tree inspected: no SVG/image node appears in any tone's tree (screen readers hear only title + description, no double announcement), `status`/`polite` vs `alert`/`assertive` mapping unchanged including the legacy `variant: :destructive` alias, icons never enter the tab order, and a dynamically injected danger alert announces only the author's text. Icon stroke is `currentColor` — the tone's AAA 7:1 text token, clearing the 3:1 non-text contrast floor by construction.

## Test plan

- [x] `bundle exec rake test` — 878 runs, 1287 assertions, 0 failures (7 new icon tests: per-tone glyph + `aria-hidden`, glyph distinctness, neutral has no icon, `icon: false` opt-out)
- [x] Legacy `variant:` back-compat suite unchanged and green

🤖 Generated with [Claude Code](https://claude.com/claude-code)