### PR TITLE
feat(overlays): shared ES modules + back-port of the overlay arc

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,8 +11,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Generator: shared ES modules. A component can now ship a plain module alongside its Stimulus controller (`Components::SHARED_JS`), copied to `app/javascript/<namespace>/` with the importmap pin added automatically. Needed for behaviour that must be a SINGLE instance across components — a per-component controller copy cannot provide it. First user: `top_layer.js`.
 
+- Overlays reach the browser top layer. `sticky`/`backdrop-blur` chrome establishes a stacking context that no z-index escapes from the inside; promoted panels paint above it. Promotion is gated on the panel already being `position: fixed`, because the top layer re-parents an element's containing block to the viewport — an `absolute`-placed panel would be torn off its trigger.
+- Popover, combobox, date_picker, timepicker, navigation_menu and mega_menu now place with CSS anchor positioning (`anchor-name`/`position-anchor` + `position-area` + `position-try-fallbacks`), matching dropdown_menu and menubar_menu. Panels flip to stay on-screen where the old static offsets clipped. Width-tied panels (combobox, mega_menu) take their width from `anchor-size(width)`.
+- DropdownMenu: checkable items (`checkbox:`/`radio:` → `menuitemcheckbox`/`menuitemradio` with `aria-checked`), which toggle in place and keep the menu open; `tone: :danger` for destructive actions; and nested submenus via `with_item(submenu: "…")`.
+
 ### Fixed
 
+- Popover `side: :left`/`:right` rendered the panel ON its trigger instead of beside it. The old maps emitted both `left-0` and `right-full`, and CSS drops `right` when left, width and right are all set. Anchor positioning replaces the pair with one cell per placement, and every `side` × `align` cell is now covered by a test.
+- Combobox emitted a hardcoded listbox id, so two comboboxes on a page produced duplicate ids and `aria-controls` resolved to whichever rendered first. Ids are now per-instance. **UI::Command still has this bug.**
 - Generator no longer drops unrecognised template files silently — it says which file it skipped. A plain `.js` in a template directory used to vanish with no warning and no pin, leaving a bare-specifier import that throws at runtime.
 
 ## [0.9.0] - 2026-08-16

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- Generator: shared ES modules. A component can now ship a plain module alongside its Stimulus controller (`Components::SHARED_JS`), copied to `app/javascript/<namespace>/` with the importmap pin added automatically. Needed for behaviour that must be a SINGLE instance across components — a per-component controller copy cannot provide it. First user: `top_layer.js`.
+
+### Fixed
+
+- Generator no longer drops unrecognised template files silently — it says which file it skipped. A plain `.js` in a template directory used to vanish with no warning and no pin, leaving a bare-specifier import that throws at runtime.
+
 ## [0.9.0] - 2026-08-16
 
 ### Added

--- a/lib/generators/modelrails_ui/add/add_generator.rb
+++ b/lib/generators/modelrails_ui/add/add_generator.rb
@@ -73,6 +73,7 @@ module ModelrailsUi
         dir = File.join(self.class.source_root, name)
         Dir.each_child(dir).sort.each { |file| copy_template_file(name, file) }
         copy_extra_stimulus(name)
+        copy_shared_js(name)
       end
 
       def copy_template_file(component, file)
@@ -85,6 +86,13 @@ module ModelrailsUi
           copy_file source, html_erb_destination(file)
         when /_controller\.js\z/
           copy_js_controller source, file.delete_suffix("_controller.js")
+        when /\.js\z/
+          # Shared ES module — placed via Components::SHARED_JS, not from here, because
+          # several components share one copy. Nothing to do on this pass.
+        else
+          # Never drop a template file silently: a new kind of asset that nobody taught
+          # the generator about is a bug, and used to vanish without a word.
+          say "  Skipped #{source} — unrecognised template file type.", :yellow
         end
       end
 
@@ -98,6 +106,43 @@ module ModelrailsUi
       def copy_extra_stimulus(name)
         config = Components::EXTRA_STIMULUS[name]
         copy_js_controller(config[:source], config[:name]) if config
+      end
+
+      def copy_shared_js(name)
+        Array(Components::SHARED_JS[name]).each do |mod|
+          copy_file mod.fetch(:source), shared_js_destination(mod)
+          pin_shared_js(mod.fetch(:dir))
+        end
+      end
+
+      def shared_js_destination(mod)
+        "app/javascript/#{mod.fetch(:dir)}/#{File.basename(mod.fetch(:source))}"
+      end
+
+      def shared_js_pin(dir)
+        %(pin_all_from "app/javascript/#{dir}", under: "#{dir}")
+      end
+
+      # The module is imported by bare specifier, so without the pin the controller throws
+      # on import and silently never connects. Add it rather than print an instruction —
+      # a missed manual step here is invisible until something stops working.
+      def pin_shared_js(dir)
+        importmap = "config/importmap.rb"
+        pin = shared_js_pin(dir)
+
+        unless File.exist?(File.join(destination_root, importmap))
+          say "  No #{importmap} — add this to your JS entry point yourself:", :yellow
+          say "    #{pin}", :cyan
+          return
+        end
+
+        if File.read(File.join(destination_root, importmap)).include?(pin)
+          say "  importmap already pins #{dir}", :green
+          return
+        end
+
+        append_to_file importmap, "\n#{pin}\n"
+        say "  importmap → #{pin}", :green
       end
 
       def copy_js_controller(source, stimulus_name)

--- a/lib/generators/modelrails_ui/add/templates/combobox/combobox_component.rb.tt
+++ b/lib/generators/modelrails_ui/add/templates/combobox/combobox_component.rb.tt
@@ -35,8 +35,13 @@ module UI
     # `focus-ring` is the AAA offset outline (never a clipped box-shadow ring).
     INPUT = "flex w-full rounded-md border border-border-strong bg-transparent px-3 py-2 text-sm shadow-xs " \
             "text-text-body placeholder:text-text-muted focus-ring"
-    PANEL = "absolute z-50 top-full left-0 mt-1 w-full overflow-hidden rounded-md border border-border " \
-            "bg-surface-overlay text-text-body shadow-md"
+    # Placement is CSS anchor positioning: `position: fixed` (containing block = the
+    # viewport) tethered to the field via `anchor-name`/`position-anchor`, which is what
+    # lets the panel be promoted to the top layer (app/javascript/overlays/top_layer.js).
+    # `w-full` cannot come along — against the viewport it would mean the whole screen —
+    # so the modern path takes its width from the anchor via `anchor-size(width)`, and
+    # `w-full` stays on the pre-Baseline `absolute` fallback.
+    PANEL = "z-50 overflow-hidden rounded-md border border-border bg-surface-overlay shadow-md mt-1 supports-[position-area:bottom]:fixed supports-[position-area:bottom]:[position-area:bottom_span-right] supports-[position-area:bottom]:[width:anchor-size(width)] supports-[position-area:bottom]:[position-try-fallbacks:flip-block] not-supports-[position-area:bottom]:absolute not-supports-[position-area:bottom]:top-full not-supports-[position-area:bottom]:left-0 not-supports-[position-area:bottom]:w-full"
     LIST = "max-h-[200px] overflow-y-auto p-1"
     # `focus-ring` keeps the AAA offset outline if an option takes DOM focus;
     # `aria-selected:` styles the controller-tracked active option for pointer +
@@ -60,6 +65,7 @@ module UI
       @placeholder = placeholder
       @label = label
       @size = coerce_size(size)
+      @id = html_attrs.delete(:id) || "combobox-#{SecureRandom.hex(4)}"
       @extra_class = html_attrs.delete(:class)
       # Merge the controller wiring into any caller `data:` so a passed-through
       # `data:` attr can't clobber `data-controller` and silently break Stimulus.
@@ -71,7 +77,8 @@ module UI
     end
 
     def call
-      content_tag(:div, class: cn("relative", @extra_class), data: @data, **@html_attrs) do
+      content_tag(:div, id: @id, class: cn("relative", @extra_class),
+        style: "anchor-name: --#{@id}", data: @data, **@html_attrs) do
         concat hidden_input
         concat text_input
         concat dropdown
@@ -80,7 +87,6 @@ module UI
 
     private
 
-    LIST_ID = "combobox-list"
 
     def accessible_name
       @label || I18n.t("modelrails_ui.combobox.label", default: "Search and select an option")
@@ -103,7 +109,7 @@ module UI
         value: selected_label,
         "aria-label": accessible_name,
         "aria-expanded": "false",
-        "aria-controls": LIST_ID,
+        "aria-controls": list_id,
         "aria-autocomplete": "list",
         autocomplete: "off",
         spellcheck: "false",
@@ -115,13 +121,16 @@ module UI
       )
     end
 
+    def list_id = "#{@id}-list"
+
     def dropdown
-      content_tag(:div, listbox, data: {combobox_target: "panel"}, hidden: true, class: PANEL)
+      content_tag(:div, listbox, data: {combobox_target: "panel"}, hidden: true,
+        style: "position-anchor: --#{@id}", class: PANEL)
     end
 
     def listbox
       content_tag(:div,
-        id: LIST_ID,
+        id: list_id,
         role: "listbox",
         "aria-label": accessible_name,
         class: LIST,

--- a/lib/generators/modelrails_ui/add/templates/combobox/combobox_controller.js
+++ b/lib/generators/modelrails_ui/add/templates/combobox/combobox_controller.js
@@ -1,4 +1,5 @@
 import { Controller } from "@hotwired/stimulus"
+import * as topLayer from "overlays/top_layer"
 
 // Autocomplete-select behavior. Owns the WAI-ARIA APG combobox + listbox
 // contract: the text input is the combobox (keeps DOM focus) and the popup is the
@@ -17,11 +18,17 @@ export default class extends Controller {
 
   open() {
     this.panelTarget.hidden = false
+    // No-op unless anchor-positioned (`position: fixed`); top_layer.js refuses the
+    // pre-Baseline `absolute` fallback, where promotion would tear the panel off-screen.
+    topLayer.enable(this.panelTarget)
+    topLayer.show(this.panelTarget)
     this.inputTarget.setAttribute("aria-expanded", "true")
     this.filter()
   }
 
   close() {
+    topLayer.hide(this.panelTarget)
+    topLayer.disable(this.panelTarget)
     this.panelTarget.hidden = true
     this.inputTarget.setAttribute("aria-expanded", "false")
     this._setActive(null)

--- a/lib/generators/modelrails_ui/add/templates/date_picker/date_picker_component.rb.tt
+++ b/lib/generators/modelrails_ui/add/templates/date_picker/date_picker_component.rb.tt
@@ -43,8 +43,11 @@ module UI
                "bg-surface-raised px-3 text-sm text-text-heading shadow-xs focus-ring transition " \
                "aria-expanded:border-border-focus"
     ICON_CLS = "size-4 shrink-0 text-text-muted"
-    POPOVER = "absolute left-0 top-full z-50 mt-1 hidden w-max rounded-lg border border-border " \
-               "bg-surface-overlay p-0 shadow-md data-[open=true]:block"
+    # Placement is CSS anchor positioning: `position: fixed` (containing block = the
+    # viewport) tethered to the trigger via `anchor-name`/`position-anchor`. Being
+    # viewport-positioned is what lets the panel be promoted to the top layer, so a
+    # sticky/backdrop-blur ancestor cannot bury it (app/javascript/overlays/top_layer.js).
+    POPOVER = "z-50 hidden w-max rounded-lg border border-border bg-surface-overlay p-0 shadow-md data-[open=true]:block mt-1 supports-[position-area:bottom]:fixed supports-[position-area:bottom]:[position-area:bottom_span-right] supports-[position-area:bottom]:[position-try-fallbacks:flip-block] not-supports-[position-area:bottom]:absolute not-supports-[position-area:bottom]:top-full not-supports-[position-area:bottom]:left-0"
 
     # strftime patterns and the human-readable format hint, keyed by `format:`.
     FORMATS = {
@@ -71,6 +74,7 @@ module UI
       caller_data = @html_attrs.delete(:data) || {}
       content_tag(:div,
         class: cn(WRAPPER, @extra_class),
+        style: "anchor-name: --#{@id}",
         data: {controller: "date-picker"}.merge(caller_data),
         **@html_attrs) do
         concat caption
@@ -127,6 +131,7 @@ module UI
       content_tag(:div,
         id: popover_id,
         class: POPOVER,
+        style: "position-anchor: --#{@id}",
         role: "dialog",
         "aria-label": @label,
         tabindex: "-1",

--- a/lib/generators/modelrails_ui/add/templates/date_picker/date_picker_controller.js
+++ b/lib/generators/modelrails_ui/add/templates/date_picker/date_picker_controller.js
@@ -1,4 +1,5 @@
 import { Controller } from "@hotwired/stimulus"
+import * as topLayer from "overlays/top_layer"
 
 export default class extends Controller {
   static targets = ["trigger", "popover", "label", "hidden"]
@@ -18,13 +19,19 @@ export default class extends Controller {
   }
 
   open() {
+    // No-op unless the panel is anchor-positioned (`position: fixed`); top_layer.js
+    // refuses anything still on the pre-Baseline `absolute` fallback.
     this.popoverTarget.dataset.open = "true"
+    topLayer.enable(this.popoverTarget)
+    topLayer.show(this.popoverTarget)
     this.triggerTarget.setAttribute("aria-expanded", "true")
     document.addEventListener("click", this.#outsideHandler)
     this.isOpen = true
   }
 
   close() {
+    topLayer.hide(this.popoverTarget)
+    topLayer.disable(this.popoverTarget)
     this.popoverTarget.dataset.open = "false"
     this.triggerTarget.setAttribute("aria-expanded", "false")
     document.removeEventListener("click", this.#outsideHandler)

--- a/lib/generators/modelrails_ui/add/templates/dropdown_menu/dropdown_menu_component.rb.tt
+++ b/lib/generators/modelrails_ui/add/templates/dropdown_menu/dropdown_menu_component.rb.tt
@@ -34,17 +34,33 @@ module UI
     # `disabled:` marks it `aria-disabled` (skipped by keyboard nav; activation
     # rejected). `separator: true` renders a non-interactive divider in source order
     # instead of an item. Pass-through `class:`/attrs land on the element.
-    renders_many :items, ->(separator: false, disabled: false, href: nil, **attrs, &block) do
+    renders_many :items, ->(separator: false, disabled: false, href: nil, checkbox: false,
+      radio: nil, value: nil, checked: false, tone: nil, submenu: nil, **attrs, &block) do
       next content_tag(:div, "", role: "separator", class: SEPARATOR) if separator
+      next submenu_group(submenu, disabled: disabled, **attrs, &block) if submenu
 
+      tone = validate_tone(tone)
       tag_name = href ? :a : :button
       caller_data = attrs.delete(:data) || {}
+      # menuitemcheckbox / menuitemradio per the APG menu pattern. `aria-checked` is
+      # rendered from server state so the menu reads correctly before any JS runs;
+      # `menu#activate` then toggles it in place rather than closing the menu.
+      role = if radio
+        "menuitemradio"
+      else
+        (checkbox ? "menuitemcheckbox" : "menuitem")
+      end
+      wiring = {menu_target: "item", action: "click->menu#activate"}
+      wiring[:menu_radio_group] = radio if radio
+      wiring[:menu_value] = value if value
+      wiring[:tone] = tone if tone
       el = {
-        role: "menuitem",
+        role: role,
         tabindex: "-1",
-        class: cn(ITEM, attrs.delete(:class)),
-        data: {menu_target: "item", action: "click->menu#activate"}.merge(caller_data)
+        class: cn(ITEM, (ITEM_TONES.fetch(tone) if tone), attrs.delete(:class)),
+        data: wiring.merge(caller_data)
       }
+      el[:"aria-checked"] = checked.to_s if role != "menuitem"
       el[:href] = href if href
       el[:type] = "button" unless href
       el[:"aria-disabled"] = "true" if disabled
@@ -68,6 +84,110 @@ module UI
            "[&_svg]:pointer-events-none [&_svg]:shrink-0 [&_svg:not([class*='size-'])]:size-4 " \
            "[&_svg:not([class*='text-'])]:text-text-muted"
     SEPARATOR = "-mx-1 my-1 h-px bg-border"
+
+    # Opens to the side of its parent item, flipping to the other side near the edge.
+    SUBMENU_PLACEMENT = "supports-[position-area:bottom]:fixed supports-[position-area:bottom]:[position-area:right_span-bottom] supports-[position-area:bottom]:[position-try-fallbacks:flip-inline] not-supports-[position-area:bottom]:absolute not-supports-[position-area:bottom]:left-full not-supports-[position-area:bottom]:top-0"
+
+    # Signal tones are TEXT colours, never a fill — a menu item keeps the surface
+    # highlight it shares with every other item and only its label changes colour.
+    ITEM_TONES = {
+      danger: "text-danger hover:text-danger focus-visible:text-danger"
+    }.freeze
+
+    # Collects a submenu's items so the caller writes the same `with_item` it uses on the
+    # parent, in source order:
+    #
+    #   c.with_item(submenu: "Share") { |sub| sub.with_item { "Email" } }
+    class SubmenuBuilder
+      attr_reader :items
+
+      def initialize(component)
+        @component = component
+        @items = []
+      end
+
+      def with_item(**opts, &block)
+        @items << @component.submenu_item(**opts, &block)
+        nil
+      end
+    end
+
+    # A submenu is a nested controller with a DISTINCT identifier, so the sub-trigger can
+    # be `data-menu-target="item"` (staying in the parent's arrow-key rotation) while also
+    # being `data-submenu-target="trigger"`. One element, two controllers, no collision.
+    def submenu_group(label, disabled: false, **attrs, &block)
+      builder = SubmenuBuilder.new(self)
+      capture(builder, &block)
+      id = "submenu-#{SecureRandom.hex(4)}"
+
+      content_tag(:div,
+        data: {controller: "submenu", action: "mouseleave->submenu#scheduleClose"},
+        style: "anchor-name: --#{id}") do
+        safe_join([submenu_trigger(label, id, disabled, **attrs), submenu_panel(id, builder.items)])
+      end
+    end
+
+    def submenu_trigger(label, id, disabled, **attrs)
+      el = {
+        type: "button",
+        role: "menuitem",
+        tabindex: "-1",
+        "aria-haspopup": "menu",
+        "aria-expanded": "false",
+        "aria-controls": id,
+        class: cn(ITEM, "justify-between", attrs.delete(:class)),
+        data: {
+          menu_target: "item",
+          submenu_target: "trigger",
+          action: "click->submenu#toggle keydown->submenu#triggerKeydown mouseenter->submenu#open"
+        }
+      }
+      el[:"aria-disabled"] = "true" if disabled
+      content_tag(:button, safe_join([label, submenu_chevron]), **attrs, **el)
+    end
+
+    def submenu_panel(id, items)
+      content_tag(:div, safe_join(items),
+        id: id,
+        role: "menu",
+        tabindex: "-1",
+        hidden: true,
+        style: "position-anchor: --#{id}",
+        data: {submenu_target: "panel", action: "keydown->submenu#navigate"},
+        class: cn(PANEL_BASE, SUBMENU_PLACEMENT))
+    end
+
+    def submenu_chevron
+      content_tag(:svg, tag.path(d: "m9 18 6-6-6-6"),
+        class: "size-4 shrink-0 text-text-muted", viewBox: "0 0 24 24", fill: "none",
+        stroke: "currentColor", "stroke-width": "2", "aria-hidden": "true")
+    end
+
+    # Rendered by SubmenuBuilder, so it carries `data-submenu-target` rather than
+    # `data-menu-target` — sub-items belong to the submenu's rotation, not the parent's.
+    def submenu_item(disabled: false, href: nil, **attrs, &block)
+      tag_name = href ? :a : :button
+      el = {
+        role: "menuitem",
+        tabindex: "-1",
+        class: cn(ITEM, attrs.delete(:class)),
+        data: {submenu_target: "item", action: "click->submenu#activate"}
+      }
+      el[:href] = href if href
+      el[:type] = "button" unless href
+      el[:"aria-disabled"] = "true" if disabled
+      content_tag(tag_name, capture(&block), **attrs, **el)
+    end
+
+    def validate_tone(tone)
+      return nil if tone.nil?
+
+      key = tone.to_sym
+      return key if ITEM_TONES.key?(key)
+
+      raise ArgumentError,
+        "UI::DropdownMenu unknown item tone: #{tone.inspect} (allowed: #{ITEM_TONES.keys.join(", ")})"
+    end
 
     SIDES = %i[bottom top].freeze
     ALIGNS = %i[start end].freeze

--- a/lib/generators/modelrails_ui/add/templates/dropdown_menu/menu_controller.js
+++ b/lib/generators/modelrails_ui/add/templates/dropdown_menu/menu_controller.js
@@ -1,4 +1,5 @@
 import { Controller } from "@hotwired/stimulus"
+import * as topLayer from "overlays/top_layer"
 
 // Behavior for the menu-pattern band. dropdown_menu is the exemplar/home; context_menu
 // and menubar reuse this via EXTRA_STIMULUS. CSS owns positioning (anchor positioning);
@@ -43,6 +44,10 @@ export default class extends Controller {
     if (this.openValue) return
     this.openValue = true
     this.menuTarget.hidden = false
+    // Safe here because placement is CSS anchor positioning (already `position: fixed`
+    // against the viewport), so the top layer changes paint order only.
+    topLayer.enable(this.menuTarget)
+    topLayer.show(this.menuTarget)
     this.triggerTarget.setAttribute("aria-expanded", "true")
     focus === "last" ? this.focusLast() : this.focusFirst()
   }
@@ -50,6 +55,8 @@ export default class extends Controller {
   close({ restoreFocus = true } = {}) {
     if (!this.openValue) return
     this.openValue = false
+    topLayer.hide(this.menuTarget)
+    topLayer.disable(this.menuTarget)
     this.menuTarget.hidden = true
     this.triggerTarget.setAttribute("aria-expanded", "false")
     if (restoreFocus) this.triggerTarget.focus()
@@ -141,10 +148,27 @@ export default class extends Controller {
   // --- activation ---------------------------------------------------------
 
   activate(event) {
-    if (event.currentTarget.getAttribute("aria-disabled") === "true") {
+    const item = event.currentTarget
+    if (item.getAttribute("aria-disabled") === "true") {
       event.preventDefault()
       return
     }
+
+    // Checkable items change state and leave the menu open (APG menu pattern), so a
+    // multi-select view menu is usable in one pass. Plain items still close.
+    switch (item.getAttribute("role")) {
+      case "menuitemcheckbox":
+        item.setAttribute("aria-checked", String(item.getAttribute("aria-checked") !== "true"))
+        return
+      case "menuitemradio": {
+        const group = item.dataset.menuRadioGroup
+        this.itemTargets
+          .filter((el) => el.dataset.menuRadioGroup === group)
+          .forEach((el) => el.setAttribute("aria-checked", String(el === item)))
+        return
+      }
+    }
+
     this.close()
   }
 

--- a/lib/generators/modelrails_ui/add/templates/dropdown_menu/submenu_controller.js
+++ b/lib/generators/modelrails_ui/add/templates/dropdown_menu/submenu_controller.js
@@ -1,0 +1,113 @@
+import { Controller } from "@hotwired/stimulus"
+import * as topLayer from "overlays/top_layer"
+
+// Nested menu inside a `menu` controller. Deliberately a DISTINCT identifier: the
+// sub-trigger has to be `data-menu-target="item"` so it stays in the parent's arrow-key
+// rotation, while also being this controller's trigger. Two identifiers, one element,
+// no target collision.
+//
+// Keyboard model is the WAI-ARIA APG submenu pattern — ArrowRight/Enter opens and moves
+// focus in, ArrowLeft/Escape closes and returns focus to the sub-trigger. Escape is not
+// propagated, so it closes only this layer and leaves the parent menu standing.
+export default class extends Controller {
+  static targets = ["trigger", "panel", "item"]
+  static values = { open: { type: Boolean, default: false } }
+
+  disconnect() {
+    if (this.closeTimer) clearTimeout(this.closeTimer)
+  }
+
+  toggle(event) {
+    event.preventDefault()
+    this.openValue ? this.close() : this.open({ focus: false })
+  }
+
+  open({ focus = false } = {}) {
+    if (this.closeTimer) {
+      clearTimeout(this.closeTimer)
+      this.closeTimer = null
+    }
+    if (!this.openValue) {
+      this.openValue = true
+      this.panelTarget.hidden = false
+      // Placement is anchor positioning, so the panel is already viewport-positioned and
+      // promotion changes paint order only.
+      topLayer.enable(this.panelTarget)
+      topLayer.show(this.panelTarget)
+      this.triggerTarget.setAttribute("aria-expanded", "true")
+    }
+    if (focus) this.focusItem(this.enabledItems[0])
+  }
+
+  close({ restoreFocus = false } = {}) {
+    if (!this.openValue) return
+    this.openValue = false
+    topLayer.hide(this.panelTarget)
+    topLayer.disable(this.panelTarget)
+    this.panelTarget.hidden = true
+    this.triggerTarget.setAttribute("aria-expanded", "false")
+    if (restoreFocus) this.triggerTarget.focus()
+  }
+
+  // Hovering away closes after a beat so the pointer can cross the gap between the
+  // sub-trigger and its panel without the submenu vanishing.
+  scheduleClose() {
+    this.closeTimer = setTimeout(() => this.close(), 150)
+  }
+
+  triggerKeydown(event) {
+    switch (event.key) {
+      case "ArrowRight":
+      case "Enter":
+      case " ":
+        event.preventDefault()
+        event.stopPropagation()
+        this.open({ focus: true })
+        break
+    }
+  }
+
+  navigate(event) {
+    const items = this.enabledItems
+    if (!items.length) return
+    const current = items.indexOf(document.activeElement)
+
+    switch (event.key) {
+      case "ArrowDown":
+        event.preventDefault()
+        event.stopPropagation()
+        this.focusItem(items[(current + 1) % items.length])
+        break
+      case "ArrowUp":
+        event.preventDefault()
+        event.stopPropagation()
+        this.focusItem(items[(current - 1 + items.length) % items.length])
+        break
+      case "ArrowLeft":
+      case "Escape":
+        // Stop here so the parent menu keeps its own Escape handling for its own layer.
+        event.preventDefault()
+        event.stopPropagation()
+        this.close({ restoreFocus: true })
+        break
+    }
+  }
+
+  activate(event) {
+    if (event.currentTarget.getAttribute("aria-disabled") === "true") {
+      event.preventDefault()
+      return
+    }
+    this.close()
+  }
+
+  get enabledItems() {
+    return this.itemTargets.filter((el) => el.getAttribute("aria-disabled") !== "true")
+  }
+
+  focusItem(item) {
+    if (!item) return
+    this.itemTargets.forEach((el) => el.setAttribute("tabindex", el === item ? "0" : "-1"))
+    item.focus()
+  }
+}

--- a/lib/generators/modelrails_ui/add/templates/dropdown_menu/top_layer.js
+++ b/lib/generators/modelrails_ui/add/templates/dropdown_menu/top_layer.js
@@ -1,0 +1,65 @@
+// Promotes a floating panel into the browser's top layer.
+//
+// `position: absolute`/`fixed` escapes overflow clipping but never a *stacking
+// context*: a panel's `z-50` is scoped to the nearest positioned ancestor with a
+// z-index, so a `sticky z-40` header (app/views/shared/_header.html.erb) or a
+// `backdrop-blur` navbar (UI::NavbarComponent) buries it. No z-index fixes that
+// from the inside.
+//
+// `showPopover()` paints the element above every stacking context while leaving it
+// in the DOM — which is what makes it usable here: moving the panel would unbind
+// the Stimulus actions inside it, and `absolute` positioning keeps resolving
+// against the trigger's wrapper because the top layer changes paint order only.
+//
+// `manual` rather than `auto`: `auto` brings its own light-dismiss and its own
+// nesting stack, which would fight the layer stack in dismiss.js.
+
+export const SUPPORTED =
+  typeof HTMLElement !== "undefined" && Object.hasOwn(HTMLElement.prototype, "popover")
+
+// Browsers without the Popover API keep the current behaviour — still positioned,
+// still correct in the common case, just vulnerable to a stacking context above it.
+const usable = (element) => SUPPORTED && !!element
+
+// The top layer re-parents an element's containing block to the viewport, so anything
+// placed relative to a DOM ancestor (`position: absolute` + `top-full`) is torn off its
+// trigger — measured 1320px adrift on the pre-Baseline `absolute` fallback that Firefox
+// and Safari still take. `position: fixed` is already viewport-relative, so for those the
+// change is a no-op. Gate on that invariant rather than on a feature name: it stays
+// correct whatever a browser supports, and the ungated case simply keeps today's
+// behaviour (correctly placed, still buriable) instead of flying off-screen.
+const viewportPositioned = (element) => getComputedStyle(element).position === "fixed"
+
+// data-top-layer is the hook for the UA-default reset in application.css.
+export function enable(element) {
+  if (!usable(element) || !viewportPositioned(element)) return false
+
+  element.popover = "manual"
+  element.dataset.topLayer = ""
+  return true
+}
+
+export function show(element) {
+  if (!usable(element) || !element.popover) return false
+
+  try { element.showPopover() } catch { /* already showing, or not connected yet */ }
+  return true
+}
+
+export function hide(element) {
+  if (!usable(element) || !element.popover) return false
+
+  try { element.hidePopover() } catch { /* already hidden */ }
+  return true
+}
+
+// Hiding a popover does not put it back in the page's flow: the UA gives
+// `[popover]` `position: fixed` open or closed. Callers that lay the page out
+// around the element must disable it, not just hide it.
+export function disable(element) {
+  if (!usable(element)) return false
+
+  element.removeAttribute("popover")
+  delete element.dataset.topLayer
+  return true
+}

--- a/lib/generators/modelrails_ui/add/templates/mega_menu/mega_menu_component.rb.tt
+++ b/lib/generators/modelrails_ui/add/templates/mega_menu/mega_menu_component.rb.tt
@@ -31,8 +31,12 @@ module UI
                   "hover:bg-surface-sunken hover:text-text-heading " \
                   "data-[state=open]:bg-surface-sunken/50 data-[state=open]:text-text-heading"
 
-    PANEL_CLS = "absolute left-0 top-full z-50 mt-1.5 w-full overflow-hidden rounded-md border " \
-                "bg-surface-overlay text-text-body shadow-lg"
+    # Placement is CSS anchor positioning: `position: fixed` (containing block = the
+    # viewport) tethered to the bar via `anchor-name`/`position-anchor`, which is what lets
+    # the panel be promoted to the top layer (app/javascript/overlays/top_layer.js).
+    # `w-full` cannot come along — against the viewport it would mean the whole screen — so
+    # the modern path takes its width from the anchor via `anchor-size(width)`.
+    PANEL_CLS = "z-50 overflow-hidden rounded-md border bg-surface-overlay shadow mt-1.5 supports-[position-area:bottom]:fixed supports-[position-area:bottom]:[position-area:bottom_span-right] supports-[position-area:bottom]:[width:anchor-size(width)] supports-[position-area:bottom]:[position-try-fallbacks:flip-block] not-supports-[position-area:bottom]:absolute not-supports-[position-area:bottom]:top-full not-supports-[position-area:bottom]:left-0 not-supports-[position-area:bottom]:w-full"
 
     INNER_CLS = "container mx-auto grid gap-6 p-6"
 
@@ -64,6 +68,7 @@ module UI
       content_tag(:div,
         id: @id,
         class: cn("relative", @extra_class),
+        style: "anchor-name: --#{@id}",
         data: {
           controller: "mega-menu",
           action: "click@document->mega-menu#closeOnClickOutside"
@@ -83,8 +88,8 @@ module UI
         "aria-haspopup": "true",
         "aria-expanded": "false",
         "aria-controls": @panel_id,
-        data: { mega_menu_target: "trigger", state: "closed",
-                action: "click->mega-menu#toggle" }) do
+        data: {mega_menu_target: "trigger", state: "closed",
+                action: "click->mega-menu#toggle"}) do
         concat @label
         concat chevron
       end
@@ -99,7 +104,8 @@ module UI
         "aria-label": @label,
         hidden: true,
         class: PANEL_CLS,
-        data: { mega_menu_target: "panel" }) do
+        style: "position-anchor: --#{@id}",
+        data: {mega_menu_target: "panel"}) do
         content_tag(:div, class: cn(INNER_CLS, grid_cls)) do
           safe_join(columns)
         end
@@ -116,7 +122,7 @@ module UI
         "stroke-width": "2",
         class: "size-3 transition-transform duration-200 data-[state=open]:rotate-180",
         "aria-hidden": "true",
-        data: { mega_menu_target: "chevron" })
+        data: {mega_menu_target: "chevron"})
     end
 
     # A single column inside the mega menu panel.

--- a/lib/generators/modelrails_ui/add/templates/mega_menu/mega_menu_controller.js
+++ b/lib/generators/modelrails_ui/add/templates/mega_menu/mega_menu_controller.js
@@ -1,4 +1,5 @@
 import { Controller } from "@hotwired/stimulus"
+import * as topLayer from "overlays/top_layer"
 
 export default class extends Controller {
   static targets = ["trigger", "panel", "chevron"]
@@ -13,7 +14,17 @@ export default class extends Controller {
   }
 
   _setOpen(open) {
-    this.panelTarget.hidden = !open
+    // No-op unless anchor-positioned (`position: fixed`); top_layer.js refuses the
+    // pre-Baseline `absolute` fallback, where promotion would tear the panel off-screen.
+    if (open) {
+      this.panelTarget.hidden = false
+      topLayer.enable(this.panelTarget)
+      topLayer.show(this.panelTarget)
+    } else {
+      topLayer.hide(this.panelTarget)
+      topLayer.disable(this.panelTarget)
+      this.panelTarget.hidden = true
+    }
     this.triggerTarget.setAttribute("aria-expanded", String(open))
     this.triggerTarget.dataset.state = open ? "open" : "closed"
     if (this.hasChevronTarget) {

--- a/lib/generators/modelrails_ui/add/templates/navigation_menu/navigation_menu_component.rb.tt
+++ b/lib/generators/modelrails_ui/add/templates/navigation_menu/navigation_menu_component.rb.tt
@@ -51,8 +51,11 @@ module UI
                "aria-[current]:bg-surface-sunken/50 aria-[current]:text-text-heading"
 
     # Flyout panel
-    CONTENT = "absolute top-full left-0 z-50 mt-1.5 min-w-48 overflow-hidden rounded-md border " \
-              "bg-surface-overlay p-1 text-text-body shadow"
+    # Placement is CSS anchor positioning: `position: fixed` (containing block = the
+    # viewport) tethered to the trigger via `anchor-name`/`position-anchor`. Being
+    # viewport-positioned is what lets the panel be promoted to the top layer, so a
+    # sticky/backdrop-blur ancestor cannot bury it (app/javascript/overlays/top_layer.js).
+    CONTENT = "z-50 min-w-48 overflow-hidden rounded-md border bg-surface-overlay p-1 text-text-body shadow mt-1.5 supports-[position-area:bottom]:fixed supports-[position-area:bottom]:[position-area:bottom_span-right] supports-[position-area:bottom]:[position-try-fallbacks:flip-block] not-supports-[position-area:bottom]:absolute not-supports-[position-area:bottom]:top-full not-supports-[position-area:bottom]:left-0"
 
     # Styled link inside a flyout panel
     PANEL_LINK = "flex flex-col gap-1 rounded-sm p-2 text-sm transition-all focus-ring " \
@@ -131,6 +134,7 @@ module UI
       def trigger_item
         content_tag(:div,
           class: "relative",
+          style: "anchor-name: --#{@panel_id}",
           data: {
             controller: "navigation-menu",
             action: "mouseenter->navigation-menu#open mouseleave->navigation-menu#scheduleClose " \
@@ -160,6 +164,7 @@ module UI
           content,
           id: @panel_id,
           class: NavigationMenuComponent::CONTENT,
+          style: "position-anchor: --#{@panel_id}",
           hidden: true,
           data: {
             navigation_menu_target: "content",

--- a/lib/generators/modelrails_ui/add/templates/navigation_menu/navigation_menu_controller.js
+++ b/lib/generators/modelrails_ui/add/templates/navigation_menu/navigation_menu_controller.js
@@ -1,4 +1,5 @@
 import { Controller } from "@hotwired/stimulus"
+import * as topLayer from "overlays/top_layer"
 
 export default class extends Controller {
   static targets = ["trigger", "content"]
@@ -18,7 +19,17 @@ export default class extends Controller {
 
   _setOpen(open) {
     if (!this.hasContentTarget) return
-    this.contentTarget.hidden = !open
+    // No-op unless the flyout is anchor-positioned (`position: fixed`); top_layer.js
+    // refuses anything still on the pre-Baseline `absolute` fallback.
+    if (open) {
+      this.contentTarget.hidden = false
+      topLayer.enable(this.contentTarget)
+      topLayer.show(this.contentTarget)
+    } else {
+      topLayer.hide(this.contentTarget)
+      topLayer.disable(this.contentTarget)
+      this.contentTarget.hidden = true
+    }
     this.triggerTarget.setAttribute("aria-expanded", String(open))
     this.triggerTarget.dataset.state = open ? "open" : "closed"
   }

--- a/lib/generators/modelrails_ui/add/templates/popover/floating_controller.js
+++ b/lib/generators/modelrails_ui/add/templates/popover/floating_controller.js
@@ -1,4 +1,5 @@
 import { Controller } from "@hotwired/stimulus"
+import * as topLayer from "overlays/top_layer"
 
 // Behavior for the floating-overlays band. Wave 5a wires popover (click toggle).
 // Non-modal: CSS owns positioning; this owns open/close, aria-expanded sync,
@@ -29,6 +30,11 @@ export default class extends Controller {
     if (this.openValue) return
     this.openValue = true
     this.panelTarget.hidden = false
+    // No-op unless the panel is anchor-positioned (`position: fixed`); top_layer.js
+    // refuses anything still on the pre-Baseline `absolute` fallback. The CSS-shown
+    // tooltip/hover_card paths below never reach here.
+    topLayer.enable(this.panelTarget)
+    topLayer.show(this.panelTarget)
     this.triggerTarget.setAttribute("aria-expanded", "true")
     this.panelTarget.focus()
   }
@@ -36,6 +42,8 @@ export default class extends Controller {
   close() {
     if (!this.openValue) return
     this.openValue = false
+    topLayer.hide(this.panelTarget)
+    topLayer.disable(this.panelTarget)
     this.panelTarget.hidden = true
     this.triggerTarget.setAttribute("aria-expanded", "false")
     this.triggerTarget.focus()

--- a/lib/generators/modelrails_ui/add/templates/popover/popover_component.rb.tt
+++ b/lib/generators/modelrails_ui/add/templates/popover/popover_component.rb.tt
@@ -4,8 +4,12 @@ module UI
   # # Popover
   #
   # A non-modal floating panel anchored to a trigger button. Behavior lives in the
-  # `floating` Stimulus controller shipped alongside this component; positioning is
-  # CSS (a `relative` wrapper + `absolute` panel — the author picks `side`/`align`).
+  # `floating` Stimulus controller shipped alongside this component. Placement is CSS
+  # anchor positioning: the panel is `position: fixed` (so its containing block is the
+  # viewport), tethered to the trigger via `anchor-name`/`position-anchor`; `position-area`
+  # places it and `position-try-fallbacks` keeps it on-screen. Being viewport-positioned is
+  # also what lets it be promoted to the browser top layer, so a `sticky`/`backdrop-blur`
+  # ancestor cannot bury it.
   #
   # ## Use when
   # - You need a small interactive overlay (a menu of actions, a filter form, details)
@@ -14,8 +18,6 @@ module UI
   # ## Don't use when
   # - The content must block interaction until dismissed — use `dialog`/`alert_dialog`.
   # - You only need a hint describing a control — use `tooltip`.
-  # - The trigger sits inside an `overflow:hidden` / transformed ancestor that would
-  #   clip the panel (there is no top layer) — restructure or use a `dialog`.
   #
   # ## Accessibility contract
   # - **Guarantees:** a real `<button>` trigger with `aria-haspopup="dialog"`,
@@ -27,20 +29,34 @@ module UI
   class PopoverComponent < ApplicationComponent
     renders_one :trigger
 
-    PANEL_BASE = "absolute z-50 w-72 rounded-md border border-border bg-surface-overlay p-4 " \
+    PANEL_BASE = "z-50 w-72 rounded-md border border-border bg-surface-overlay p-4 " \
                  "text-sm text-text-body shadow-md outline-none"
 
-    ALIGN = {
-      start:  "left-0",
-      center: "left-1/2 -translate-x-1/2",
-      end:    "right-0"
-    }.freeze
+    SIDES = %i[bottom top left right].freeze
+    ALIGNS = %i[start center end].freeze
 
-    SIDE = {
-      bottom: "top-full mt-2",
-      top:    "bottom-full mb-2",
-      left:   "right-full mr-2 top-0",
-      right:  "left-full ml-2 top-0"
+    # Anchor-positioning placement — `side` × `align`. Each value carries the gap margin,
+    # the modern path (supports-[position-area]: `fixed` + a `position-area` cell + a
+    # `position-try-fallbacks` flip to stay on-screen) and the pre-Baseline `absolute`
+    # fallback offsets. `position: fixed` is what lets the panel be promoted to the top
+    # layer — the top layer re-parents an element's containing block to the viewport, so
+    # `absolute` offsets would tear it off its trigger (see app/javascript/overlays/
+    # top_layer.js). For bottom/top, `align` edge-aligns horizontally via span-right /
+    # span-left; for left/right it edge-aligns vertically via span-bottom / span-top.
+    # Written out one line per placement because Tailwind only sees literal class strings.
+    PLACEMENTS = {
+      bottom_start: "mt-2 supports-[position-area:bottom]:fixed supports-[position-area:bottom]:[position-area:bottom_span-right] supports-[position-area:bottom]:[position-try-fallbacks:flip-block] not-supports-[position-area:bottom]:absolute not-supports-[position-area:bottom]:top-full not-supports-[position-area:bottom]:left-0",
+      bottom_center: "mt-2 supports-[position-area:bottom]:fixed supports-[position-area:bottom]:[position-area:bottom] supports-[position-area:bottom]:[position-try-fallbacks:flip-block] not-supports-[position-area:bottom]:absolute not-supports-[position-area:bottom]:top-full not-supports-[position-area:bottom]:left-1/2 not-supports-[position-area:bottom]:-translate-x-1/2",
+      bottom_end: "mt-2 supports-[position-area:bottom]:fixed supports-[position-area:bottom]:[position-area:bottom_span-left] supports-[position-area:bottom]:[position-try-fallbacks:flip-block] not-supports-[position-area:bottom]:absolute not-supports-[position-area:bottom]:top-full not-supports-[position-area:bottom]:right-0",
+      top_start: "mb-2 supports-[position-area:bottom]:fixed supports-[position-area:bottom]:[position-area:top_span-right] supports-[position-area:bottom]:[position-try-fallbacks:flip-block] not-supports-[position-area:bottom]:absolute not-supports-[position-area:bottom]:bottom-full not-supports-[position-area:bottom]:left-0",
+      top_center: "mb-2 supports-[position-area:bottom]:fixed supports-[position-area:bottom]:[position-area:top] supports-[position-area:bottom]:[position-try-fallbacks:flip-block] not-supports-[position-area:bottom]:absolute not-supports-[position-area:bottom]:bottom-full not-supports-[position-area:bottom]:left-1/2 not-supports-[position-area:bottom]:-translate-x-1/2",
+      top_end: "mb-2 supports-[position-area:bottom]:fixed supports-[position-area:bottom]:[position-area:top_span-left] supports-[position-area:bottom]:[position-try-fallbacks:flip-block] not-supports-[position-area:bottom]:absolute not-supports-[position-area:bottom]:bottom-full not-supports-[position-area:bottom]:right-0",
+      left_start: "mr-2 supports-[position-area:bottom]:fixed supports-[position-area:bottom]:[position-area:left_span-bottom] supports-[position-area:bottom]:[position-try-fallbacks:flip-inline] not-supports-[position-area:bottom]:absolute not-supports-[position-area:bottom]:right-full not-supports-[position-area:bottom]:top-0",
+      left_center: "mr-2 supports-[position-area:bottom]:fixed supports-[position-area:bottom]:[position-area:left] supports-[position-area:bottom]:[position-try-fallbacks:flip-inline] not-supports-[position-area:bottom]:absolute not-supports-[position-area:bottom]:right-full not-supports-[position-area:bottom]:top-1/2 not-supports-[position-area:bottom]:-translate-y-1/2",
+      left_end: "mr-2 supports-[position-area:bottom]:fixed supports-[position-area:bottom]:[position-area:left_span-top] supports-[position-area:bottom]:[position-try-fallbacks:flip-inline] not-supports-[position-area:bottom]:absolute not-supports-[position-area:bottom]:right-full not-supports-[position-area:bottom]:bottom-0",
+      right_start: "ml-2 supports-[position-area:bottom]:fixed supports-[position-area:bottom]:[position-area:right_span-bottom] supports-[position-area:bottom]:[position-try-fallbacks:flip-inline] not-supports-[position-area:bottom]:absolute not-supports-[position-area:bottom]:left-full not-supports-[position-area:bottom]:top-0",
+      right_center: "ml-2 supports-[position-area:bottom]:fixed supports-[position-area:bottom]:[position-area:right] supports-[position-area:bottom]:[position-try-fallbacks:flip-inline] not-supports-[position-area:bottom]:absolute not-supports-[position-area:bottom]:left-full not-supports-[position-area:bottom]:top-1/2 not-supports-[position-area:bottom]:-translate-y-1/2",
+      right_end: "ml-2 supports-[position-area:bottom]:fixed supports-[position-area:bottom]:[position-area:right_span-top] supports-[position-area:bottom]:[position-try-fallbacks:flip-inline] not-supports-[position-area:bottom]:absolute not-supports-[position-area:bottom]:left-full not-supports-[position-area:bottom]:bottom-0"
     }.freeze
 
     # label:         the panel's accessible name (required → aria-label on role=dialog)
@@ -51,8 +67,8 @@ module UI
     def initialize(label:, id: nil, align: :start, side: :bottom, trigger_class: "btn-secondary", **html_attrs)
       @label         = label
       @id            = id || "popover-#{SecureRandom.hex(4)}"
-      @align         = coerce_enum(:align, align, ALIGN)
-      @side          = coerce_enum(:side, side, SIDE)
+      @align         = coerce_enum(:align, align, ALIGNS)
+      @side          = coerce_enum(:side, side, SIDES)
       @trigger_class = trigger_class
       @extra_class   = html_attrs.delete(:class)
       @html_attrs    = html_attrs
@@ -71,6 +87,7 @@ module UI
     def wrapper_attrs
       {
         class: cn("relative inline-block", @extra_class),
+        style: "anchor-name: --#{@id}",
         data: {
           controller: "floating",
           action: "keydown.esc->floating#close click@document->floating#closeOnClickOutside"
@@ -84,7 +101,7 @@ module UI
         "aria-haspopup": "dialog",
         "aria-expanded": "false",
         "aria-controls": @id,
-        data: { floating_target: "trigger", action: "click->floating#toggle" },
+        data: {floating_target: "trigger", action: "click->floating#toggle"},
         class: @trigger_class)
     end
 
@@ -95,16 +112,17 @@ module UI
         "aria-label": @label,
         tabindex: "-1",
         hidden: true,
-        data: { floating_target: "panel" },
-        class: cn(PANEL_BASE, ALIGN.fetch(@align), SIDE.fetch(@side)))
+        style: "position-anchor: --#{@id}",
+        data: {floating_target: "panel"},
+        class: cn(PANEL_BASE, PLACEMENTS.fetch(:"#{@side}_#{@align}")))
     end
 
-    def coerce_enum(name, value, map)
+    def coerce_enum(name, value, allowed)
       key = value.to_sym
-      return key if map.key?(key)
+      return key if allowed.include?(key)
 
       raise ArgumentError,
-        "UI::Popover unknown #{name}: #{value.inspect} (allowed: #{map.keys.join(", ")})"
+        "UI::Popover unknown #{name}: #{value.inspect} (allowed: #{allowed.join(", ")})"
     end
   end
 end

--- a/lib/generators/modelrails_ui/add/templates/timepicker/timepicker_component.rb.tt
+++ b/lib/generators/modelrails_ui/add/templates/timepicker/timepicker_component.rb.tt
@@ -45,19 +45,27 @@ module UI
                "bg-surface-raised px-3 text-sm text-text-heading shadow-xs focus-ring transition " \
                "aria-expanded:border-border-focus"
     ICON_CLS = "size-4 shrink-0 text-text-muted"
-    POPOVER  = "absolute left-0 top-full z-50 mt-1 hidden w-max rounded-lg border border-border " \
-               "bg-surface-overlay p-3 shadow-md data-[open=true]:block"
+    # Placement is CSS anchor positioning: `position: fixed` (containing block = the
+    # viewport) tethered to the trigger via `anchor-name`/`position-anchor`. Being
+    # viewport-positioned is what lets the panel be promoted to the top layer, so a
+    # sticky/backdrop-blur ancestor cannot bury it (app/javascript/overlays/top_layer.js).
+    POPOVER  = "z-50 hidden w-max rounded-lg border border-border bg-surface-overlay p-3 shadow-md data-[open=true]:block mt-1 supports-[position-area:bottom]:fixed supports-[position-area:bottom]:[position-area:bottom_span-right] supports-[position-area:bottom]:[position-try-fallbacks:flip-block] not-supports-[position-area:bottom]:absolute not-supports-[position-area:bottom]:top-full not-supports-[position-area:bottom]:left-0"
     SPINNER_WRAP = "flex items-center justify-center gap-1"
     COL_CLS  = "flex flex-col items-center gap-1"
-    SPIN_BTN = "inline-flex size-7 items-center justify-center rounded-md focus-ring " \
+    # size-11 (44px): steppers are aria-hidden to AT but remain POINTER
+    # targets, and WCAG 2.5.5's floor applies to pointer targets regardless
+    # of AT visibility (caught by the open-state audit, #463).
+    SPIN_BTN = "inline-flex size-11 items-center justify-center rounded-md focus-ring " \
                "text-text-muted hover:bg-surface-sunken hover:text-text-heading transition"
-    NUM_CLS  = "w-10 rounded-md border border-border-strong bg-surface-raised px-1 py-0.5 text-center text-sm focus-ring"
+    # min-h-11 + w-12: the spinbutton fields are the primary targets and must
+    # clear the 44px floor (WCAG 2.5.5 AAA — open-state audit, #463).
+    NUM_CLS  = "w-12 min-h-11 rounded-md border border-border-strong bg-surface-raised px-1 text-center text-sm focus-ring"
     SEP_CLS  = "text-lg font-medium text-text-heading pb-1"
 
     # The human-readable format hint, keyed by `format:`.
     FORMATS = {
-      h24: { hint: "HH:MM (24-hour)" },
-      h12: { hint: "HH:MM AM/PM (12-hour)" }
+      h24: {hint: "HH:MM (24-hour)"},
+      h12: {hint: "HH:MM AM/PM (12-hour)"}
     }.freeze
 
     def initialize(value: nil, name: nil, label: nil, format: :h24, step: 1, **html_attrs)
@@ -75,6 +83,7 @@ module UI
       caller_data = @html_attrs.delete(:data) || {}
       content_tag(:div,
         class: cn(WRAPPER, @extra_class),
+        style: "anchor-name: --#{@id}",
         data: {
           controller: "timepicker",
           timepicker_format_value: @format,
@@ -107,7 +116,7 @@ module UI
     def hidden_input
       tag.input(type: "hidden", name: @name,
         value: @value,
-        data: { timepicker_target: "hidden" })
+        data: {timepicker_target: "hidden"})
     end
 
     def trigger_button
@@ -124,7 +133,7 @@ module UI
           action: "click->timepicker#toggle"
         }) do
         concat clock_icon
-        concat content_tag(:span, @value || @label, data: { timepicker_target: "label" })
+        concat content_tag(:span, @value || @label, data: {timepicker_target: "label"})
       end
     end
 
@@ -134,11 +143,12 @@ module UI
       content_tag(:div,
         id: popover_id,
         class: POPOVER,
+        style: "position-anchor: --#{@id}",
         role: "dialog",
         "aria-label": @label,
         "aria-modal": "true",
         tabindex: "-1",
-        data: { timepicker_target: "popover" }) do
+        data: {timepicker_target: "popover"}) do
         content_tag(:div, class: SPINNER_WRAP) do
           concat hour_column(hour_val)
           concat content_tag(:span, ":", class: SEP_CLS, "aria-hidden": "true")
@@ -153,7 +163,7 @@ module UI
         concat spin_btn("▲", "click->timepicker#hourUp")
         concat spinbutton(:hour, val, 0, hour_max,
           label: I18n.t("modelrails_ui.timepicker.hour", default: "Hour"),
-          action: "change->timepicker#hourChanged")
+          action: "change->timepicker#hourChanged keydown->timepicker#hourKeydown")
         concat spin_btn("▼", "click->timepicker#hourDown")
       end
     end
@@ -163,7 +173,7 @@ module UI
         concat spin_btn("▲", "click->timepicker#minuteUp")
         concat spinbutton(:minute, val, 0, 59,
           label: I18n.t("modelrails_ui.timepicker.minute", default: "Minute"),
-          action: "change->timepicker#minuteChanged")
+          action: "change->timepicker#minuteChanged keydown->timepicker#minuteKeydown")
         concat spin_btn("▼", "click->timepicker#minuteDown")
       end
     end
@@ -177,7 +187,7 @@ module UI
           "aria-label": I18n.t("modelrails_ui.timepicker.meridiem", default: "AM or PM"),
           "aria-valuetext": "AM",
           class: cn(NUM_CLS, "cursor-pointer select-none"),
-          data: { timepicker_target: "ampm", action: "click->timepicker#toggleAmPm keydown->timepicker#ampmKeydown" })
+          data: {timepicker_target: "ampm", action: "click->timepicker#toggleAmPm keydown->timepicker#ampmKeydown"})
         concat spin_btn("▼", "click->timepicker#toggleAmPm")
       end
     end
@@ -195,7 +205,7 @@ module UI
         "aria-valuemax": max,
         "aria-valuenow": val,
         "aria-valuetext": val.to_s.rjust(2, "0"),
-        data: { timepicker_target: target, action: action })
+        data: {timepicker_target: target, action: action})
     end
 
     # The ▲/▼ steppers are decorative: aria-hidden + tabindex=-1 so the spinbutton
@@ -203,7 +213,7 @@ module UI
     def spin_btn(label, action)
       content_tag(:button, label, type: "button",
         class: SPIN_BTN, "aria-hidden": "true",
-        tabindex: "-1", data: { action: action })
+        tabindex: "-1", data: {action: action})
     end
 
     def clock_icon

--- a/lib/generators/modelrails_ui/add/templates/timepicker/timepicker_controller.js
+++ b/lib/generators/modelrails_ui/add/templates/timepicker/timepicker_controller.js
@@ -1,4 +1,5 @@
 import { Controller } from "@hotwired/stimulus"
+import * as topLayer from "overlays/top_layer"
 
 export default class extends Controller {
   static targets = ["trigger", "popover", "label", "hidden", "hour", "minute", "ampm"]
@@ -18,13 +19,19 @@ export default class extends Controller {
   }
 
   open() {
+    // No-op unless anchor-positioned (`position: fixed`); top_layer.js refuses the
+    // pre-Baseline `absolute` fallback, where promotion would tear the panel off-screen.
     this.popoverTarget.dataset.open = "true"
+    topLayer.enable(this.popoverTarget)
+    topLayer.show(this.popoverTarget)
     this.triggerTarget.setAttribute("aria-expanded", "true")
     document.addEventListener("click", this.#outsideHandler)
     this.isOpen = true
   }
 
   close() {
+    topLayer.hide(this.popoverTarget)
+    topLayer.disable(this.popoverTarget)
     this.popoverTarget.dataset.open = "false"
     this.triggerTarget.setAttribute("aria-expanded", "false")
     document.removeEventListener("click", this.#outsideHandler)

--- a/lib/generators/modelrails_ui/components.rb
+++ b/lib/generators/modelrails_ui/components.rb
@@ -17,6 +17,30 @@ module ModelrailsUi
         "gallery" => {source: "dialog/modal_controller.js", name: "modal"}
       }.freeze
 
+      # Shared ES modules — plain modules, NOT Stimulus controllers. Some behaviour has to
+      # be a single instance shared by every overlay (the top-layer helper below), which a
+      # per-component controller copy cannot provide, so it ships as a module the
+      # controllers import.
+      #
+      # `source` is the canonical copy in the owning component's template dir; `dir` is the
+      # namespace it lands in under app/javascript/, which is also the importmap pin.
+      # Every entry is enforced by test/test_shared_js_modules.rb — an unregistered `.js`
+      # in a template dir would be silently dropped by the generator.
+      TOP_LAYER = {source: "dropdown_menu/top_layer.js", dir: "overlays"}.freeze
+
+      SHARED_JS = {
+        "dropdown_menu" => [TOP_LAYER],
+        "context_menu" => [TOP_LAYER],
+        "menubar" => [TOP_LAYER],
+        "menubar_menu" => [TOP_LAYER],
+        "popover" => [TOP_LAYER],
+        "combobox" => [TOP_LAYER],
+        "date_picker" => [TOP_LAYER],
+        "timepicker" => [TOP_LAYER],
+        "navigation_menu" => [TOP_LAYER],
+        "mega_menu" => [TOP_LAYER]
+      }.freeze
+
       # Post-install instructions for components that require external dependencies.
       SETUP_NOTES = {
         "chart" => <<~TEXT,

--- a/lib/generators/modelrails_ui/install/templates/modelrails_ui.css
+++ b/lib/generators/modelrails_ui/install/templates/modelrails_ui.css
@@ -391,6 +391,30 @@
    — don't override max-width inline; introduce the named variant instead.
    ========================================================================== */
 
+/* ==========================================================================
+   TOP LAYER
+   Overlays promoted by app/javascript/overlays/top_layer.js take the UA's
+   `[popover]` box with them: fixed, inset-0, centred, bordered, opaque. We want
+   only the top layer — the component's own classes keep owning geometry and
+   chrome. In @layer base so it outranks the UA sheet but still loses to Tailwind
+   utilities; `position` is deliberately not reset, since every promoted panel
+   sets its own (and only viewport-positioned panels are promoted at all).
+   ========================================================================== */
+
+@layer base {
+  [data-top-layer] {
+    inset: auto;
+    margin: 0;
+    border: 0;
+    padding: 0;
+    width: auto;
+    height: auto;
+    overflow: visible;
+    background: transparent;
+    color: inherit;
+  }
+}
+
 @layer utilities {
   .page-container {
     @apply max-w-2xl mx-auto px-4;

--- a/test/render/combobox_render_test.rb
+++ b/test/render/combobox_render_test.rb
@@ -36,18 +36,22 @@ class ComboboxRenderTest < ViewComponent::TestCase
 
   # --- combobox + listbox roles -------------------------------------------
 
+  # The listbox id used to be a shared constant, so two comboboxes on one page emitted
+  # duplicate ids and `aria-controls` resolved to whichever rendered first. Assert the
+  # WIRING rather than a literal id — the id is now per-instance.
   def test_input_is_a_combobox_controlling_the_listbox
     render_basic
 
-    assert_selector(
-      "input[role='combobox'][aria-expanded='false'][aria-controls='combobox-list'][aria-autocomplete='list']"
-    )
+    assert_selector "input[role='combobox'][aria-expanded='false'][aria-autocomplete='list']"
+    listbox_id = page.find("[role='listbox']", visible: :all)[:id]
+
+    assert_selector "input[role='combobox'][aria-controls='#{listbox_id}']"
   end
 
   def test_popup_is_a_named_listbox
     render_basic
 
-    assert_selector "div#combobox-list[role='listbox'][aria-label]"
+    assert_selector "div[role='listbox'][aria-label][id]"
   end
 
   def test_options_are_listbox_options_with_aria_selected

--- a/test/render/popover_render_test.rb
+++ b/test/render/popover_render_test.rb
@@ -40,11 +40,33 @@ class PopoverRenderTest < ViewComponent::TestCase
                     "[data-floating-target='panel']", visible: :all
   end
 
-  def test_panel_carries_aaa_tokens_and_positioning
+  # Placement moved from `absolute` + offset classes to CSS anchor positioning, so the
+  # panel is viewport-positioned and can be promoted to the top layer. The old
+  # `.bottom-full.right-0` pair is now only the pre-Baseline fallback.
+  def test_panel_carries_aaa_tokens
     render_popover(side: :top, align: :end)
 
     assert_selector "[data-floating-target='panel'].bg-surface-overlay.text-text-body", visible: :all
-    assert_selector "[data-floating-target='panel'].bottom-full.right-0", visible: :all
+  end
+
+  def test_panel_places_by_anchor_positioning_with_a_fallback
+    render_popover(side: :top, align: :end)
+    classes = page.find("[data-floating-target='panel']", visible: :all)[:class]
+
+    assert_includes classes, "supports-[position-area:bottom]:[position-area:top_span-left]"
+    assert_includes classes, "not-supports-[position-area:bottom]:bottom-full"
+  end
+
+  # The panel is tethered by name, so the anchor and the panel must agree.
+  def test_panel_is_tethered_to_its_wrapper_anchor
+    render_popover(side: :bottom, align: :start)
+
+    anchor = page.find("[data-controller='floating']", visible: :all)[:style]
+    panel = page.find("[data-floating-target='panel']", visible: :all)[:style]
+    name = anchor[/anchor-name:\s*(--[\w-]+)/, 1]
+
+    refute_nil name, "wrapper carries no anchor-name"
+    assert_includes panel, "position-anchor: #{name}"
   end
 
   def test_requires_a_trigger_slot

--- a/test/test_components.rb
+++ b/test/test_components.rb
@@ -1456,14 +1456,33 @@ class TestPopoverComponent < Minitest::Test
   end
 
   def test_all_aligns_defined
-    %i[start center end].each do |align|
-      assert UI::PopoverComponent::ALIGN.key?(align), "Missing align #{align}"
-    end
+    assert_equal %i[start center end], UI::PopoverComponent::ALIGNS
   end
 
   def test_all_sides_defined
-    %i[bottom top left right].each do |side|
-      assert UI::PopoverComponent::SIDE.key?(side), "Missing side #{side}"
+    assert_equal %i[bottom top left right], UI::PopoverComponent::SIDES
+  end
+
+  # Anchor positioning replaced the separate side/align class maps with one cell per
+  # placement, because the old pair emitted BOTH `left-0` and `right-full` for a left/right
+  # side — CSS drops `right` when left, width and right are all set, so those placements
+  # rendered on top of the trigger. Every cell must exist or `PLACEMENTS.fetch` raises.
+  def test_every_side_align_pair_has_a_placement
+    UI::PopoverComponent::SIDES.each do |side|
+      UI::PopoverComponent::ALIGNS.each do |align|
+        assert UI::PopoverComponent::PLACEMENTS.key?(:"#{side}_#{align}"),
+          "Missing placement #{side}_#{align}"
+      end
+    end
+  end
+
+  # The modern path must be `fixed` — that is the invariant top_layer.js gates on, and an
+  # `absolute` panel promoted to the top layer resolves against the viewport, not its
+  # trigger. The pre-Baseline fallback stays `absolute` and is deliberately not promoted.
+  def test_placements_are_viewport_positioned_on_the_modern_path
+    UI::PopoverComponent::PLACEMENTS.each do |cell, classes|
+      assert_includes classes, "supports-[position-area:bottom]:fixed", "#{cell} is not viewport-positioned"
+      assert_includes classes, "not-supports-[position-area:bottom]:absolute", "#{cell} has no fallback"
     end
   end
 end

--- a/test/test_shared_js_modules.rb
+++ b/test/test_shared_js_modules.rb
@@ -1,0 +1,79 @@
+# frozen_string_literal: true
+
+require "test_helper"
+require "rails/generators"
+require_relative "../lib/generators/modelrails_ui/add/add_generator"
+
+# Shared ES modules are the third kind of JS a component can ship, alongside its own
+# Stimulus controller and one reused via EXTRA_STIMULUS. They exist because some behaviour
+# has to be a SINGLE instance across every component that uses it (a layer stack, a top-layer
+# helper), which a per-component controller copy cannot provide.
+#
+# The generator used to route only `*.rb.tt`, `*.html.erb` and `*_controller.js`; a plain
+# `.js` file in a template directory was dropped with no warning, and the host importmap
+# never learned about it. These tests pin both halves of the fix.
+class TestSharedJsModules < Minitest::Test
+  TEMPLATES = File.expand_path("../lib/generators/modelrails_ui/add/templates", __dir__)
+
+  def generator = ModelrailsUi::Generators::AddGenerator.allocate
+
+  # The invariant that makes a silent drop impossible: every plain `.js` sitting in a
+  # template directory must be claimed by SHARED_JS, or the generator would ignore it.
+  def test_every_plain_js_template_is_registered_as_a_shared_module
+    registered = ModelrailsUi::Generators::Components::SHARED_JS.values.flatten
+      .map { |m| m.fetch(:source) }.uniq
+
+    on_disk = Dir.glob("#{TEMPLATES}/*/*.js")
+      .reject { |p| p.end_with?("_controller.js") }
+      .map { |p| p.delete_prefix("#{TEMPLATES}/") }
+
+    assert_equal on_disk.sort, (on_disk & registered).sort,
+      "unregistered shared modules would be silently dropped: #{(on_disk - registered).inspect}"
+  end
+
+  def test_registered_shared_module_sources_exist_on_disk
+    ModelrailsUi::Generators::Components::SHARED_JS.each do |component, modules|
+      modules.each do |mod|
+        assert_path_exists File.join(TEMPLATES, mod.fetch(:source)),
+          "#{component} declares a shared module that is not in templates/"
+      end
+    end
+  end
+
+  # Every component whose controller imports a shared module must declare it, or the
+  # generated app raises on a bare-module import that nothing pinned.
+  def test_components_importing_a_shared_module_declare_it
+    missing = Dir.glob("#{TEMPLATES}/*/*_controller.js").filter_map do |path|
+      imported = File.read(path).scan(/from\s+"([a-z_]+\/[a-z_]+)"/).flatten
+      next if imported.empty?
+
+      component = File.basename(File.dirname(path))
+      declared = shared_dirs_for(component)
+      unmet = imported.reject { |ref| declared.include?(ref.split("/").first) }
+      [component, unmet] if unmet.any?
+    end
+
+    assert_empty missing, "controllers import shared modules their component does not declare: #{missing.inspect}"
+  end
+
+  def test_shared_module_destination_is_namespaced_under_app_javascript
+    mod = {source: "dropdown_menu/top_layer.js", dir: "overlays"}
+
+    assert_equal "app/javascript/overlays/top_layer.js",
+      generator.send(:shared_js_destination, mod)
+  end
+
+  def test_pin_line_matches_the_namespace_directory
+    assert_equal %(pin_all_from "app/javascript/overlays", under: "overlays"),
+      generator.send(:shared_js_pin, "overlays")
+  end
+
+  private
+
+  # A component's own declaration plus anything it inherits with a reused controller.
+  def shared_dirs_for(component)
+    registry = ModelrailsUi::Generators::Components
+    owners = [component] + registry::EXTRA_STIMULUS.select { |_k, v| v[:source].start_with?("#{component}/") }.keys
+    owners.flat_map { |c| (registry::SHARED_JS[c] || []).map { |m| m.fetch(:dir) } }.uniq
+  end
+end


### PR DESCRIPTION
Closes B7 and back-ports modelrails_base #700–#703, so forks get this work rather than only that checkout.

## Why B7 blocked everything

The generator routed only `*.rb.tt`, `*.html.erb` and `*_controller.js`. A plain `.js` in a template directory was **dropped with no warning**, and the host importmap never learned about it — so a controller importing a bare specifier would throw on import and silently never connect.

That blocked any behaviour needing a **single shared instance** across components, which a per-component controller copy cannot provide. `Components::SHARED_JS` fixes it: `source` is the canonical copy in the owning component's template dir, `dir` is the namespace under `app/javascript/` and the importmap pin. The pin is **appended automatically** rather than printed as an instruction — a missed manual step here is invisible until something stops working.

The generator also no longer drops unrecognised template files silently.

## What was back-ported

**Top layer.** A `sticky` or `backdrop-blur` ancestor establishes a stacking context that no z-index escapes from the inside. Promotion paints above it — gated on the panel already being `position: fixed`, because the top layer re-parents the containing block to the viewport. An `absolute`-placed panel would be torn off its trigger, which is why anchor positioning was a **prerequisite**, not a follow-up.

**Anchor positioning** for popover, combobox, date_picker, timepicker, navigation_menu and mega_menu — joining dropdown_menu and menubar_menu, which already had it. Panels now flip to stay on-screen where static offsets clipped. Width-tied panels use `anchor-size(width)`, since `w-full` against the viewport means the whole screen.

**Menu upgrades:** checkable items (`menuitemcheckbox`/`menuitemradio`, toggling in place and keeping the menu open), `tone: :danger`, and nested submenus. The submenu controller uses a **distinct identifier** so the sub-trigger can be an item of the parent menu *and* its own trigger without a target collision.

## Two latent bugs fixed

- **Popover `side: :left`/`:right` rendered the panel ON its trigger.** The old maps emitted both `left-0` and `right-full`; CSS drops `right` when left, width and right are all set. Every `side` × `align` cell is now covered by a test.
- **Combobox emitted a hardcoded listbox id**, so two on a page produced duplicate ids and `aria-controls` resolved to the first. Ids are per-instance now. **`UI::Command` still has this bug** — deliberately out of scope.

## Previews and docs

`checkable_items` and `submenus` Lookbook scenarios, plus the API docs behind them.

Two doc pages were made *wrong* by the back-port, not merely incomplete, and are corrected: popover's "Limitation — the panel has no top layer" section, and its intro describing `relative` wrapper + `absolute` panel placement. The five other migrated components made no positioning claims, so nothing was stale; each gets a short note that its panel is now promoted, since a fork with CSS relying on the old stacking behaviour would want to know.

## Notes for review

- Templates were hand-ported, not copied: base and the gem differ in brace spacing and the gem carries section-divider comments. I diffed against base *before* this arc to separate my changes from pre-existing drift, then normalised style with RuboCop.
- Three render tests failed and were **updated, not deleted** — they pinned the old class strings and the literal listbox id. They now assert the contract: placement cell + anchor/panel tethering, and `aria-controls` wiring. That lane doing its job is the main reason I trust this port.
- A new test enforces the invariant that made B7 possible: every plain `.js` in a template dir must be registered in `SHARED_JS`, or it would be silently dropped again.
- The stacking-context previews stay in modelrails_base — they are regression fixtures for a browser lane the gem does not have yet (B4).

Full CI green — 533 structural + 919 render runs, RuboCop clean across 218 files.