### PR TITLE
release: v0.5.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.5.0] - 2026-07-05
+
+### Added
+- Alert: signal tones (`info` · `success` · `warning` · `danger`) now render a tone-matched severity icon automatically — the same Lucide-style glyphs as the toaster, so an alert and a toast at the same level share one glyph. Distinct shapes keep severity legible without relying on color alone (WCAG 1.4.1); the icon is `aria-hidden`, so screen readers still hear only the urgency-matched live region and the caller's title/description. `neutral` stays icon-free; the new `icon: false` kwarg opts out and restores the previous rendering exactly.
+
 ### Fixed
 - Customizable Select: the styled base-select button dropped its picker-icon onto a second line (and let it drift as the picker opened), because `.form-field`/`.form-input` set `display: block`, overriding base-select's default flex button. The `@supports` block now restores `display: flex` on `.ui-select` and pins the picker-icon inline at the end.
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    modelrails_ui (0.4.0)
+    modelrails_ui (0.5.0)
       railties (>= 7.1)
       view_component (>= 4.0)
 
@@ -362,7 +362,7 @@ CHECKSUMS
   matrix (0.4.3) sha256=a0d5ab7ddcc1973ff690ab361b67f359acbb16958d1dc072b8b956a286564c5b
   mini_mime (1.1.5) sha256=8681b7e2e4215f2a159f9400b5816d85e9d8c6c6b491e96a12797e798f8bccef
   minitest (6.0.6) sha256=153ea36d1d987a62942382b61075745042a2b3123b1cd48f4c3675af9cc7d6f1
-  modelrails_ui (0.4.0)
+  modelrails_ui (0.5.0)
   net-imap (0.6.4.1) sha256=29f0360d75a7efd3539f16ac1957dea5c0a51ddeceb348db4553c3120914ea0d
   net-pop (0.1.2) sha256=848b4e982013c15b2f0382792268763b748cce91c9e91e36b0f27ed26420dff3
   net-protocol (0.2.2) sha256=aa73e0cba6a125369de9837b8d8ef82a61849360eba0521900e2c3713aa162a8

--- a/lib/modelrails_ui/version.rb
+++ b/lib/modelrails_ui/version.rb
@@ -2,5 +2,5 @@
 
 module ModelrailsUi
   # modelrails_ui's own SemVer line (forked from view_primitives 0.1.0). See MODELRAILS_STATUS.md.
-  VERSION = "0.4.0"
+  VERSION = "0.5.0"
 end


### PR DESCRIPTION
## Summary

Version bump to **v0.5.0** — minor bump for the Added alert-icons feature.

- **Added** — Alert tone icons: signal tones render `aria-hidden` severity glyphs matching the toaster's (WCAG 1.4.1 non-color severity cue), with an `icon: false` opt-out (#63)
- **Fixed** — base-select chevron layout fix, already on main (#62)

## Merge order

⚠️ **Draft until #63 merges** — this PR's changelog describes the alert feature, so #63 must land first. After both merge, tag the release commit on main:

```bash
git tag -a v0.5.0 -m "v0.5.0 — alert tone severity icons" <merge-commit>
git push origin v0.5.0
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)