### PR TITLE
feat(file_input): opt-in selection display for multi-file inputs

### DIFF
--- a/docs/components/file_input.md
+++ b/docs/components/file_input.md
@@ -32,6 +32,46 @@ Creates `app/components/ui/file_input_component.rb`.
 <%= ui :file_input, name: "attachments[]", multiple: true %>
 ```
 
+## Showing which files are selected
+
+A native `<input type="file" multiple>` only shows a count — "3 files" — never
+which files. `show_selection: true` fixes that dead end: the input is wrapped with
+a pill list (one badge-style chip per file name) and an sr-only live region, kept
+in sync by the vendored `file-input` Stimulus controller. Re-selecting replaces
+the pills; clearing the selection hides the list and announces the `none` string.
+
+```erb
+<%= ui :file_input, name: "attachments[]", multiple: true, show_selection: true %>
+```
+
+The default mode (no `show_selection:`) still renders the bare `<input>`,
+unchanged.
+
+### Selection strings (`selection_labels:`)
+
+The announcement/label strings are host-supplied (i18n lives in your app; the
+defaults are English). Pass any subset — it merges over the defaults:
+
+```erb
+<%= ui :file_input, name: "attachments[]", multiple: true, show_selection: true,
+      selection_labels: {
+        one:  t("uploads.one_selected"),   # e.g. "1 file selected: %{names}"
+        many: t("uploads.many_selected"),  # e.g. "%{count} files selected: %{names}"
+        none: t("uploads.none_selected")   # e.g. "No files selected"
+      } %>
+```
+
+`%{count}` and `%{names}` are substituted client-side (names joined with `", "`),
+so keep the placeholders literal in your locale files.
+
+### Design note: why the live region is separate from the list
+
+The sr-only status `<span aria-live="polite">` is always present in the DOM, even
+while empty. A live region that exists from page load announces reliably;
+un-hiding an already-populated live region often does not. The visible pill list
+is therefore a separate element that starts `hidden` and carries no live-region
+semantics.
+
 ## With FormField
 
 ```erb
@@ -46,4 +86,6 @@ Creates `app/components/ui/file_input_component.rb`.
 |--------|------|---------|-------------|
 | `accept` | String | `nil` | MIME types or file extensions, e.g. `"image/*"` or `".pdf,.docx"` |
 | `multiple` | Boolean | `false` | Allow selecting multiple files |
+| `show_selection` | Boolean | `false` | Also render the selected file names as pills plus an sr-only announcement (Stimulus `file-input` controller); default is the bare input, unchanged |
+| `selection_labels` | Hash | `{}` | Selection strings merged over the English defaults (i18n; defaults to `one: "1 file selected: %{names}"`, `many: "%{count} files selected: %{names}"`, `none: "No files selected"`) |
 | `**html_attrs` | Hash | — | Forwarded to the `<input type="file">` element |

--- a/lib/generators/modelrails_ui/add/templates/file_input/file_input_component.rb.tt
+++ b/lib/generators/modelrails_ui/add/templates/file_input/file_input_component.rb.tt
@@ -12,20 +12,64 @@ module UI
            "disabled:cursor-not-allowed disabled:opacity-50 " \
            "aria-invalid:border-danger-border aria-invalid:ring-danger"
 
+    # Per-file pill for the show_selection list: the badge chip shape plus the
+    # proven [:soft, :primary] color cell (bg-interactive-subtle + text-interactive
+    # — the same AAA pairing UI::BadgeComponent ships; badges have no soft-neutral
+    # cell, and inventing a new color pairing here is off-limits).
+    PILL = "inline-flex w-fit shrink-0 items-center justify-center gap-1 overflow-hidden rounded-full " \
+           "border border-transparent px-2 py-0.5 text-xs font-medium whitespace-nowrap " \
+           "bg-interactive-subtle text-interactive"
+
+    # English fallbacks for the selection strings; hosts pass translated strings
+    # via `selection_labels:` (i18n lives in the host app, not the gem).
+    DEFAULT_SELECTION_LABELS = {
+      one: "1 file selected: %{names}",
+      many: "%{count} files selected: %{names}",
+      none: "No files selected"
+    }.freeze
+
     # accept:   MIME types or extensions, e.g. "image/*" or ".pdf,.docx"
     # multiple: allow selecting multiple files
     # required/invalid/describedby: form + a11y wiring (see UI::InputComponent)
-    def initialize(accept: nil, multiple: false, required: false, invalid: false, describedby: nil, **html_attrs)
+    # show_selection:   also render the selected file names as pills plus an sr-only
+    #                   live-region announcement, synced by the `file-input` Stimulus
+    #                   controller (default false = bare input, byte-unchanged) —
+    #                   the native control alone only shows a count ("3 files")
+    # selection_labels: host-supplied strings merged over DEFAULT_SELECTION_LABELS
+    #                   (i18n; e.g. `{ many: t("uploads.many_selected") }` with
+    #                   `%{count}`/`%{names}` placeholders)
+    def initialize(accept: nil, multiple: false, required: false, invalid: false, describedby: nil,
+                   show_selection: false, selection_labels: {}, **html_attrs)
       @accept = accept
       @multiple = multiple
       @required = required
       @invalid = invalid
       @describedby = describedby
+      @show_selection = show_selection
+      @selection_labels = DEFAULT_SELECTION_LABELS.merge(selection_labels.transform_keys(&:to_sym))
       @extra_class = html_attrs.delete(:class)
       @html_attrs = html_attrs
     end
 
     def call
+      # Default: a bare native input (output byte-identical to the pre-selection
+      # component). With `show_selection:` the input is wrapped with the pill list,
+      # pill <template>, and sr-only status region the `file-input` controller drives.
+      return content_tag(:input, nil, **input_attrs, **@html_attrs) unless @show_selection
+
+      content_tag(:div, data: {
+        controller: "file-input",
+        file_input_one_value: @selection_labels[:one],
+        file_input_many_value: @selection_labels[:many],
+        file_input_none_value: @selection_labels[:none]
+      }) do
+        safe_join([wired_input, selection_list, pill_template, status_region])
+      end
+    end
+
+    private
+
+    def input_attrs
       attrs = { type: "file", class: cn(BASE, @extra_class) }
       attrs[:accept] = @accept if @accept
       attrs[:multiple] = true if @multiple
@@ -35,7 +79,37 @@ module UI
       end
       attrs["aria-invalid"] = "true" if @invalid
       attrs["aria-describedby"] = @describedby if @describedby.present?
-      content_tag(:input, nil, **attrs, **@html_attrs)
+      attrs
+    end
+
+    # The input keeps every attr it has in bare mode; the controller wiring is
+    # merged into `data:` so a caller-supplied `data:` hash survives.
+    def wired_input
+      attrs = input_attrs.merge(@html_attrs)
+      attrs[:data] = (attrs[:data] || {}).merge(
+        file_input_target: "input", action: "change->file-input#update"
+      )
+      content_tag(:input, nil, **attrs)
+    end
+
+    # Starts hidden; the controller un-hides it only while it holds pills.
+    def selection_list
+      content_tag(:ul, nil, hidden: true, class: "mt-2 flex flex-wrap gap-1.5",
+        data: { file_input_target: "list" })
+    end
+
+    def pill_template
+      content_tag(:template, data: { file_input_target: "pill" }) do
+        content_tag(:li, nil, class: PILL)
+      end
+    end
+
+    # Always present in the DOM: a live region that exists from page load announces
+    # reliably; un-hiding a populated one does not — so status is separate from the
+    # visible list.
+    def status_region
+      content_tag(:span, nil, class: "sr-only", "aria-live": "polite",
+        data: { file_input_target: "status" })
     end
   end
 end

--- a/lib/generators/modelrails_ui/add/templates/file_input/file_input_controller.js
+++ b/lib/generators/modelrails_ui/add/templates/file_input/file_input_controller.js
@@ -1,0 +1,33 @@
+import { Controller } from "@hotwired/stimulus"
+
+// Shows WHICH files a file input has selected — the native control only shows a count
+// ("3 files"). On change: one pill per file into the list (cloned from the <template>),
+// and the selection mirrored into the always-present sr-only status live region.
+// INVARIANT: file names are written via textContent, never innerHTML — names are
+// user-controlled. The one/many/none values are host-supplied strings with
+// %{count}/%{names} placeholders.
+export default class extends Controller {
+  static targets = ["input", "list", "pill", "status"]
+  static values = { one: String, many: String, none: String }
+
+  update() {
+    const files = Array.from(this.inputTarget.files)
+    this.listTarget.replaceChildren(...files.map((file) => this.#pill(file.name)))
+    this.listTarget.hidden = files.length === 0
+    this.statusTarget.textContent = this.#announcement(files)
+  }
+
+  #pill(name) {
+    const pill = this.pillTarget.content.firstElementChild.cloneNode(true)
+    pill.textContent = name
+    return pill
+  }
+
+  #announcement(files) {
+    if (files.length === 0) return this.noneValue
+    const template = files.length === 1 ? this.oneValue : this.manyValue
+    return template
+      .replaceAll("%{count}", String(files.length))
+      .replaceAll("%{names}", files.map((file) => file.name).join(", "))
+  }
+}

--- a/lib/generators/modelrails_ui/lookbook/templates/previews/ui/file_input_component_preview.rb
+++ b/lib/generators/modelrails_ui/lookbook/templates/previews/ui/file_input_component_preview.rb
@@ -47,6 +47,13 @@ module UI
     def multiple
     end
 
+    # Shows WHICH files are selected — the native control alone only shows a count
+    # ("3 files"). Renders one soft pill per file name plus an sr-only live-region
+    # announcement, synced by the vendored `file-input` Stimulus controller. Pass
+    # host-app translations via `selection_labels:`.
+    def show_selection
+    end
+
     # @!endgroup
 
     # @!group Reference

--- a/lib/generators/modelrails_ui/lookbook/templates/previews/ui/file_input_component_preview/show_selection.html.erb
+++ b/lib/generators/modelrails_ui/lookbook/templates/previews/ui/file_input_component_preview/show_selection.html.erb
@@ -1,0 +1,1 @@
+<%= ui :file_input, name: "demo_attachments[]", multiple: true, show_selection: true %>

--- a/test/render/file_input_render_test.rb
+++ b/test/render/file_input_render_test.rb
@@ -101,4 +101,106 @@ class FileInputRenderTest < ViewComponent::TestCase
 
     assert_no_selector "input[aria-describedby]"
   end
+
+  # --- show_selection: opt-in file-name display (STRUCTURE) ---
+  # No JS runtime in render tests, so we assert the Stimulus wiring
+  # (data-controller / values / targets / action) like range's show_value tests.
+
+  # Default (show_selection omitted) is byte-unchanged: bare <input>, no wrapper.
+  def test_default_renders_no_selection_wrapper
+    render_inline(UI::FileInputComponent.new)
+
+    assert_no_selector "[data-controller='file-input']"
+    assert_no_selector "div"
+  end
+
+  def test_default_renders_no_selection_list_template_or_live_region
+    render_inline(UI::FileInputComponent.new)
+
+    assert_no_selector "ul", visible: :all
+    assert_no_selector "template", visible: :all
+    assert_no_selector "[aria-live]", visible: :all
+  end
+
+  def test_show_selection_wraps_input_in_file_input_controller
+    render_inline(UI::FileInputComponent.new(show_selection: true))
+
+    assert_selector "div[data-controller='file-input'] input[type='file']"
+  end
+
+  def test_show_selection_wires_input_target_and_change_action
+    render_inline(UI::FileInputComponent.new(show_selection: true))
+
+    assert_selector "input[data-file-input-target='input'][data-action~='change->file-input#update']"
+  end
+
+  def test_show_selection_carries_default_english_label_values
+    render_inline(UI::FileInputComponent.new(show_selection: true))
+
+    assert_selector "div[data-file-input-one-value='1 file selected: %{names}']"
+    assert_selector "div[data-file-input-many-value='%{count} files selected: %{names}']"
+    assert_selector "div[data-file-input-none-value='No files selected']"
+  end
+
+  # selection_labels merges over the English defaults (host supplies i18n strings).
+  def test_selection_labels_override_reaches_the_data_values
+    render_inline(UI::FileInputComponent.new(
+      show_selection: true,
+      selection_labels: {many: "%{count} Dateien: %{names}", none: "Keine Dateien"}
+    ))
+
+    assert_selector "div[data-file-input-many-value='%{count} Dateien: %{names}']"
+    assert_selector "div[data-file-input-none-value='Keine Dateien']"
+    assert_selector "div[data-file-input-one-value='1 file selected: %{names}']"
+  end
+
+  # The list starts hidden (the controller un-hides it once it holds pills).
+  def test_show_selection_renders_hidden_list_target
+    render_inline(UI::FileInputComponent.new(show_selection: true))
+
+    assert_selector "ul[data-file-input-target='list'][hidden]", visible: :all
+  end
+
+  # Pill template reuses the badge soft chip treatment (proven AAA pairing:
+  # bg-interactive-subtle + text-interactive — the badge [:soft, :primary] cell).
+  # Capybara's HTML5 parse makes <template> content an inert fragment, so we
+  # reach the pill through an HTML4 Nokogiri parse of the rendered output.
+  def test_show_selection_pill_template_uses_badge_soft_chip_tokens
+    render_inline(UI::FileInputComponent.new(show_selection: true))
+
+    pill = Nokogiri::HTML4.fragment(rendered_content)
+      .at_css("template[data-file-input-target=pill] > li")
+
+    refute_nil pill
+    %w[rounded-full bg-interactive-subtle text-interactive].each do |token|
+      assert_includes pill["class"].split, token
+    end
+  end
+
+  # The sr-only status live region is ALWAYS present in the DOM (a live region
+  # that exists from page load announces reliably; un-hiding a populated one
+  # does not — which is why status is separate from the visible list).
+  def test_show_selection_renders_always_present_sr_only_live_region
+    render_inline(UI::FileInputComponent.new(show_selection: true))
+
+    assert_selector "span.sr-only[aria-live='polite'][data-file-input-target='status']"
+  end
+
+  # All existing attrs/html_attrs still land on the INPUT in wrapper mode.
+  def test_show_selection_keeps_input_attrs_and_html_attrs_on_the_input
+    render_inline(UI::FileInputComponent.new(
+      show_selection: true, accept: "image/*", multiple: true, required: true,
+      invalid: true, describedby: "gallery_error", name: "photos[]", id: "photos"
+    ))
+
+    assert_selector "div[data-controller='file-input'] " \
+      "input[type='file'][accept='image/*'][multiple][required][aria-required='true']" \
+      "[aria-invalid='true'][aria-describedby='gallery_error'][name='photos[]'][id='photos']"
+  end
+
+  def test_show_selection_keeps_aaa_tokens_on_the_input
+    render_inline(UI::FileInputComponent.new(show_selection: true))
+
+    assert_selector "div[data-controller='file-input'] input.block.w-full.text-text-body"
+  end
 end


### PR DESCRIPTION
Native `<input type="file" multiple>` shows only a count ("3 files"), never which files — in every browser. `UI::FileInputComponent` exposes `multiple:` but left that dead end for any host app using it.

## What this adds

`show_selection: true` (default `false` — the bare-input render is unchanged, proven by tests) wraps the input with a small component-own Stimulus controller that:

- renders a pill per selected file name, cloned from a `<template>` so tokens stay server-side; names go in via `textContent` only
- announces the selection through an **always-present** sr-only `aria-live="polite"` region, deliberately separate from the visible list (un-hiding a populated live region announces unreliably)
- handles re-selection (list replaced) and cancel/deselect (list cleared and re-hidden, "none" announcement)

`selection_labels:` takes host-supplied strings merged over English defaults (`one:` / `many:` / `none:` with `%{count}`/`%{names}` placeholders) — i18n lives in the host app, same pattern as toaster's `label:`.

Pill colors reuse the proven badge `[:soft, :primary]` cell (`bg-interactive-subtle text-interactive`) — no new AAA pairing is introduced, so no new proof rows needed. `html_attrs` and caller `data:` still land on the input in wrapper mode. The controller auto-vendors via the existing per-template-dir mechanism (not shared — no `EXTRA_STIMULUS` entry).

## Verification

Render tests written red-first (9 failing before implementation, now 11 new tests green). Full suite: render 526 runs / 2169 assertions, structural 917 runs / 1395 assertions, 0 failures. Rubocop clean (217 files). Docs page updated and a Lookbook `show_selection` scenario included. One test asserts `<template>` content via Nokogiri fragment parsing (Capybara treats template content as inert).

Downstream: modelrails_base adopts the vendored copy (with a JS-driving system spec + axe AAA proof in both themes) in its companion PR.

Prompted by danielabaron.me's write-up on displaying file names for multi-file inputs with Stimulus, adapted to the design system's a11y and token standards.