### PR TITLE
feat(tabs): vertical orientation and manual activation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- Tabs: `orientation: :vertical` (↑/↓ navigation, `aria-orientation`, restacked bar) and `activation: :manual` (arrows move the tab stop; Enter/Space reveals). Both default to the previous behaviour — horizontal and automatic — so existing call sites are unaffected.
+
+### Added
+
 - Generator: shared ES modules. A component can now ship a plain module alongside its Stimulus controller (`Components::SHARED_JS`), copied to `app/javascript/<namespace>/` with the importmap pin added automatically. Needed for behaviour that must be a SINGLE instance across components — a per-component controller copy cannot provide it. First user: `top_layer.js`.
 
 - Overlays reach the browser top layer. `sticky`/`backdrop-blur` chrome establishes a stacking context that no z-index escapes from the inside; promoted panels paint above it. Promotion is gated on the panel already being `position: fixed`, because the top layer re-parents an element's containing block to the viewport — an `absolute`-placed panel would be torn off its trigger.

--- a/docs/components/tabs.md
+++ b/docs/components/tabs.md
@@ -50,6 +50,27 @@ via `cn`, and the panels/root are untouched.
 | click | Reveal that tab's panel |
 | `Tab` again | Move into the active panel (it is `tabindex="0"`) |
 
+## Orientation and activation
+
+| Arg | Values | Default |
+|-----|--------|---------|
+| `orientation` | `:horizontal` (←/→), `:vertical` (↑/↓) | `:horizontal` |
+| `activation` | `:automatic`, `:manual` | `:automatic` |
+
+`orientation` also sets `aria-orientation` and restacks the bar. The other arrow axis is
+deliberately inert, per APG — a horizontal tablist ignoring ↑/↓ leaves those keys to the
+page rather than trapping them.
+
+`:automatic` reveals a panel as focus reaches its tab. That is the default because panels
+render inline and eager, so there is no latency to hide. Use `:manual` when a panel is
+expensive to reveal: the arrows move the tab stop, and `Enter`/`Space` commits.
+
+```erb
+<%= render(UI::TabsComponent.new(label: "Settings", orientation: :vertical, activation: :manual)) do |t| %>
+  <% t.with_tab(title: "Profile") { "…" } %>
+<% end %>
+```
+
 ## Accessibility
 
 WCAG 2.2 AAA. `role="tablist"` named by `label:`; each `role="tab"` carries `aria-selected`,

--- a/lib/generators/modelrails_ui/add/templates/tabs/tabs_component.rb.tt
+++ b/lib/generators/modelrails_ui/add/templates/tabs/tabs_component.rb.tt
@@ -28,14 +28,28 @@ module UI
     # rubocop:enable Layout/LineLength
     PANEL = "mt-2 focus-ring"
 
+    ORIENTATIONS = %i[horizontal vertical].freeze
+    ACTIVATIONS = %i[automatic manual].freeze
+
+    # Vertical tablists stack, so the bar grows down instead of across.
+    TABLIST_VERTICAL = "inline-flex flex-col items-stretch rounded-lg bg-surface-sunken " \
+                       "p-1 text-text-muted"
+
     # label:    accessible name for the tablist (aria-label; required; i18n at the call site).
     # selected: index of the initially-active tab (default 0).
     # id:       base id (auto-generated; → tab/panel ids).
     # tablist_class: extra classes merged onto the tablist bar (placement/styling —
     #           e.g. a tablist floated over a media stage).
-    def initialize(label:, selected: 0, id: nil, tablist_class: nil, **html_attrs)
+    # orientation: :horizontal (←/→) | :vertical (↑/↓) — also sets aria-orientation.
+    # activation:  :automatic (focus reveals the panel, APG default) | :manual (arrows move
+    #           focus only; Enter/Space reveals). Manual suits panels that are expensive to
+    #           reveal, where activating on every arrow press would thrash.
+    def initialize(label:, selected: 0, id: nil, tablist_class: nil, orientation: :horizontal,
+      activation: :automatic, **html_attrs)
       @label = label
       @tablist_class = tablist_class
+      @orientation = coerce(:orientation, orientation, ORIENTATIONS)
+      @activation = coerce(:activation, activation, ACTIVATIONS)
       @selected = selected.to_i
       @id = id || "tabs-#{SecureRandom.hex(4)}"
       @extra_class = html_attrs.delete(:class)
@@ -46,18 +60,30 @@ module UI
       caller_data = @html_attrs.delete(:data) || {}
       content_tag(:div, safe_join([tablist, *panels]),
         class: cn("w-full", @extra_class),
-        data: {controller: "tabs", tabs_index_value: @selected}.merge(caller_data),
+        data: {
+          controller: "tabs",
+          tabs_index_value: @selected,
+          tabs_orientation_value: @orientation,
+          tabs_activation_value: @activation
+        }.merge(caller_data),
         **@html_attrs)
     end
 
     private
 
+    def coerce(name, value, allowed)
+      key = value.to_sym
+      return key if allowed.include?(key)
+
+      raise ArgumentError, "UI::Tabs unknown #{name}: #{value.inspect} (allowed: #{allowed.join(", ")})"
+    end
+
     def tablist
       content_tag(:div, safe_join(tabs.each_with_index.map { |tab, i| trigger(tab, i) }),
         role: "tablist",
         "aria-label": @label,
-        "aria-orientation": "horizontal",
-        class: cn(TABLIST, @tablist_class))
+        "aria-orientation": @orientation,
+        class: cn((@orientation == :vertical ? TABLIST_VERTICAL : TABLIST), @tablist_class))
     end
 
     def trigger(tab, index)

--- a/lib/generators/modelrails_ui/add/templates/tabs/tabs_controller.js
+++ b/lib/generators/modelrails_ui/add/templates/tabs/tabs_controller.js
@@ -1,14 +1,25 @@
 import { Controller } from "@hotwired/stimulus"
 
-// WAI-ARIA APG tabs — AUTOMATIC activation. Roving tabindex across the role=tab buttons; the
-// active tab is tabindex=0, the rest -1. ←/→ move focus AND activate (show the panel),
-// wrapping and skipping aria-disabled tabs; Home/End jump to the first/last enabled tab; a
-// click activates. Horizontal orientation only (no ArrowUp/Down). Panels render inline/eager,
-// so activating on focus has no latency. INVARIANT: keep automatic — Enter/Space are no-ops
-// because focus already activated.
+// WAI-ARIA APG tabs. Roving tabindex across the role=tab buttons; the active tab is
+// tabindex=0, the rest -1. Arrow keys wrap and skip aria-disabled tabs; Home/End jump to
+// the first/last enabled tab; a click activates.
+//
+// Two axes, both defaulting to what this shipped with:
+//   orientation — horizontal (←/→) or vertical (↑/↓). The OTHER axis is deliberately inert,
+//     per APG: a horizontal tablist ignoring ↑/↓ leaves those keys to the page.
+//   activation  — automatic (focus reveals the panel) or manual (arrows move focus only,
+//     Enter/Space reveals). Panels render inline/eager, so automatic has no latency and
+//     stays the default; manual exists for panels that are expensive to reveal, where
+//     activating on every arrow press would thrash.
+//
+// Under automatic, Enter/Space are no-ops because focus already activated.
 export default class extends Controller {
   static targets = ["tab", "panel"]
-  static values = { index: Number }
+  static values = {
+    index: Number,
+    orientation: { type: String, default: "horizontal" },
+    activation: { type: String, default: "automatic" }
+  }
 
   connect() {
     const start = this.#disabled(this.indexValue) ? (this.#firstEnabled() ?? 0) : this.indexValue
@@ -26,17 +37,40 @@ export default class extends Controller {
   navigate(event) {
     const current = this.tabTargets.indexOf(event.currentTarget)
     if (current < 0) return
+    const vertical = this.orientationValue === "vertical"
+    const forward = vertical ? "ArrowDown" : "ArrowRight"
+    const back = vertical ? "ArrowUp" : "ArrowLeft"
+
+    // Manual activation: Enter/Space reveal whatever the arrows moved focus to.
+    if (this.activationValue === "manual" && (event.key === "Enter" || event.key === " ")) {
+      event.preventDefault()
+      this.#activate(current, { focus: true })
+      return
+    }
+
     let next = null
     switch (event.key) {
-      case "ArrowRight": next = this.#adjacent(current, 1); break
-      case "ArrowLeft":  next = this.#adjacent(current, -1); break
-      case "Home":       next = this.#firstEnabled(); break
-      case "End":        next = this.#lastEnabled(); break
+      case forward: next = this.#adjacent(current, 1); break
+      case back:    next = this.#adjacent(current, -1); break
+      case "Home":  next = this.#firstEnabled(); break
+      case "End":   next = this.#lastEnabled(); break
       default: return
     }
     if (next === null) return
     event.preventDefault()
-    this.#activate(next, { focus: true })
+
+    if (this.activationValue === "manual") {
+      this.#focusOnly(next)
+    } else {
+      this.#activate(next, { focus: true })
+    }
+  }
+
+  // Manual mode moves the tab stop with focus (APG) but leaves aria-selected and the
+  // panels alone until the user commits.
+  #focusOnly(index) {
+    this.tabTargets.forEach((tab, i) => tab.setAttribute("tabindex", i === index ? "0" : "-1"))
+    this.tabTargets[index]?.focus()
   }
 
   #adjacent(from, delta) {

--- a/lib/generators/modelrails_ui/lookbook/templates/previews/ui/tabs_component_preview.rb
+++ b/lib/generators/modelrails_ui/lookbook/templates/previews/ui/tabs_component_preview.rb
@@ -25,5 +25,14 @@ module UI
     # Profile / Password / Notifications (Notifications disabled).
     def basic
     end
+
+    # Vertical tablist — ↑/↓ navigate instead of ←/→.
+    def vertical
+    end
+
+    # Manual activation — arrows move focus only; Enter/Space reveals the panel. Suits
+    # panels that are expensive to reveal.
+    def manual
+    end
   end
 end

--- a/lib/generators/modelrails_ui/lookbook/templates/previews/ui/tabs_component_preview/manual.html.erb
+++ b/lib/generators/modelrails_ui/lookbook/templates/previews/ui/tabs_component_preview/manual.html.erb
@@ -1,0 +1,22 @@
+<div class="min-h-96 p-12">
+  <%= render(UI::TabsComponent.new(label: "Account settings", activation: :manual)) do |t| %>
+    <% t.with_tab(title: "Profile") do %>
+      <div class="rounded-md border border-border bg-surface-raised p-4 text-text-body">
+        <h3 class="font-medium text-text-heading">Profile</h3>
+        <p class="mt-1 text-sm">Manage your public profile and avatar.</p>
+      </div>
+    <% end %>
+    <% t.with_tab(title: "Password") do %>
+      <div class="rounded-md border border-border bg-surface-raised p-4 text-text-body">
+        <h3 class="font-medium text-text-heading">Password</h3>
+        <p class="mt-1 text-sm">Change your password and review active sessions.</p>
+      </div>
+    <% end %>
+    <% t.with_tab(title: "Notifications", disabled: true) do %>
+      <div class="rounded-md border border-border bg-surface-raised p-4 text-text-body">
+        <h3 class="font-medium text-text-heading">Notifications</h3>
+        <p class="mt-1 text-sm">Coming soon.</p>
+      </div>
+    <% end %>
+  <% end %>
+</div>

--- a/lib/generators/modelrails_ui/lookbook/templates/previews/ui/tabs_component_preview/vertical.html.erb
+++ b/lib/generators/modelrails_ui/lookbook/templates/previews/ui/tabs_component_preview/vertical.html.erb
@@ -1,0 +1,22 @@
+<div class="min-h-96 p-12">
+  <%= render(UI::TabsComponent.new(label: "Account settings", orientation: :vertical)) do |t| %>
+    <% t.with_tab(title: "Profile") do %>
+      <div class="rounded-md border border-border bg-surface-raised p-4 text-text-body">
+        <h3 class="font-medium text-text-heading">Profile</h3>
+        <p class="mt-1 text-sm">Manage your public profile and avatar.</p>
+      </div>
+    <% end %>
+    <% t.with_tab(title: "Password") do %>
+      <div class="rounded-md border border-border bg-surface-raised p-4 text-text-body">
+        <h3 class="font-medium text-text-heading">Password</h3>
+        <p class="mt-1 text-sm">Change your password and review active sessions.</p>
+      </div>
+    <% end %>
+    <% t.with_tab(title: "Notifications", disabled: true) do %>
+      <div class="rounded-md border border-border bg-surface-raised p-4 text-text-body">
+        <h3 class="font-medium text-text-heading">Notifications</h3>
+        <p class="mt-1 text-sm">Coming soon.</p>
+      </div>
+    <% end %>
+  <% end %>
+</div>

--- a/test/render/tabs_render_test.rb
+++ b/test/render/tabs_render_test.rb
@@ -98,4 +98,58 @@ class TabsRenderTest < ViewComponent::TestCase
   def test_tab_item_requires_a_title
     assert_raises(ArgumentError) { UI::TabsItemComponent.new }
   end
+
+  # orientation / activation — both default to what this component shipped with, so
+  # existing call sites are unaffected. The controller reads the Stimulus values; the
+  # keyboard behaviour itself is proven by the app browser spec.
+  def test_orientation_defaults_to_horizontal
+    render_tabs
+
+    assert_selector "[data-tabs-orientation-value='horizontal']", visible: :all
+  end
+
+  def test_vertical_orientation_is_declared_and_restacks_the_bar
+    render_inline(UI::TabsComponent.new(label: "Account", orientation: :vertical)) do |t|
+      t.with_tab(title: "Profile") { "profile body" }
+    end
+
+    assert_selector "div[role='tablist'][aria-orientation='vertical'].flex-col", visible: :all
+    assert_selector "[data-tabs-orientation-value='vertical']", visible: :all
+  end
+
+  def test_activation_defaults_to_automatic
+    render_tabs
+
+    assert_selector "[data-tabs-activation-value='automatic']", visible: :all
+  end
+
+  def test_manual_activation_is_declared
+    render_inline(UI::TabsComponent.new(label: "Account", activation: :manual)) do |t|
+      t.with_tab(title: "Profile") { "profile body" }
+    end
+
+    assert_selector "[data-tabs-activation-value='manual']", visible: :all
+  end
+
+  # tablist_class still merges when the bar restacks — the vertical base class set is a
+  # different constant, so this is the case a naive swap would drop.
+  def test_tablist_class_merges_onto_a_vertical_tablist
+    render_inline(UI::TabsComponent.new(label: "Account", orientation: :vertical, tablist_class: "w-48")) do |t|
+      t.with_tab(title: "Profile") { "profile body" }
+    end
+
+    assert_selector "div[role='tablist'].w-48.flex-col.bg-surface-sunken", visible: :all
+  end
+
+  def test_unknown_orientation_raises
+    error = assert_raises(ArgumentError) { UI::TabsComponent.new(label: "Account", orientation: :diagonal) }
+
+    assert_match(/orientation/, error.message)
+  end
+
+  def test_unknown_activation_raises
+    error = assert_raises(ArgumentError) { UI::TabsComponent.new(label: "Account", activation: :telepathic) }
+
+    assert_match(/activation/, error.message)
+  end
 end


### PR DESCRIPTION
Back-ports modelrails_base #705.

| Arg | Values | Default |
|-----|--------|---------|
| `orientation` | `:horizontal` (←/→), `:vertical` (↑/↓) | `:horizontal` |
| `activation` | `:automatic`, `:manual` | `:automatic` |

Both default to the previous behaviour, so existing call sites render and behave identically.

`orientation` also sets `aria-orientation` and restacks the bar. The other arrow axis stays deliberately **inert**, per APG — a horizontal tablist ignoring ↑/↓ leaves those keys to the page rather than trapping them.

`:automatic` stays the default because panels render inline and eager, so revealing on focus has no latency. `:manual` exists for panels expensive to reveal: arrows move the tab stop, Enter/Space commits.

## Hand-ported, not copied

`tablist_class:` exists in this gem but **not** in base, so a wholesale copy would have silently deleted it. A render test now covers it merging onto the **vertical** bar as well — that path uses a different base class set and is precisely what a naive swap would drop.

## Comments that became false

The controller header claimed "Horizontal orientation only (no ArrowUp/Down)" and carried `INVARIANT: keep automatic`. Both were statements about the only modes it had rather than design constraints, so they are rewritten to describe both axes rather than left contradicting the code.

## Testing

Seven render tests: both defaults, both new values declared and reflected in `aria-orientation`/the bar's classes, `tablist_class` on the vertical path, and unknown values raising.

Keyboard behaviour is proven in base (#705) where the browser lane lives, with controls that make each direction non-vacuous (horizontal ignores ↑/↓ and vertical ignores ←/→) and probes confirming sensitivity.

Full CI green — 533 structural + 926 render runs, RuboCop clean.