### PR TITLE
v0.7.1: context-menu keyboard + range hit-area (2026-07 review)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,11 +7,27 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.7.1] - 2026-07-13
+
 ### Fixed
 
 - form_draft controller: rename instance property `scope` → `scopeDigest` — it collided with Stimulus's reserved `scope` getter, throwing on connect and disabling recovery entirely. form_draft is non-functional in v0.6.0 and v0.7.0.
 - form_draft controller: evaluateReveal hides an already-visible notice when a re-check finds no valid draft (expired drafts no longer leave a stale notice after a morph).
 - form_draft notice partial: build the chip wrapper with tag.div so the conditional hidden attribute passes herb-lint (erb-no-output-in-attribute-name).
+
+### Accessibility (follow-up review)
+
+- **context_menu trigger honors `role="button"`.** v0.7.0 added
+  `role="button"` (to satisfy axe `aria-allowed-attr`) but the trigger only
+  opened on Shift+F10 — a name-role-value promise it didn't keep (WCAG
+  4.1.2). It now wires `menu#triggerKeydown`, so Enter/Space/ArrowDown open
+  the menu (anchored to the trigger); right-click still opens at the pointer.
+- **range slider is a 44px hit box with a slim visible track.** v0.7.0's
+  batch omitted `range`, leaving its 8px track failing 2.5.5. Rather than
+  inflate the visible track to 44px (a fat pill), the input is now a
+  transparent 44px interaction box with a slim track painted via
+  `::-webkit-slider-runnable-track` / `::-moz-range-track` and a larger
+  (20px) thumb.
 
 ## [0.7.0] - 2026-07-06
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    modelrails_ui (0.7.0)
+    modelrails_ui (0.7.1)
       railties (>= 7.1)
       view_component (>= 4.0)
 
@@ -362,7 +362,7 @@ CHECKSUMS
   matrix (0.4.3) sha256=a0d5ab7ddcc1973ff690ab361b67f359acbb16958d1dc072b8b956a286564c5b
   mini_mime (1.1.5) sha256=8681b7e2e4215f2a159f9400b5816d85e9d8c6c6b491e96a12797e798f8bccef
   minitest (6.0.6) sha256=153ea36d1d987a62942382b61075745042a2b3123b1cd48f4c3675af9cc7d6f1
-  modelrails_ui (0.7.0)
+  modelrails_ui (0.7.1)
   net-imap (0.6.4.1) sha256=29f0360d75a7efd3539f16ac1957dea5c0a51ddeceb348db4553c3120914ea0d
   net-pop (0.1.2) sha256=848b4e982013c15b2f0382792268763b748cce91c9e91e36b0f27ed26420dff3
   net-protocol (0.2.2) sha256=aa73e0cba6a125369de9837b8d8ef82a61849360eba0521900e2c3713aa162a8

--- a/lib/generators/modelrails_ui/add/templates/context_menu/context_menu_component.rb.tt
+++ b/lib/generators/modelrails_ui/add/templates/context_menu/context_menu_component.rb.tt
@@ -99,13 +99,17 @@ module UI
     def trigger_region
       content_tag(:div, trigger,
         id: @trigger_id,
+        # role=button is a PROMISE the trigger honors — triggerKeydown opens
+        # the menu on Enter/Space/ArrowDown (anchored to the trigger), so
+        # keyboard users get button semantics, not just Shift+F10 / the
+        # ContextMenu key (openContextKey). Right-click opens at the pointer.
         role: "button",
         class: "select-none inline-flex min-h-11 min-w-11 items-center",
         tabindex: "0",
         "aria-haspopup": "menu",
         "aria-expanded": "false",
         "aria-controls": @id,
-        data: {menu_target: "trigger", action: "contextmenu->menu#openAt keydown->menu#openContextKey"})
+        data: {menu_target: "trigger", action: "contextmenu->menu#openAt keydown->menu#openContextKey keydown->menu#triggerKeydown"})
     end
 
     def menu_panel

--- a/lib/generators/modelrails_ui/add/templates/range/range_component.rb.tt
+++ b/lib/generators/modelrails_ui/add/templates/range/range_component.rb.tt
@@ -36,16 +36,23 @@ module UI
   #
   # No fail-loud guard — there's no enum axis to validate.
   class RangeComponent < ApplicationComponent
-    BASE = "w-full cursor-pointer appearance-none rounded-full bg-surface-sunken outline-none " \
-           "h-2 accent-interactive " \
-           "focus-ring " \
-           "aria-invalid:ring-danger " \
+    # 2.5.5: the INTERACTION box is 44px tall (h-11) so the whole control is a
+    # 44px pointer target — but transparent, so the VISIBLE track stays slim.
+    # (The original h-2 track was a slim 8px control that failed target size;
+    # a naive h-11 background would have been a fat 44px pill. This paints a
+    # slim track on ::-slider-runnable-track inside a 44px hit box — 2026-07
+    # a11y review.) The thumb is 20px, centered on the slim track (webkit
+    # `-mt-1.5` = -(20-8)/2 offsets it onto the 8px runnable-track).
+    BASE = "w-full h-11 cursor-pointer appearance-none bg-transparent outline-none " \
+           "focus-ring rounded aria-invalid:ring-1 aria-invalid:ring-danger " \
            "disabled:pointer-events-none disabled:opacity-50 " \
-           "[&::-webkit-slider-thumb]:size-4 [&::-webkit-slider-thumb]:appearance-none " \
+           "[&::-webkit-slider-runnable-track]:h-2 [&::-webkit-slider-runnable-track]:rounded-full [&::-webkit-slider-runnable-track]:bg-surface-sunken " \
+           "[&::-moz-range-track]:h-2 [&::-moz-range-track]:rounded-full [&::-moz-range-track]:bg-surface-sunken " \
+           "[&::-webkit-slider-thumb]:size-5 [&::-webkit-slider-thumb]:-mt-1.5 [&::-webkit-slider-thumb]:appearance-none " \
            "[&::-webkit-slider-thumb]:rounded-full [&::-webkit-slider-thumb]:bg-interactive " \
            "[&::-webkit-slider-thumb]:border-2 [&::-webkit-slider-thumb]:border-surface-raised " \
            "[&::-webkit-slider-thumb]:shadow-xs [&::-webkit-slider-thumb]:transition-[color,box-shadow] " \
-           "[&::-moz-range-thumb]:size-4 [&::-moz-range-thumb]:appearance-none " \
+           "[&::-moz-range-thumb]:size-5 [&::-moz-range-thumb]:appearance-none " \
            "[&::-moz-range-thumb]:rounded-full [&::-moz-range-thumb]:bg-interactive " \
            "[&::-moz-range-thumb]:border-2 [&::-moz-range-thumb]:border-surface-raised " \
            "[&::-moz-range-thumb]:border-solid [&::-moz-range-thumb]:shadow-xs"

--- a/lib/modelrails_ui/version.rb
+++ b/lib/modelrails_ui/version.rb
@@ -2,5 +2,5 @@
 
 module ModelrailsUi
   # modelrails_ui's own SemVer line (forked from view_primitives 0.1.0). See MODELRAILS_STATUS.md.
-  VERSION = "0.7.0"
+  VERSION = "0.7.1"
 end

--- a/test/render/range_render_test.rb
+++ b/test/render/range_render_test.rb
@@ -26,11 +26,18 @@ class RangeRenderTest < ViewComponent::TestCase
     assert_no_selector "input[type='range'][value]"
   end
 
-  # AAA semantic token (the design-token guarantee), not raw Tailwind:
+  # AAA semantic token (the design-token guarantee), not raw Tailwind: the
+  # visible track is painted on ::-webkit-slider-runnable-track with the
+  # semantic bg-surface-sunken token inside a transparent 44px hit box (v0.7.1
+  # redesign — `accent-interactive` is moot once appearance-none + a custom
+  # track/thumb replace the native accent).
   def test_renders_with_aaa_token
     render_inline(UI::RangeComponent.new)
 
-    assert_selector "input.accent-interactive"
+    assert_selector "input.bg-transparent.h-11"
+    # &-prefixed arbitrary variant is HTML-escaped in the attribute; match the
+    # unambiguous tail so the semantic token on the runnable-track is pinned.
+    assert_includes rendered_content, "slider-runnable-track]:bg-surface-sunken"
   end
 
   # invalid: drives a visible danger ring on the slider, not just aria-invalid.

--- a/test/test_target_size.rb
+++ b/test/test_target_size.rb
@@ -40,6 +40,26 @@ class TestTargetSize < Minitest::Test
     assert_includes template("context_menu/context_menu_component.rb.tt"), 'role: "button"'
   end
 
+  def test_context_menu_trigger_honors_button_activation
+    # role="button" is a name-role-value PROMISE — the trigger must open on
+    # Enter/Space, not only Shift+F10 (2026-07 review). triggerKeydown wires
+    # Enter/Space/ArrowDown.
+    assert_includes template("context_menu/context_menu_component.rb.tt"),
+      "keydown->menu#triggerKeydown",
+      "context_menu trigger must wire triggerKeydown so role=button is truthful"
+  end
+
+  def test_range_is_a_44px_hit_box_with_a_slim_track
+    src = template("range/range_component.rb.tt")
+
+    assert_includes src, "h-11", "range must have a 44px interaction box (2.5.5)"
+    assert_includes src, "bg-transparent", "range box must be transparent so the visible track stays slim"
+    assert_includes src, "[&::-webkit-slider-runnable-track]:h-2",
+      "range must paint a slim track on the runnable-track pseudo, not inflate the box"
+    refute_includes src, "h-2 accent-interactive",
+      "range must not put the slim height on the input itself (fails target size)"
+  end
+
   def test_sidebar_toggle_is_44px
     assert_includes template("sidebar/sidebar_component.rb.tt"), "size-11",
       "sidebar TOGGLE_CLS must be size-11"


### PR DESCRIPTION
Follow-up review of the v0.7.0 a11y batch surfaced two component defects.

- **context_menu trigger honors `role="button"`.** v0.7.0 added `role="button"` (to satisfy axe `aria-allowed-attr`) but the trigger only opened on Shift+F10 — a name-role-value promise it didn't keep (WCAG 4.1.2). It now wires `menu#triggerKeydown`, so Enter/Space/ArrowDown open the menu (anchored to the trigger); right-click still opens at the pointer.
- **range slider is a 44px hit box with a slim visible track.** v0.7.0's batch omitted `range`, leaving its 8px track failing 2.5.5. Rather than inflate the visible track to 44px (a fat pill), the input is now a transparent 44px interaction box with a slim track painted via `::-webkit-slider-runnable-track` / `::-moz-range-track` and a larger (20px) thumb.

`test_target_size` gains context-menu-honors-activation + range hit-box/slim-track guards; range render test updated. Both lanes green (500 structural + 899 render), RuboCop clean. **v0.7.0 → v0.7.1.**

🤖 Generated with [Claude Code](https://claude.com/claude-code)