### PR TITLE
fix(form_draft): rename scope to scopeDigest (Stimulus reserved-name collision)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - form_draft controller: rename instance property `scope` → `scopeDigest` — it collided with Stimulus's reserved `scope` getter, throwing on connect and disabling recovery entirely. form_draft is non-functional in v0.6.0 and v0.7.0.
 - form_draft controller: evaluateReveal hides an already-visible notice when a re-check finds no valid draft (expired drafts no longer leave a stale notice after a morph).
+- form_draft notice partial: build the chip wrapper with tag.div so the conditional hidden attribute passes herb-lint (erb-no-output-in-attribute-name).
 
 ## [0.7.0] - 2026-07-06
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- form_draft controller: rename instance property `scope` → `scopeDigest` — it collided with Stimulus's reserved `scope` getter, throwing on connect and disabling recovery entirely. form_draft is non-functional in v0.6.0 and v0.7.0.
+
 ## [0.7.0] - 2026-07-06
 
 Fixes surfaced by MiClassrooms rooms work.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Fixed
 
 - form_draft controller: rename instance property `scope` → `scopeDigest` — it collided with Stimulus's reserved `scope` getter, throwing on connect and disabling recovery entirely. form_draft is non-functional in v0.6.0 and v0.7.0.
+- form_draft controller: evaluateReveal hides an already-visible notice when a re-check finds no valid draft (expired drafts no longer leave a stale notice after a morph).
 
 ## [0.7.0] - 2026-07-06
 

--- a/lib/generators/modelrails_ui/add/templates/form_draft/_form_draft_notice.html.erb
+++ b/lib/generators/modelrails_ui/add/templates/form_draft/_form_draft_notice.html.erb
@@ -13,9 +13,9 @@
   `revealed:` exists for previews/render-tests only; production callers use
   the default.
 -%>
-<div data-form-draft-target="notice"
-     <%= "hidden" unless revealed %>
-     class="mb-6 flex flex-wrap items-center justify-between gap-3 rounded-md border border-warning-border bg-warning-surface px-4 py-3">
+<%= tag.div data: { form_draft_target: "notice" },
+      hidden: !revealed,
+      class: "mb-6 flex flex-wrap items-center justify-between gap-3 rounded-md border border-warning-border bg-warning-surface px-4 py-3" do %>
   <p class="font-medium text-warning">
     <%= t("form_draft.notice", default: "You have an unsaved draft of this form.") %>
   </p>
@@ -29,7 +29,7 @@
       <%= t("form_draft.discard", default: "Discard draft") %>
     </button>
   </div>
-</div>
+<% end %>
 <div data-form-draft-target="status"
      role="status" aria-live="polite" aria-atomic="true" class="sr-only"
      data-found-text="<%= t("form_draft.found", default: "Recoverable draft found. Recover and Discard buttons are before the form fields.") %>"

--- a/lib/generators/modelrails_ui/add/templates/form_draft/form_draft_controller.js
+++ b/lib/generators/modelrails_ui/add/templates/form_draft/form_draft_controller.js
@@ -330,7 +330,10 @@ export default class extends Controller {
     if (!this.enabled) return
     if (this.consumeSuppressMarker()) return
     const draft = await this.readDraft()
-    if (!draft || this.disarmed) return
+    if (!draft || this.disarmed) {
+      this.hideNotice()
+      return
+    }
     if (this.hasNoticeTarget) this.noticeTarget.hidden = false
     this.announce(this.statusText("found"))
   }

--- a/lib/generators/modelrails_ui/add/templates/form_draft/form_draft_controller.js
+++ b/lib/generators/modelrails_ui/add/templates/form_draft/form_draft_controller.js
@@ -106,7 +106,7 @@ export default class extends Controller {
   connect() {
     this.disarmed = false
     this.pendingSave = null
-    this.scope = document.querySelector('meta[name="form-draft-scope"]')?.content
+    this.scopeDigest = document.querySelector('meta[name="form-draft-scope"]')?.content
     resolveKey() // scrub + warm the key cache even if this instance no-ops
 
     this.boundStorage = this.onStorage.bind(this)
@@ -135,11 +135,11 @@ export default class extends Controller {
   }
 
   get enabled() {
-    return Boolean(this.scope) && Boolean(window.crypto?.subtle)
+    return Boolean(this.scopeDigest) && Boolean(window.crypto?.subtle)
   }
 
   get storageKey() {
-    return `draft:v1:${this.scope}:${draftKeyFor(this.element, this.keyValue)}`
+    return `draft:v1:${this.scopeDigest}:${draftKeyFor(this.element, this.keyValue)}`
   }
 
   get suppressKey() {
@@ -352,7 +352,7 @@ export default class extends Controller {
       const foreign = []
       for (let i = 0; i < localStorage.length; i += 1) {
         const key = localStorage.key(i)
-        if (key?.startsWith("draft:v1:") && !key.startsWith(`draft:v1:${this.scope}:`)) {
+        if (key?.startsWith("draft:v1:") && !key.startsWith(`draft:v1:${this.scopeDigest}:`)) {
           foreign.push(key)
         }
       }

--- a/test/render/form_draft_render_test.rb
+++ b/test/render/form_draft_render_test.rb
@@ -24,8 +24,12 @@ class FormDraftRenderTest < Minitest::Test
     assert_equal ["_form_draft_notice.html.erb", "form_draft_controller.js"], files
   end
 
+  # The chip's wrapper (including the hidden-until-revealed attribute) is
+  # built via tag.div's block form — not string interpolation in attribute-
+  # name position — so herb-lint's erb-no-output-in-attribute-name rule passes.
   def test_notice_chip_is_a_controller_target
-    assert_includes partial_source, 'data-form-draft-target="notice"'
+    assert_includes partial_source, 'form_draft_target: "notice"'
+    assert_includes partial_source, "hidden: !revealed"
   end
 
   def test_notice_chip_wears_the_warning_surface_treatment


### PR DESCRIPTION
## Bug

`form_draft_controller.js` assigns `this.scope` in `connect()`. Stimulus's `Controller` base class reserves `scope` as a getter-only accessor, so the assignment throws a `TypeError` in strict mode. Stimulus swallows the error and the rest of `connect()` never runs: no lifecycle listeners, no housekeeping, no notice reveal, and storage keys serialize as `draft:v1:[object Object]:…`. Autosave still fires via `data-action`, which made the breakage easy to miss.

**Impact: form_draft is non-functional in v0.6.0 and v0.7.0.** Recommend cutting v0.7.1 with this fix.

## Fix

Rename the instance property to `scopeDigest` at every site (connect assignment, `enabled` getter, `storageKey` getter, `housekeep`). The `form-draft-scope` meta-tag contract is unchanged. Audited every other `this.*` assignment in the controller against Stimulus's reserved members — no other collisions.

## Validation

- Found by modelrails_base's app-0b round-trip system specs (5/5 failing on v0.6.0's controller, 5/5 + 8/8 directory green with this fix; app copy byte-identical, MD5-verified).
- Gem suite: 899 runs, 0 failures.