### PR TITLE
Alert: bigger severity icons + normalized warning triangle

### DIFF
--- a/lib/generators/modelrails_ui/add/templates/alert/alert_component.rb.tt
+++ b/lib/generators/modelrails_ui/add/templates/alert/alert_component.rb.tt
@@ -30,8 +30,8 @@ module UI
   # `destructive`→`danger`, the rest 1:1.)
   class AlertComponent < ApplicationComponent
     OUTER_CLASSES = "relative grid w-full grid-cols-[0_1fr] items-start gap-y-0.5 rounded-lg border " \
-                    "px-4 py-3 text-sm has-[>svg]:grid-cols-[calc(var(--spacing)*4)_1fr] " \
-                    "has-[>svg]:gap-x-3 [&>svg]:size-4 [&>svg]:translate-y-0.5 [&>svg]:text-current"
+                    "px-4 py-3 text-sm has-[>svg]:grid-cols-[calc(var(--spacing)*5)_1fr] " \
+                    "has-[>svg]:gap-x-3 [&>svg]:size-5 [&>svg]:translate-y-0.5 [&>svg]:text-current"
 
     # Signal levels share the tinted-surface treatment used by the toast cards
     # (`bg-<level>-surface` + `border-<level>-border` + `text-<level>`), so an alert
@@ -54,7 +54,7 @@ module UI
       neutral: nil,
       info:    "M13 16h-1v-4h-1m1-4h.01M21 12a9 9 0 1 1-18 0 9 9 0 0 1 18 0z",
       success: "M9 12l2 2 4-4m6 2a9 9 0 1 1-18 0 9 9 0 0 1 18 0z",
-      warning: "M12 9v4m0 4h.01M10.29 3.86L1.82 18a2 2 0 0 0 1.71 3h16.94a2 2 0 0 0 1.71-3L13.71 3.86a2 2 0 0 0-3.42 0z",
+      warning: "M12 9.36v3.52m0 3.52h.01M10.5 4.84L3.04 17.28a1.76 1.76 0 0 0 1.51 2.64h14.91a1.76 1.76 0 0 0 1.51-2.64L13.5 4.84a1.76 1.76 0 0 0-3.01 0z",
       danger:  "M10 14l2-2m0 0l2-2m-2 2l-2-2m2 2l2 2m7-2a9 9 0 1 1-18 0 9 9 0 0 1 18 0z"
     }.freeze
 


### PR DESCRIPTION
Follows up the v0.5.0 alert severity icons. Both tweaks were **validated in a downstream app first** (modelrails_base — dschmura/modelrails_base#427) before landing in the gem.

## Changes (`add/templates/alert/alert_component.rb.tt`)

- **Bigger glyphs** — `size-4 → size-5` (16 → 20px), icon grid column widened to match. The severity cue reads a bit stronger without crowding the text.
- **Normalized warning triangle** — the triangle path fills a wider box (~20.4 units) than the circle glyphs (info/success/danger, 18 units), so it optically reads larger. Scaled its geometry ~0.88 about center to sit in the same 18-unit box. Done as a **path resize, not a CSS scale**, so stroke-width stays a uniform 2 next to the circles (a `scale-*` would thin the stroke).

Neutral stays icon-less (unchanged) — a downstream review (Wathan/DHH/Watson) confirmed reusing another tone's glyph would defeat the non-color WCAG 1.4.1 cue.

## Notes

- The alert render test is behavior-focused (roles/live-region/text), not size/path-pinned, so no test change was needed.
- After release, the downstream app will bump its tag and re-vendor to drop the temporary vendored divergence.

🤖 Generated with [Claude Code](https://claude.com/claude-code)