### PR TITLE
fix(agent-rules): contrast bullet reflects the local-by-default AAA audit

### DIFF
--- a/lib/generators/modelrails_ui/agent_rules/templates/agent-rules.md
+++ b/lib/generators/modelrails_ui/agent_rules/templates/agent-rules.md
@@ -52,8 +52,9 @@ Defer to it instead of inventing UI from scratch.
 
 ## Before you call UI work done
 - **Check both themes** — light *and* dark (class-based dark mode).
-- **Contrast is proven in CI, not locally** — a local axe pass is AA-only; don't claim AAA
-  from a local run.
+- **Contrast is proven by the axe gate, not by eyeballing** — the reference host runs the
+  WCAG 2.2 AAA audit locally by default (both themes, each set explicitly) and again in CI;
+  don't claim AAA until that gate has passed on your change.
 - **Fail loud, don't fabricate.** If a needed token or primitive seems missing, surface it —
   don't invent a raw-value or contrast workaround.
 - **Check adoption drift** — `rake modelrails_ui:adoption` shows which components this app


### PR DESCRIPTION
The generator template's "Before you call UI work done" section still taught the pre-#542 posture — "Contrast is proven in CI, not locally — a local axe pass is AA-only." That was true when written; modelrails_base inverted it on 2026-08-02: issue base#541 exposed that the CI-gated audit was missing real AAA violations (the base#540 badge fix is the incident that slipped through), and base PR #542 made the axe AAA audit run locally by default, both themes, each set explicitly, with CI as the second proof.

Until this lands and hosts regenerate, every `bin/rails g modelrails_ui:agent_rules` output actively contradicts the reference host's real gate — telling agents a local AAA failure can't be trusted, when it's now exactly the signal to act on.

One bullet changed; `bundle exec rake` green (217 files, no offenses). Hosts pick it up on their next `agent_rules` regenerate after release.