### PR TITLE
release: v0.6.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,9 +7,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.6.0] - 2026-07-06
+
 ### Added
 - Component adoption manifest: a new `rake modelrails_ui:adoption` (and `:adoption:strict`) reports, per component, how the host app adopts it (`direct`/`adapter`/`utility-standin`/`transitive`/`none`) and its `N/M` audit-scenario coverage — leading with the "adopted-but-under-audited" blind-spot list. Adoption is read from host code (comments/strings stripped, so doc examples don't inflate); the audit denominator comes from the host's own live previews; a fork-owned `.modelrails_ui/adoption.yml` supplies adapter overrides and row suppression. A gem-internal completeness gate now fails the build if any shipped component lacks a real Lookbook preview or render test.
-- Add form_draft: encrypted localStorage form-draft recovery (notice partial + form-mounted controller).
+- form_draft: encrypted localStorage form-draft recovery (notice partial + form-mounted controller).
 
 ### Changed
 - `COMPONENT_STATUS.md` drops its two machine-derivable columns (`Render test`, `App-adopted`) — those facts are now computed by `rake modelrails_ui:adoption`; the ledger is human judgment (Tier + Notes) only.

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    modelrails_ui (0.5.0)
+    modelrails_ui (0.6.0)
       railties (>= 7.1)
       view_component (>= 4.0)
 
@@ -362,7 +362,7 @@ CHECKSUMS
   matrix (0.4.3) sha256=a0d5ab7ddcc1973ff690ab361b67f359acbb16958d1dc072b8b956a286564c5b
   mini_mime (1.1.5) sha256=8681b7e2e4215f2a159f9400b5816d85e9d8c6c6b491e96a12797e798f8bccef
   minitest (6.0.6) sha256=153ea36d1d987a62942382b61075745042a2b3123b1cd48f4c3675af9cc7d6f1
-  modelrails_ui (0.5.0)
+  modelrails_ui (0.6.0)
   net-imap (0.6.4.1) sha256=29f0360d75a7efd3539f16ac1957dea5c0a51ddeceb348db4553c3120914ea0d
   net-pop (0.1.2) sha256=848b4e982013c15b2f0382792268763b748cce91c9e91e36b0f27ed26420dff3
   net-protocol (0.2.2) sha256=aa73e0cba6a125369de9837b8d8ef82a61849360eba0521900e2c3713aa162a8

--- a/lib/modelrails_ui/version.rb
+++ b/lib/modelrails_ui/version.rb
@@ -2,5 +2,5 @@
 
 module ModelrailsUi
   # modelrails_ui's own SemVer line (forked from view_primitives 0.1.0). See MODELRAILS_STATUS.md.
-  VERSION = "0.5.0"
+  VERSION = "0.6.0"
 end


### PR DESCRIPTION
## Summary

Version bump to **v0.6.0** — minor bump for two Added features, both already on main:

- **Added** — Component adoption manifest: `rake modelrails_ui:adoption` (+ `:strict`) with per-component adoption classification and audit-scenario coverage, plus the gem-internal completeness gate (#67)
- **Added** — form_draft: encrypted localStorage form-draft recovery — notice partial + form-mounted controller (#68)
- **Changed** — `COMPONENT_STATUS.md` drops its two machine-derivable columns; those facts now come from the rake task (#67)

After merge, v0.6.0 gets tagged on the release commit.

🤖 Generated with [Claude Code](https://claude.com/claude-code)