### PR TITLE
feat(gallery): lightbox navigation + full_src (v0.8.0)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.8.0] - 2026-08-07
+
+### Added
+
+- Gallery: `full_src:` option lets the lightbox display a larger rendition than the grid thumbnail — lightbox previews auto-scale to fit the viewport while the full source remains clickable.
+- Gallery: `LightboxComponent` extracted as a standalone, reusable view component (previously lightbox logic was inline within GalleryComponent). The lightbox now ships prev/next buttons, arrow-key navigation (← / →), and a caption + counter bar (e.g., "2 / 8") rendered only when 2+ images are present.
+- Gallery: new `gallery:navigated` Stimulus event fired whenever the lightbox opens, moves to the previous image, or moves to the next image. Event detail includes `{index: N}` (0-based position in the gallery). Callers can listen to this event for analytics, logging, or coordinating with other UI.
+- Gallery: trigger contract now includes `gallery-index-param` and `gallery-caption-param` to support the new caption + counter rendering in the lightbox.
+- **Migration note:** Running `rails g modelrails_ui:add gallery` regenerates local copies and may overwrite your edits if you have drift. Diff before regenerating; manual integration of changes is safe.
+
 ## [0.7.1] - 2026-07-13
 
 ### Fixed

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    modelrails_ui (0.7.1)
+    modelrails_ui (0.8.0)
       railties (>= 7.1)
       view_component (>= 4.0)
 
@@ -362,7 +362,7 @@ CHECKSUMS
   matrix (0.4.3) sha256=a0d5ab7ddcc1973ff690ab361b67f359acbb16958d1dc072b8b956a286564c5b
   mini_mime (1.1.5) sha256=8681b7e2e4215f2a159f9400b5816d85e9d8c6c6b491e96a12797e798f8bccef
   minitest (6.0.6) sha256=153ea36d1d987a62942382b61075745042a2b3123b1cd48f4c3675af9cc7d6f1
-  modelrails_ui (0.7.1)
+  modelrails_ui (0.8.0)
   net-imap (0.6.4.1) sha256=29f0360d75a7efd3539f16ac1957dea5c0a51ddeceb348db4553c3120914ea0d
   net-pop (0.1.2) sha256=848b4e982013c15b2f0382792268763b748cce91c9e91e36b0f27ed26420dff3
   net-protocol (0.2.2) sha256=aa73e0cba6a125369de9837b8d8ef82a61849360eba0521900e2c3713aa162a8

--- a/docs/components/gallery.md
+++ b/docs/components/gallery.md
@@ -1,6 +1,8 @@
 # Gallery
 
-Responsive image grid with an optional click-to-enlarge lightbox.
+Responsive image grid with an optional click-to-enlarge lightbox. With more
+than one image, the lightbox gains prev/next buttons, a caption, and a
+counter ("1 / 3"); Left/Right arrow keys navigate too.
 
 Requires `gallery_controller.js` (copied automatically by the generator) when `lightbox: true`.
 
@@ -50,6 +52,77 @@ Creates `app/components/ui/gallery_component.rb`.
 <% end %>
 ```
 
+## Larger lightbox rendition (`full_src`)
+
+The grid cell always renders `src` (the thumbnail), so a small grid image is
+never upscaled full-screen. Pass `full_src` to swap in a larger rendition when
+the lightbox opens:
+
+```erb
+<%= ui :gallery do |g| %>
+  <% g.with_image(src: "/thumb/a.jpg", full_src: "/full/a.jpg", alt: "Mountain view") %>
+<% end %>
+```
+
+## Prev/next navigation
+
+With more than one image, the lightbox automatically gains prev/next buttons,
+a caption region, and a counter ("1 / 3"). Left/Right arrow keys navigate as
+well. With exactly one image, none of that nav renders.
+
+## Trigger contract
+
+Each grid cell is a `<button>` wired with `data-action="gallery#open modal#open"`
+and four Stimulus params, read by the `gallery` controller in DOM order via
+`[data-gallery-index-param]`:
+
+| Param | Type | Description |
+|---|---|---|
+| `gallery-index-param` | Integer | Position among triggers (0-based) |
+| `gallery-src-param` | String | Image src for the dialog swap (`full_src` if set, else `src`) |
+| `gallery-alt-param` | String | Alt text for the dialog `<img>` |
+| `gallery-caption-param` | String | Optional caption shown in the counter bar |
+
+Any element with this shape — not just `GalleryComponent`'s own cells — is a
+valid trigger, as long as it shares a `gallery modal` controller ancestor with
+the dialog.
+
+## Standalone `LightboxComponent`
+
+`UI::GalleryComponent::LightboxComponent` is the dialog on its own, for
+consumers that build their own triggers (e.g. a media stage that isn't a plain
+grid):
+
+```erb
+<div data-controller="gallery modal">
+  <% my_items.each_with_index do |item, i| %>
+    <button type="button" data-action="gallery#open modal#open"
+      data-gallery-index-param="<%= i %>" data-gallery-src-param="<%= item.full_src %>"
+      data-gallery-alt-param="<%= item.alt %>" data-gallery-caption-param="<%= item.caption %>">
+      <%= image_tag item.thumb %>
+    </button>
+  <% end %>
+
+  <%= render(UI::GalleryComponent::LightboxComponent.new(count: my_items.size)) %>
+</div>
+```
+
+`count` controls whether nav renders (`count > 1`); `label` sets an optional
+`aria-label` on the `<dialog>`.
+
+## `gallery:navigated` event
+
+The `gallery` controller dispatches a bubbling `gallery:navigated` custom
+event — `detail: { index }` — on every open, prev, and next. A host component
+(e.g. a media stage keeping a larger frame in sync) can listen for it instead
+of re-deriving the current index:
+
+```javascript
+document.addEventListener("gallery:navigated", (event) => {
+  console.log(event.detail.index)
+})
+```
+
 ## API
 
 ### GalleryComponent
@@ -65,6 +138,14 @@ Creates `app/components/ui/gallery_component.rb`.
 
 | Option | Type | Required | Description |
 |--------|------|----------|-------------|
-| `src` | String | Yes | Image URL |
+| `src` | String | Yes | Image URL (also the lightbox image, unless `full_src` is set) |
 | `alt` | String | Yes | Alternative text |
-| `caption` | String | No | Text shown on hover over the image |
+| `caption` | String | No | Text shown on hover over the image, and in the lightbox counter bar |
+| `full_src` | String | No | Larger rendition swapped in when the lightbox opens |
+
+### LightboxComponent
+
+| Option | Type | Default | Description |
+|--------|------|---------|-------------|
+| `count` | Integer | — | Total image count; nav/counter render only when `count > 1` |
+| `label` | String | `nil` | Optional `aria-label` on the `<dialog>` |

--- a/lib/generators/modelrails_ui/add/templates/gallery/gallery_component.rb.tt
+++ b/lib/generators/modelrails_ui/add/templates/gallery/gallery_component.rb.tt
@@ -5,7 +5,9 @@ module UI
     # Responsive image grid. With lightbox: true (default) each cell is a focusable
     # <button> that opens a single shared native <dialog> (the `modal` controller —
     # focus-trap/escape/restore for free). The `gallery` controller swaps the dialog
-    # image's src/alt before `modal#open` runs.
+    # image's src/alt/caption before `modal#open` runs, and — with more than one
+    # image — the dialog gains prev/next buttons and a counter bar
+    # (see `LightboxComponent`, standalone-renderable for bespoke consumers).
     #
     # Usage:
     #   ui :gallery, cols: 3 do |g|
@@ -29,8 +31,6 @@ module UI
     DIALOG_CLS  = "m-auto bg-transparent backdrop:bg-black/80 p-4"
     PANEL_CLS   = "relative opacity-0"
     LIGHTBOX_IMG_CLS = "max-h-[90vh] max-w-[90vw] rounded-md object-contain"
-    CLOSE_CLS   = "absolute -top-2 -right-2 inline-flex size-11 items-center justify-center " \
-                  "rounded-full bg-surface-overlay border border-border shadow-sm focus-ring"
 
     renders_many :images, "UI::GalleryComponent::ImageComponent"
 
@@ -53,8 +53,8 @@ module UI
       grid_attrs.merge!(@html_attrs)
 
       content_tag(:div, **grid_attrs) do
-        body = safe_join(images.map { |img| cell(img) })
-        @lightbox ? safe_join([body, lightbox_dialog]) : body
+        body = safe_join(images.each_with_index.map { |img, i| cell(img, i) })
+        @lightbox ? safe_join([body, render(LightboxComponent.new(count: images.size))]) : body
       end
     end
 
@@ -70,14 +70,17 @@ module UI
       end
     end
 
-    def cell(img)
+    def cell(img, idx)
       return plain_cell(img) unless @lightbox
 
       content_tag(:button, type: "button",
         class: cn(TRIGGER_CLS, @aspect),
         "aria-label": t("ui.gallery.enlarge", alt: img.alt, default: "Enlarge %{alt}"),
         data: { action: "gallery#open modal#open",
-                gallery_src_param: img.full_src || img.src, gallery_alt_param: img.alt }) do
+                gallery_index_param: idx,
+                gallery_src_param: img.full_src || img.src,
+                gallery_alt_param: img.alt,
+                gallery_caption_param: img.caption }) do
         caption_wrap(img)
       end
     end
@@ -94,27 +97,74 @@ module UI
       safe_join(inner)
     end
 
-    def lightbox_dialog
-      content_tag(:dialog, class: DIALOG_CLS, data: { modal_target: "dialog" }) do
-        content_tag(:div, class: PANEL_CLS, data: { modal_target: "panel" }) do
+    # Standalone-renderable lightbox: the gallery grid renders it automatically,
+    # and bespoke consumers (e.g. a media stage) can render it directly next to
+    # their own triggers. Requires `gallery modal` controllers on a shared
+    # ancestor. Nav renders only when count > 1.
+    class LightboxComponent < ApplicationComponent
+      NAV_CLS = "absolute top-1/2 -translate-y-1/2 inline-flex size-11 items-center justify-center " \
+                "rounded-full bg-surface-overlay border border-border shadow-sm focus-ring"
+      BAR_CLS = "mt-1 flex items-center justify-between gap-4 rounded-b-md bg-surface-overlay px-3 py-2"
+      CLOSE_CLS = "absolute -top-2 -right-2 inline-flex size-11 items-center justify-center " \
+                  "rounded-full bg-surface-overlay border border-border shadow-sm focus-ring"
+
+      def initialize(count:, label: nil)
+        @count = count
+        @label = label
+      end
+
+      def call
+        content_tag(:dialog, class: GalleryComponent::DIALOG_CLS,
+          "aria-label": @label,
+          data: { modal_target: "dialog",
+                  action: "keydown.left->gallery#prev keydown.right->gallery#next" }) do
+          content_tag(:div, class: GalleryComponent::PANEL_CLS, data: { modal_target: "panel" }) do
+            safe_join([
+              tag.img(class: GalleryComponent::LIGHTBOX_IMG_CLS, alt: "", data: { gallery_target: "image" }),
+              (nav_button(:prev) if @count > 1),
+              (nav_button(:next) if @count > 1),
+              close_button,
+              (counter_bar if @count > 1)
+            ].compact)
+          end
+        end
+      end
+
+      private
+
+      def nav_button(dir)
+        side = dir == :prev ? "-left-3" : "-right-3"
+        content_tag(:button, arrow_icon(dir), type: "button",
+          "aria-label": t("ui.gallery.#{dir}", default: dir == :prev ? "Previous image" : "Next image"),
+          class: cn(NAV_CLS, side), data: { action: "click->gallery##{dir}" })
+      end
+
+      def counter_bar
+        content_tag(:div, class: BAR_CLS) do
           safe_join([
-            tag.img(class: LIGHTBOX_IMG_CLS, alt: "", data: { gallery_target: "image" }),
-            close_button
+            content_tag(:span, "", class: "text-sm text-text-body min-w-0", data: { gallery_target: "caption" }),
+            content_tag(:span, "", class: "text-xs text-text-body tabular-nums shrink-0",
+              aria: { hidden: true }, data: { gallery_target: "count" })
           ])
         end
       end
-    end
 
-    def close_button
-      content_tag(:button, close_icon, type: "button",
-        "aria-label": t("ui.gallery.close", default: "Close"),
-        class: CLOSE_CLS, data: { action: "click->modal#close" })
-    end
+      def close_button
+        content_tag(:button, close_icon, type: "button",
+          "aria-label": t("ui.gallery.close", default: "Close"),
+          class: CLOSE_CLS, data: { action: "click->modal#close" })
+      end
 
-    def close_icon
-      raw('<svg xmlns="http://www.w3.org/2000/svg" width="20" height="20" viewBox="0 0 24 24" fill="none" ' \
-          'stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true">' \
-          '<path d="M18 6 6 18"/><path d="m6 6 12 12"/></svg>')
+      def arrow_icon(dir)
+        path = dir == :prev ? "m15 18-6-6 6-6" : "m9 18 6-6-6-6"
+        raw(%(<svg xmlns="http://www.w3.org/2000/svg" width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><path d="#{path}"/></svg>))
+      end
+
+      def close_icon
+        raw('<svg xmlns="http://www.w3.org/2000/svg" width="20" height="20" viewBox="0 0 24 24" fill="none" ' \
+            'stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true">' \
+            '<path d="M18 6 6 18"/><path d="m6 6 12 12"/></svg>')
+      end
     end
 
     class ImageComponent < ApplicationComponent

--- a/lib/generators/modelrails_ui/add/templates/gallery/gallery_component.rb.tt
+++ b/lib/generators/modelrails_ui/add/templates/gallery/gallery_component.rb.tt
@@ -77,7 +77,7 @@ module UI
         class: cn(TRIGGER_CLS, @aspect),
         "aria-label": t("ui.gallery.enlarge", alt: img.alt, default: "Enlarge %{alt}"),
         data: { action: "gallery#open modal#open",
-                gallery_src_param: img.src, gallery_alt_param: img.alt }) do
+                gallery_src_param: img.full_src || img.src, gallery_alt_param: img.alt }) do
         caption_wrap(img)
       end
     end
@@ -118,12 +118,15 @@ module UI
     end
 
     class ImageComponent < ApplicationComponent
-      attr_reader :src, :alt, :caption
+      attr_reader :src, :alt, :caption, :full_src
 
-      def initialize(src:, alt: "", caption: nil, **html_attrs)
-        @src     = src
-        @alt     = alt
-        @caption = caption
+      # full_src: optional larger rendition for the lightbox swap — the cell
+      # <img> keeps `src`, so a small grid thumb is never upscaled full-screen.
+      def initialize(src:, alt: "", caption: nil, full_src: nil, **html_attrs)
+        @src      = src
+        @alt      = alt
+        @caption  = caption
+        @full_src = full_src
         @html_attrs = html_attrs
       end
 

--- a/lib/generators/modelrails_ui/add/templates/gallery/gallery_controller.js
+++ b/lib/generators/modelrails_ui/add/templates/gallery/gallery_controller.js
@@ -1,13 +1,34 @@
 import { Controller } from "@hotwired/stimulus"
 
-// Thin coordinator: on a trigger click it sets the shared dialog image's src/alt,
-// then the SAME action string runs `modal#open` (focus-trap/escape/restore live in
-// the reused modal controller — see EXTRA_STIMULUS). No overlay is hand-built here.
+// Index-aware lightbox coordinator. Triggers are any [data-gallery-index-param]
+// elements inside this controller's scope, in DOM order. On open/prev/next it
+// swaps the shared dialog image's src/alt, updates caption + counter, and
+// dispatches "gallery:navigated" {index} so a host (e.g. a media stage) can
+// stay in sync. Focus-trap/escape/restore stay in the reused modal controller.
 export default class extends Controller {
-  static targets = ["image"]
+  static targets = ["image", "caption", "count"]
 
-  open({ params: { src, alt } }) {
+  open({ params: { index } }) {
+    this.show(index ?? 0)
+  }
+
+  prev() { this.show(this.index - 1) }
+  next() { this.show(this.index + 1) }
+
+  show(index) {
+    const items = this.items
+    if (items.length === 0) return
+    this.index = ((index % items.length) + items.length) % items.length
+    const { gallerySrcParam: src, galleryAltParam: alt, galleryCaptionParam: caption } =
+      items[this.index].dataset
     this.imageTarget.src = src
     this.imageTarget.alt = alt || ""
+    if (this.hasCaptionTarget) this.captionTarget.textContent = caption || ""
+    if (this.hasCountTarget) this.countTarget.textContent = `${this.index + 1} / ${items.length}`
+    this.dispatch("navigated", { detail: { index: this.index } })
+  }
+
+  get items() {
+    return [...this.element.querySelectorAll("[data-gallery-index-param]")]
   }
 }

--- a/lib/generators/modelrails_ui/lookbook/templates/previews/ui/gallery_component_preview.rb
+++ b/lib/generators/modelrails_ui/lookbook/templates/previews/ui/gallery_component_preview.rb
@@ -6,12 +6,15 @@ module UI
   # A responsive image grid. With `lightbox: true` (default) each cell is a
   # focusable `<button>` that opens a single shared native `<dialog>` (the reused
   # `modal` controller — focus-trap / Escape / restore for free). The `gallery`
-  # controller swaps the dialog image's `src`/`alt` before `modal#open` runs.
+  # controller swaps the dialog image's `src`/`alt`/caption before `modal#open`
+  # runs, and — with more than one image — the dialog gains prev/next buttons
+  # and a counter bar (`LightboxComponent`, also renderable standalone).
   #
   # ## Accessibility contract
   # - **Guarantees:** each enlargeable cell is a real `<button>` with an i18n
   #   accessible name ("Enlarge %{alt}") and the `focus-ring` utility; the lightbox
-  #   is a native focus-trapped `<dialog>` with an accessible close button.
+  #   is a native focus-trapped `<dialog>` with an accessible close button, and
+  #   (with 2+ images) accessible prev/next buttons plus Left/Right arrow keys.
   # - **You supply:** a non-blank `alt:` per image when lightbox is on (fail-loud).
   #
   # ## Related
@@ -22,6 +25,11 @@ module UI
 
     # A 3-up lightbox grid. Click (or keyboard-activate) any cell to enlarge it.
     def default
+    end
+
+    # Multiple images with captions: the lightbox shows prev/next nav, a
+    # caption, and a counter ("1 / 3"). Left/Right arrow keys also navigate.
+    def multiple_images
     end
   end
 end

--- a/lib/generators/modelrails_ui/lookbook/templates/previews/ui/gallery_component_preview/multiple_images.html.erb
+++ b/lib/generators/modelrails_ui/lookbook/templates/previews/ui/gallery_component_preview/multiple_images.html.erb
@@ -1,0 +1,9 @@
+<%# Three captioned images so the lightbox's prev/next buttons, counter bar %>
+<%# ("1 / 3"), and per-image caption are all visible when a cell is opened. %>
+<div data-test="gallery">
+  <%= render(UI::GalleryComponent.new(cols: 3)) do |g| %>
+    <% g.with_image(src: "https://picsum.photos/id/1018/600/600", alt: "Forest canopy", caption: "Forest canopy") %>
+    <% g.with_image(src: "https://picsum.photos/id/1071/600/600", alt: "City street", caption: "Downtown") %>
+    <% g.with_image(src: "https://picsum.photos/id/1016/600/600", alt: "Mountain lake", caption: "Mountain lake") %>
+  <% end %>
+</div>

--- a/lib/modelrails_ui/version.rb
+++ b/lib/modelrails_ui/version.rb
@@ -2,5 +2,5 @@
 
 module ModelrailsUi
   # modelrails_ui's own SemVer line (forked from view_primitives 0.1.0). See MODELRAILS_STATUS.md.
-  VERSION = "0.7.1"
+  VERSION = "0.8.0"
 end

--- a/test/render/gallery_render_test.rb
+++ b/test/render/gallery_render_test.rb
@@ -78,4 +78,47 @@ class GalleryRenderTest < ViewComponent::TestCase
     assert_selector "button[data-gallery-src-param='/big.jpg']"
     assert_selector "img[src='/thumb.jpg']"
   end
+
+  def multi_image_gallery
+    render_inline(UI::GalleryComponent.new) do |g|
+      g.with_image(src: "/a.jpg", alt: "A", caption: "First")
+      g.with_image(src: "/b.jpg", alt: "B")
+    end
+  end
+
+  def test_lightbox_with_multiple_images_renders_prev_and_next_buttons
+    multi_image_gallery
+
+    assert_selector "dialog button[data-action='click->gallery#prev']", visible: :all
+    assert_selector "dialog button[data-action='click->gallery#next']", visible: :all
+  end
+
+  def test_lightbox_with_multiple_images_renders_caption_and_count_targets
+    multi_image_gallery
+
+    assert_selector "dialog [data-gallery-target='caption']", visible: :all
+    assert_selector "dialog [data-gallery-target='count']", visible: :all
+  end
+
+  def test_lightbox_triggers_carry_index_params_in_dom_order
+    multi_image_gallery
+
+    assert_selector "button[data-gallery-index-param='0']"
+    assert_selector "button[data-gallery-index-param='1']"
+  end
+
+  def test_lightbox_with_a_single_image_renders_no_nav
+    render_inline(UI::GalleryComponent.new) do |g|
+      g.with_image(src: "/a.jpg", alt: "A")
+    end
+
+    assert_no_selector "dialog button[data-action='click->gallery#prev']", visible: :all
+  end
+
+  def test_lightbox_component_renders_standalone
+    render_inline(UI::GalleryComponent::LightboxComponent.new(count: 3))
+
+    assert_selector "dialog[data-modal-target='dialog']", visible: :all
+    assert_selector "dialog button[data-action='click->gallery#next']", visible: :all
+  end
 end

--- a/test/render/gallery_render_test.rb
+++ b/test/render/gallery_render_test.rb
@@ -69,4 +69,13 @@ class GalleryRenderTest < ViewComponent::TestCase
 
     assert_match(/alt/, error.message)
   end
+
+  def test_lightbox_trigger_prefers_full_src_over_src_for_the_dialog_swap
+    render_inline(UI::GalleryComponent.new) do |g|
+      g.with_image(src: "/thumb.jpg", full_src: "/big.jpg", alt: "A photo")
+    end
+
+    assert_selector "button[data-gallery-src-param='/big.jpg']"
+    assert_selector "img[src='/thumb.jpg']"
+  end
 end

--- a/test/test_generator_components.rb
+++ b/test/test_generator_components.rb
@@ -367,13 +367,16 @@ class TestGeneratorComponents < Minitest::Test
     assert_includes source, "gallery"
   end
 
-  def test_gallery_controller_is_a_thin_open_coordinator
+  def test_gallery_controller_is_an_index_aware_open_prev_next_coordinator
     js = File.read(File.join(TEMPLATE_ROOT, "gallery", "gallery_controller.js"))
 
     # Hardened: opening swaps the shared <dialog> image; the reused `modal`
     # controller owns close/escape/restore (no colocated close here).
     assert_includes js, "open("
-    assert_includes js, 'static targets = ["image"]'
+    assert_includes js, "prev("
+    assert_includes js, "next("
+    assert_includes js, 'static targets = ["image", "caption", "count"]'
+    assert_includes js, 'this.dispatch("navigated"'
   end
 
   def test_carousel_has_slides_and_controller


### PR DESCRIPTION
## Summary

Gallery component enhancements for lightbox media browsing:

- **Full-source rendering:** `full_src:` option lets the lightbox display a higher-quality rendition than the grid thumbnail
- **Standalone lightbox component:** extracted `UI::GalleryComponent::LightboxComponent` with previous/next navigation, arrow-key support, and a caption + counter bar (renders only when 2+ images present)
- **New stimulus event:** `gallery:navigated` fires on open/prev/next with `detail: {index}` for analytics and UI coordination
- **Enhanced trigger contract:** `gallery-index-param` and `gallery-caption-param` support the new counter + caption rendering

## New Public Interface

- `UI::GalleryComponent::LightboxComponent.new(count:, label:)` — standalone reusable lightbox component
- Stimulus trigger element attributes: `gallery-index-param`, `gallery-caption-param`
- Stimulus event: `gallery:navigated` with `event.detail.index` (0-based)

## Migration Note

Apps with local gallery component drift should diff before regenerating:
```
rails g modelrails_ui:add gallery
```

The generator overwrites all local copies — safe after reviewing changes.

## Test Results

- Full test suite: **905 runs, 1370 assertions, 0 failures** ✓
- RuboCop: **217 files, no offenses** ✓

## Commits Included

1. Full source rendering support
2. Lightbox navigation + standalone component
3. Release: v0.8.0