### PR TITLE
docs(agent-rules): overlay containers as live regions or landmarks

### DIFF
--- a/lib/generators/modelrails_ui/agent_rules/templates/agent-rules.md
+++ b/lib/generators/modelrails_ui/agent_rules/templates/agent-rules.md
@@ -38,6 +38,17 @@ Defer to it instead of inventing UI from scratch.
   box-shadow ring is clipped by `overflow:hidden` ancestors and vanishes in forced-colors mode
   (a 2.4.7 failure). The one exception is a menu item's full-surface
   `focus-visible:bg-surface-sunken` highlight (a stronger indicator where an outline is clipped).
+- **A fixed-position overlay container with `aria-label` is a live region OR a landmark — never
+  bare, never `role="group"`.** Such a container (toast stack, notification tray) must clear two
+  axe rules at once: `aria-prohibited-attr` (`aria-label` needs a role) and `region` (its content
+  must sit in a live region or landmark, since it lives outside `<main>`). Two valid shapes:
+  (a) make the container the live region — `role="status"` + `aria-live="polite"` (or
+  `role="alert"`/`assertive` for errors) — when the container announces its own children; or
+  (b) make it a landmark — `role="region"`, with the `aria-label` as its name — when the live
+  regions live on the individual items (per-item `role="status"`, so the container must *not*
+  also be a live region). `role="group"` clears `aria-prohibited-attr` but is neither, so it
+  trips `region`. (`ToasterComponent` uses shape (a); an app's own `shared/_toasts` per-toast
+  stack uses shape (b).)
 
 ## Before you call UI work done
 - **Check both themes** — light *and* dark (class-based dark mode).

--- a/test/render/toaster_render_test.rb
+++ b/test/render/toaster_render_test.rb
@@ -4,7 +4,7 @@ require "render_test_helper"
 load_component "toaster", "toaster_component.rb.tt"
 
 class ToasterRenderTest < ViewComponent::TestCase
-  # --- The stack container is a polite live region landmark ---
+  # --- The stack container is a polite live region (role=status, not a landmark) ---
 
   def test_container_is_a_polite_live_region_with_an_i18n_name
     render_inline(UI::ToasterComponent.new)


### PR DESCRIPTION
## What

Captures a hard-won accessibility rule in the scaffolded `agent-rules.md` design-system guidance, and fixes one imprecise comment in the toaster render test.

## Why

Downstream (a fork's app-owned `shared/_toasts` stack) hit a two-rule axe trap on a fixed-position toast container carrying `aria-label`:

1. A role-less container → `aria-prohibited-attr` (`aria-label` needs a role).
2. `role="group"` clears that — but then trips axe's `region` rule ("all content in a landmark"), because the container sits outside `<main>` and `group` is neither a landmark nor a live region.

`role="region"` (a landmark) cleared both. Verified against axe-core 4.12's own `region` check: a node satisfies it when `aria-live` is `polite`/`assertive`, **or** its role is `alert`/`log`/`status`, **or** it's a landmark. So there are two correct shapes, and this gem's `ToasterComponent` already uses one of them:

- **(a) container as the live region** — `role="status"` + `aria-live="polite"` (what `ToasterComponent` does): exempt from `region` on two counts, no bug. Nothing to change in the component.
- **(b) container as a landmark** — `role="region"` + `aria-label` as its name: correct when the live regions live on the individual items (per-item `role="status"`), so the container must *not* also be a live region. This is the app-owned `shared/_toasts` shape.

The new agent-rules bullet states both shapes and why `role="group"` is the trap, so any future overlay primitive (tray, snackbar, banner stack) gets it right by construction.

## Changes

- `agent-rules.md` template: one bullet under the ARIA/focus section.
- `toaster_render_test.rb`: the container comment said "live region landmark" — `role="status"` is a live region, **not** a landmark; corrected for precision (this is exactly the distinction the rule turns on).

No component behavior changes. Render lane green (878 runs, 0 failures).