### PR TITLE
fix(release): sync Gemfile.lock to v0.9.0

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    modelrails_ui (0.8.0)
+    modelrails_ui (0.9.0)
       railties (>= 7.1)
       view_component (>= 4.0)
 
@@ -362,7 +362,7 @@ CHECKSUMS
   matrix (0.4.3) sha256=a0d5ab7ddcc1973ff690ab361b67f359acbb16958d1dc072b8b956a286564c5b
   mini_mime (1.1.5) sha256=8681b7e2e4215f2a159f9400b5816d85e9d8c6c6b491e96a12797e798f8bccef
   minitest (6.0.6) sha256=153ea36d1d987a62942382b61075745042a2b3123b1cd48f4c3675af9cc7d6f1
-  modelrails_ui (0.8.0)
+  modelrails_ui (0.9.0)
   net-imap (0.6.4.1) sha256=29f0360d75a7efd3539f16ac1957dea5c0a51ddeceb348db4553c3120914ea0d
   net-pop (0.1.2) sha256=848b4e982013c15b2f0382792268763b748cce91c9e91e36b0f27ed26420dff3
   net-protocol (0.2.2) sha256=aa73e0cba6a125369de9837b8d8ef82a61849360eba0521900e2c3713aa162a8


### PR DESCRIPTION
The v0.9.0 release commit (4640462) bumped `lib/modelrails_ui/version.rb` to 0.9.0 without regenerating `Gemfile.lock`, which still records `modelrails_ui (0.8.0)`. Bundler's frozen mode therefore fails **every CI job at setup** ("The gemspecs for path gems changed, but the lockfile can't be updated because frozen mode is set", exit 16) on any branch cut from main — first observed on PR #88, whose one-file docs change couldn't plausibly break six jobs in 7 seconds. No CI ran on main between the release push and now, so the drift went unnoticed.

Two-line fix: the lockfile's PATH spec now says 0.9.0.

**Merge this before #88** — #88 will go green once its base includes this (I'll update the branch after this lands).