### PR TITLE
fix(command): per-instance element ids

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- Command emitted a constant listbox id, so two palettes on a page produced duplicate ids and the `aria-controls` pointing at one resolved to whichever rendered first. Ids are per-instance now — the same bug fixed in Combobox.
+- Combobox and Command minted option ids from a hardcoded prefix with a per-instance counter, so two instances each produced `-option-0` and `aria-activedescendant` named an ambiguous node. Prefixes derive from the host element's id.
+
 - Popover `side: :left`/`:right` rendered the panel ON its trigger instead of beside it. The old maps emitted both `left-0` and `right-full`, and CSS drops `right` when left, width and right are all set. Anchor positioning replaces the pair with one cell per placement, and every `side` × `align` cell is now covered by a test.
 - Combobox emitted a hardcoded listbox id, so two comboboxes on a page produced duplicate ids and `aria-controls` resolved to whichever rendered first. Ids are now per-instance. **UI::Command still has this bug.**
 - Generator no longer drops unrecognised template files silently — it says which file it skipped. A plain `.js` in a template directory used to vanish with no warning and no pin, leaving a bare-specifier import that throws at runtime.

--- a/lib/generators/modelrails_ui/add/templates/combobox/combobox_controller.js
+++ b/lib/generators/modelrails_ui/add/templates/combobox/combobox_controller.js
@@ -108,9 +108,16 @@ export default class extends Controller {
 
   // Promote options to stable ids so aria-activedescendant can reference them
   // (the markup ships role="option"; the id contract is applied here).
+  // The host element's id is unique per instance; deriving the prefix from it keeps
+  // option ids unique across several instances on one page, which aria-activedescendant
+  // depends on to point at the right node.
+  get _idPrefix() {
+    return this.element.id || "combobox"
+  }
+
   _tagOptions() {
     this.optionTargets.forEach(option => {
-      if (!option.id) option.id = `combobox-option-${this._optionId++}`
+      if (!option.id) option.id = `${this._idPrefix}-option-${this._optionId++}`
     })
   }
 

--- a/lib/generators/modelrails_ui/add/templates/command/command_component.rb.tt
+++ b/lib/generators/modelrails_ui/add/templates/command/command_component.rb.tt
@@ -76,6 +76,7 @@ module UI
 
     def initialize(size: :md, **html_attrs)
       @size        = coerce_size(size)
+      @id          = html_attrs.delete(:id) || "command-#{SecureRandom.hex(4)}"
       @extra_class = html_attrs.delete(:class)
       # Merge the controller wiring into any caller `data:` so a passed-through
       # `data:` attr can't clobber `data-controller` and silently break Stimulus.
@@ -84,7 +85,7 @@ module UI
     end
 
     def call
-      content_tag(:div, data: @data, **@html_attrs) do
+      content_tag(:div, id: @id, data: @data, **@html_attrs) do
         concat content_tag(:span, trigger, data: {action: "click->command#open"}, class: "contents") if trigger
         concat panel
       end
@@ -92,7 +93,9 @@ module UI
 
     private
 
-    LIST_ID = "command-list"
+    # Derived per instance: a constant id collides the moment a page renders two
+    # palettes, and the aria-controls pointing at it resolves to the first.
+    def list_id = "#{@id}-list"
 
     def panel
       content_tag(:div, data: {command_target: "panel"}, hidden: true) do
@@ -109,7 +112,7 @@ module UI
           concat search_bar
           concat content_tag(:div,
             class: LIST,
-            id: LIST_ID,
+            id: list_id,
             role: "listbox",
             "aria-label": I18n.t("modelrails_ui.command.list_label", default: "Commands"),
             data: {command_target: "list"}) {
@@ -134,7 +137,7 @@ module UI
           placeholder: I18n.t("modelrails_ui.command.placeholder", default: "Type a command or search…"),
           "aria-label": I18n.t("modelrails_ui.command.input_label", default: "Search commands"),
           "aria-expanded": "true",
-          "aria-controls": LIST_ID,
+          "aria-controls": list_id,
           "aria-autocomplete": "list",
           autocomplete: "off",
           spellcheck: "false",

--- a/lib/generators/modelrails_ui/add/templates/command/command_controller.js
+++ b/lib/generators/modelrails_ui/add/templates/command/command_controller.js
@@ -107,10 +107,17 @@ export default class extends Controller {
 
   // Promote caller-supplied items to listbox options with stable ids (the markup
   // stays plain — the role/id contract is applied here so callers can't break it).
+  // The host element's id is unique per instance; deriving the prefix from it keeps
+  // option ids unique across several instances on one page, which aria-activedescendant
+  // depends on to point at the right node.
+  get _idPrefix() {
+    return this.element.id || "command"
+  }
+
   _tagOptions() {
     this.options.forEach(item => {
       item.setAttribute("role", "option")
-      if (!item.id) item.id = `command-option-${this._optionId++}`
+      if (!item.id) item.id = `${this._idPrefix}-option-${this._optionId++}`
     })
   }
 

--- a/test/render/command_render_test.rb
+++ b/test/render/command_render_test.rb
@@ -52,7 +52,7 @@ class CommandRenderTest < ViewComponent::TestCase
   def test_input_is_a_combobox_controlling_the_listbox
     render_basic
 
-    assert_selector "input[role='combobox'][aria-controls='command-list'][aria-autocomplete='list'][aria-expanded='true']"
+    assert_selector "input[role='combobox'][aria-autocomplete='list'][aria-expanded='true']"
     assert_selector "input[data-command-target='input']"
   end
 
@@ -65,11 +65,16 @@ class CommandRenderTest < ViewComponent::TestCase
     assert_selector "input[data-action~='keydown->command#navigate']"
   end
 
-  # The list is the listbox the combobox points at — same id, with an accessible name.
+  # The list is the listbox the combobox points at — assert the MATCH, not a literal id.
+  # The id is per-instance now: a constant one collided the moment a page rendered two
+  # palettes, and `aria-controls` then resolved to whichever came first.
   def test_list_is_a_named_listbox_matching_the_combobox
     render_basic
 
-    assert_selector "div#command-list[role='listbox'][aria-label='Commands'][data-command-target='list']"
+    assert_selector "div[role='listbox'][aria-label='Commands'][data-command-target='list'][id]"
+    listbox_id = page.find("[role='listbox']", visible: :all)[:id]
+
+    assert_selector "input[role='combobox'][aria-controls='#{listbox_id}']"
   end
 
   # The dialog is a labelled modal.


### PR DESCRIPTION
Back-ports modelrails_base #704.

`Command` emitted a constant listbox id, so two palettes on a page produced duplicate ids and the `aria-controls` pointing at one resolved to whichever rendered first — assistive tech then describes the wrong node. Same bug fixed in `Combobox` in #90.

## The runtime half, in both components

The earlier Combobox fix was incomplete. Both controllers minted option ids from a hardcoded prefix with a per-instance counter:

```js
if (!option.id) option.id = `combobox-option-${this._optionId++}`
```

Two instances each produce `-option-0`, so `aria-activedescendant` names an ambiguous node — the failure that actually reaches a screen reader. Prefixes now derive from the host element's id, which is already unique.

## Render tests

`test_list_is_a_named_listbox_matching_the_combobox` pinned the literal `command-list`. It now asserts the **match** between `aria-controls` and the listbox id — which is what the test's own name always claimed to check, and what survives the id becoming per-instance.

The host-side guard lives in modelrails_base (`spec/code_smells/no_constant_element_ids_spec.rb`) since that is where the browser lane runs; it is what found the runtime half.

Full CI green — 533 structural + 919 render runs, RuboCop clean.