### PR TITLE
feat(ui): checkbox indeterminate, collapsible disabled, breadcrumb ellipsis, avatar error fallback

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- Checkbox: `indeterminate:` for tri-state parents. Ships an `indeterminate` controller, since the property has no HTML attribute; deliberately does not also set `checked`.
+- Collapsible: `disabled:` — `aria-disabled` + out of the tab order + pointer-inert, no JS. An already-open disclosure stays open.
+- Breadcrumb: `max_items:` collapses the middle of a long trail behind an ellipsis, dropping the collapsed crumbs for every audience rather than hiding them from one.
+- Avatar: initials now take over when the image FAILS to load, not only when `src` is nil. Wired only when both a `src` and a `fallback` are given, so src-only call sites keep their bare `<img>`.
+
+### Added
+
 - Tabs: `orientation: :vertical` (↑/↓ navigation, `aria-orientation`, restacked bar) and `activation: :manual` (arrows move the tab stop; Enter/Space reveals). Both default to the previous behaviour — horizontal and automatic — so existing call sites are unaffected.
 
 ### Added

--- a/docs/components/avatar.md
+++ b/docs/components/avatar.md
@@ -46,3 +46,14 @@ Creates `app/components/ui/avatar_component.rb`.
 | `fallback` | String | `nil` | Overrides `alt` as the initials source |
 | `size` | Symbol | `:default` | Size variant |
 | `**html_attrs` | Hash | — | Forwarded to the outer `<div>` |
+
+## When the image fails to load
+
+`fallback:` stands in for a **nil** `src`. It does not cover a `src` that 404s — that
+leaves the browser's broken-image glyph, and the `error` event is the only signal for it.
+
+Pass both a `src` and a `fallback` and the component wires an `avatar` controller that
+swaps the initials in on failure. It **removes** the failed `<img>` rather than hiding it:
+a hidden-but-present image keeps announcing a picture that never arrived.
+
+A `src` with no `fallback` renders a bare `<img>`, unchanged.

--- a/docs/components/breadcrumb.md
+++ b/docs/components/breadcrumb.md
@@ -28,6 +28,18 @@ A **non-last** item without an `href` renders as plain text (never a dead `<a>`)
 "linked for some viewers, plain for others" crumbs — e.g. a parent page whose link is
 policy-gated — stay expressible with the same `items:` array.
 
+## Collapsing a long trail
+
+`max_items:` keeps the root and the tail and stands one ellipsis in for the rest.
+
+```erb
+<%= render(UI::BreadcrumbComponent.new(items: trail, max_items: 3)) %>
+```
+
+The collapsed crumbs are dropped for **everyone** — there is no visually-hidden copy. A
+trail that reads as four levels to a screen reader and two on screen describes a structure
+neither audience can act on, so the rendered trail stays truthful to both.
+
 ## Accessibility
 
 WCAG 2.2 AAA. `<nav>` named by `label:`; an `<ol>` of crumbs; the current page is

--- a/docs/components/checkbox.md
+++ b/docs/components/checkbox.md
@@ -54,3 +54,16 @@ Creates `app/components/ui/checkbox_component.rb`.
 | `label` | String | `nil` | Text shown next to the checkbox in a `<label>` |
 | `checked` | Boolean | `false` | Pre-checked state |
 | `**html_attrs` | Hash | — | Forwarded to the `<input type="checkbox">` element |
+
+## Indeterminate (tri-state)
+
+`indeterminate: true` marks a "some children selected" parent. There is no HTML attribute
+for it — `indeterminate` is a DOM property — so the component ships an `indeterminate`
+Stimulus controller that sets it on connect and clears it once the user acts.
+
+```erb
+<%= render(UI::CheckboxComponent.new(label: "Select all", indeterminate: true, name: "all")) %>
+```
+
+It deliberately does **not** also set `checked`: a partially-selected parent must not
+submit as checked. Without JS the box renders unchecked, which is the honest degradation.

--- a/docs/components/collapsible.md
+++ b/docs/components/collapsible.md
@@ -44,3 +44,12 @@ Creates `app/components/ui/collapsible_component.rb`.
 | Slot | Required | Description |
 |------|----------|-------------|
 | `trigger` | No | Content of the `<summary>` row |
+
+## Disabled
+
+`disabled: true` announces the disclosure as disabled (`aria-disabled`), removes it from
+the tab order, and makes it pointer-inert. `<details>` has no `disabled` attribute, so
+this is the ARIA equivalent — still no JS.
+
+An already-open disclosure **stays open**: disabling blocks the control, it does not
+collapse content out from under someone reading it.

--- a/lib/generators/modelrails_ui/add/templates/avatar/avatar_component.rb.tt
+++ b/lib/generators/modelrails_ui/add/templates/avatar/avatar_component.rb.tt
@@ -6,14 +6,16 @@ module UI
     # and hue-tinted initials. The app's avatar_for helper keeps the model logic
     # (avatar_source / Active Storage / gravatar / primary_color) and renders this.
     SIZES = {
-      xs: { css: "w-6 h-6",   text: "text-xs" },
-      sm: { css: "w-8 h-8",   text: "text-xs" },
-      md: { css: "w-10 h-10", text: "text-sm" },
-      lg: { css: "w-16 h-16", text: "text-lg" },
-      xl: { css: "w-32 h-32", text: "text-3xl" }
+      xs: {css: "w-6 h-6",   text: "text-xs"},
+      sm: {css: "w-8 h-8",   text: "text-xs"},
+      md: {css: "w-10 h-10", text: "text-sm"},
+      lg: {css: "w-16 h-16", text: "text-lg"},
+      xl: {css: "w-32 h-32", text: "text-3xl"}
     }.freeze
 
-    # src:        image URL (renders <img>); falls back to initials when nil
+    # src:        image URL (renders <img>); falls back to initials when nil. When a
+    #             `fallback:` is also given, a controller swaps the initials in if the
+    #             image FAILS to load — `fallback:` alone only covers a nil src.
     # alt:        image alt text
     # fallback:   initials string (rendered as-is — caller supplies them)
     # size:       xs | sm | md | lg | xl
@@ -31,7 +33,10 @@ module UI
     end
 
     def call
-      @src ? image_avatar : initials_avatar
+      return initials_avatar unless @src
+      return image_avatar unless @fallback
+
+      recoverable_image
     end
 
     private
@@ -57,6 +62,24 @@ module UI
       :md
     end
 
+    # Both nodes ship together so the swap needs no network round trip. Only the <img>
+    # is named; the standby initials stay unnamed so the avatar is announced once.
+    def recoverable_image
+      content_tag(:span, class: "contents", data: {controller: "avatar"}) do
+        concat content_tag(:img, nil,
+          src: @src, alt: (@aria_label.presence || @alt),
+          class: cn(config[:css], "rounded-full object-cover", @extra_class),
+          data: {avatar_target: "image", action: "error->avatar#showFallback"},
+          **aria_attrs, **@html_attrs)
+        concat content_tag(:span, @fallback,
+          class: cn(config[:css], config[:text],
+            "rounded-full flex items-center justify-center font-semibold", color_classes, @extra_class),
+          hidden: true,
+          "aria-hidden": "true",
+          data: {avatar_target: "fallback"})
+      end
+    end
+
     def image_avatar
       content_tag(:img, nil,
         src: @src, alt: (@aria_label.presence || @alt),
@@ -78,7 +101,7 @@ module UI
     end
 
     def aria_attrs
-      @aria_label ? { role: "img", "aria-label": @aria_label } : { "aria-hidden": "true" }
+      @aria_label ? {role: "img", "aria-label": @aria_label} : {"aria-hidden": "true"}
     end
   end
 end

--- a/lib/generators/modelrails_ui/add/templates/avatar/avatar_controller.js
+++ b/lib/generators/modelrails_ui/add/templates/avatar/avatar_controller.js
@@ -1,0 +1,15 @@
+import { Controller } from "@hotwired/stimulus"
+
+// Swaps initials in when the avatar image fails to load. `fallback:` alone only covers a
+// NIL src; a 404 still leaves the browser's broken-image glyph, and the `error` event is
+// the only signal for it. CSP forbids an inline `onerror`, so it lives here.
+export default class extends Controller {
+  static targets = ["image", "fallback"]
+
+  showFallback() {
+    // The <img> carries the accessible name, so it is removed rather than hidden — a
+    // hidden-but-present img would keep announcing a picture that never arrived.
+    this.imageTarget.remove()
+    this.fallbackTarget.hidden = false
+  }
+}

--- a/lib/generators/modelrails_ui/add/templates/breadcrumb/breadcrumb_component.rb.tt
+++ b/lib/generators/modelrails_ui/add/templates/breadcrumb/breadcrumb_component.rb.tt
@@ -22,7 +22,12 @@ module UI
     # items: [{ label:, href: }, ..., { label: }] — last item is the current page (no href).
     # separator: the visual divider between crumbs (decorative). label: the <nav> accessible
     # name (i18n; default t("ui.breadcrumb.label", default: "Breadcrumb")).
-    def initialize(items: [], separator: "/", label: nil, **html_attrs)
+    def initialize(items: [], separator: "/", label: nil, max_items: nil, **html_attrs)
+      if max_items && max_items < 2
+        raise ArgumentError, "UI::Breadcrumb max_items must be at least 2 (got #{max_items.inspect})"
+      end
+
+      @max_items = max_items
       @items = items
       @separator = separator
       @label = label
@@ -41,10 +46,35 @@ module UI
       @label || t("ui.breadcrumb.label", default: "Breadcrumb")
     end
 
+    # Collapse the middle when the trail is longer than `max_items`: keep the root and
+    # the tail, and stand one ellipsis in for what was dropped. The collapsed crumbs are
+    # removed for EVERYONE — no visually-hidden copy — so the rendered trail never claims
+    # a depth the reader cannot reach.
+    def displayed
+      return @items unless @max_items && @items.size > @max_items
+
+      [@items.first, :ellipsis, *@items.last(@max_items - 1)]
+    end
+
     def ordered_list
+      shown = displayed
       content_tag(:ol,
-        safe_join(@items.each_with_index.map { |item, i| crumb(item, i == @items.size - 1) }),
+        safe_join(shown.each_with_index.map { |item, i|
+          item == :ellipsis ? ellipsis : crumb(item, i == shown.size - 1)
+        }),
         class: cn("flex flex-wrap items-center gap-1.5 break-words text-sm text-text-muted sm:gap-2.5", @extra_class))
+    end
+
+    def ellipsis
+      content_tag(:li, class: "inline-flex items-center gap-1.5") do
+        safe_join([
+          content_tag(:span, "…",
+            class: "select-none px-1 text-text-muted",
+            "aria-hidden": "true",
+            data: {slot: "breadcrumb-ellipsis"}),
+          content_tag(:span, @separator, class: "select-none text-text-muted", "aria-hidden": "true")
+        ])
+      end
     end
 
     def crumb(item, is_last)

--- a/lib/generators/modelrails_ui/add/templates/checkbox/checkbox_component.rb.tt
+++ b/lib/generators/modelrails_ui/add/templates/checkbox/checkbox_component.rb.tt
@@ -36,9 +36,13 @@ module UI
 
     # invalid: drives the app's server-validation-driven aria-invalid posture.
     # describedby: wires the input to its error message's id (aria-describedby).
-    def initialize(label: nil, checked: false, invalid: false, describedby: nil, **html_attrs)
+    # indeterminate: tri-state ("some children checked"). No HTML attribute exists for it,
+    #   so a controller sets the DOM property on connect and clears it once the user acts.
+    def initialize(label: nil, checked: false, invalid: false, describedby: nil,
+      indeterminate: false, **html_attrs)
       @label = label
       @checked = checked
+      @indeterminate = indeterminate
       @invalid = invalid
       @describedby = describedby
       # Always resolve an id so the label association never breaks: explicit id →
@@ -68,6 +72,13 @@ module UI
         class: cn(BASE, @extra_class)
       )
       attrs[:checked] = true if @checked
+      if @indeterminate
+        caller_data = attrs.delete(:data) || {}
+        attrs[:data] = {
+          controller: [caller_data[:controller], "indeterminate"].compact.join(" "),
+          action: [caller_data[:action], "change->indeterminate#clear"].compact.join(" ")
+        }.merge(caller_data.except(:controller, :action))
+      end
       attrs[:"aria-invalid"] = "true" if @invalid
       attrs[:"aria-describedby"] = @describedby if @describedby
       content_tag(:input, nil, **attrs)

--- a/lib/generators/modelrails_ui/add/templates/checkbox/indeterminate_controller.js
+++ b/lib/generators/modelrails_ui/add/templates/checkbox/indeterminate_controller.js
@@ -1,0 +1,19 @@
+import { Controller } from "@hotwired/stimulus"
+
+// `indeterminate` is a DOM property with no HTML attribute, so a server-rendered
+// checkbox cannot express it — it has to be set after the element exists. Everything
+// else about the tri-state (the `:indeterminate` styling, the AT announcement) rides on
+// that property, so this is the whole controller.
+//
+// Without JS the box renders unchecked, which is the honest degradation: a tri-state
+// parent whose children are partly selected reads as "not all selected".
+export default class extends Controller {
+  connect() {
+    this.element.indeterminate = true
+  }
+
+  // Once the user acts on it the box is no longer partial — let the native toggle stand.
+  clear() {
+    this.element.indeterminate = false
+  }
+}

--- a/lib/generators/modelrails_ui/add/templates/collapsible/collapsible_component.rb.tt
+++ b/lib/generators/modelrails_ui/add/templates/collapsible/collapsible_component.rb.tt
@@ -5,6 +5,11 @@ module UI
   #
   # trigger slot: content for the summary row (button, icon, label, etc.)
   # open:         render pre-expanded (default: false)
+  # disabled:     the disclosure is announced as disabled and cannot be operated.
+  #               <details> has no `disabled` attribute, so this is aria-disabled +
+  #               out of the tab order + pointer-inert. An already-open disclosure
+  #               stays open: disabling blocks the control, it does not collapse
+  #               content out from under the reader.
   #
   # Accessibility contract:
   # - Native <details>/<summary> carries the disclosure semantics — the summary is
@@ -21,8 +26,9 @@ module UI
 
     renders_one :trigger
 
-    def initialize(open: false, **html_attrs)
+    def initialize(open: false, disabled: false, **html_attrs)
       @open = open
+      @disabled = disabled
       @extra_class = html_attrs.delete(:class)
       @html_attrs = html_attrs
     end
@@ -32,9 +38,21 @@ module UI
       attrs[:open] = true if @open
 
       content_tag(:details, **attrs) do
-        concat content_tag(:summary, trigger, class: SUMMARY_CLS)
+        concat content_tag(:summary, trigger, **summary_attrs)
         concat content_tag(:div, content, class: CONTENT_CLS)
       end
+    end
+
+    private
+
+    def summary_attrs
+      return {class: SUMMARY_CLS} unless @disabled
+
+      {
+        class: cn(SUMMARY_CLS, "pointer-events-none opacity-60"),
+        "aria-disabled": "true",
+        tabindex: "-1"
+      }
     end
   end
 end

--- a/lib/generators/modelrails_ui/lookbook/templates/previews/ui/avatar_component_preview.rb
+++ b/lib/generators/modelrails_ui/lookbook/templates/previews/ui/avatar_component_preview.rb
@@ -47,6 +47,10 @@ module UI
     def custom_hue
     end
 
+    # The image 404s, so the initials take over instead of a broken-image glyph.
+    def broken_image
+    end
+
     # @!endgroup
 
     # @!group Reference

--- a/lib/generators/modelrails_ui/lookbook/templates/previews/ui/avatar_component_preview/broken_image.html.erb
+++ b/lib/generators/modelrails_ui/lookbook/templates/previews/ui/avatar_component_preview/broken_image.html.erb
@@ -1,0 +1,6 @@
+<%# The src 404s on purpose: the initials must take over rather than leaving the
+    browser's broken-image glyph. %>
+<div class="flex items-center gap-4 p-8">
+  <%= ui :avatar, src: "/this-image-does-not-exist.png", fallback: "DC", aria_label: "Dave Chmura" %>
+  <%= ui :avatar, src: "/also-missing.png", fallback: "AB", aria_label: "Ada Byron", size: :lg %>
+</div>

--- a/lib/generators/modelrails_ui/lookbook/templates/previews/ui/checkbox_component_preview.rb
+++ b/lib/generators/modelrails_ui/lookbook/templates/previews/ui/checkbox_component_preview.rb
@@ -42,6 +42,10 @@ module UI
     def disabled
     end
 
+    # Tri-state parent: `indeterminate:` sets the DOM property a checkbox cannot render.
+    def indeterminate
+    end
+
     # @!endgroup
 
     # @!group Reference

--- a/lib/generators/modelrails_ui/lookbook/templates/previews/ui/checkbox_component_preview/indeterminate.html.erb
+++ b/lib/generators/modelrails_ui/lookbook/templates/previews/ui/checkbox_component_preview/indeterminate.html.erb
@@ -1,0 +1,5 @@
+<div class="p-8 space-y-2">
+  <%= ui :checkbox, label: "Select all", indeterminate: true, name: "all" %>
+  <%= ui :checkbox, label: "Invoices", checked: true, name: "invoices" %>
+  <%= ui :checkbox, label: "Receipts", name: "receipts" %>
+</div>

--- a/test/render/avatar_render_test.rb
+++ b/test/render/avatar_render_test.rb
@@ -77,4 +77,32 @@ class AvatarRenderTest < ViewComponent::TestCase
 
     assert_match(/unknown size/, error.message)
   end
+
+  # `fallback:` alone only ever covered a NIL src; a 404 still left a broken-image glyph.
+  # The recovery pair is rendered only when BOTH a src and a fallback exist, so a
+  # src-only call site keeps its bare <img>.
+  def test_src_without_fallback_stays_a_bare_img
+    render_inline(UI::AvatarComponent.new(src: "/a.png", aria_label: "Dave"))
+
+    assert_no_selector "[data-controller~='avatar']", visible: :all
+  end
+
+  def test_src_with_fallback_wires_the_error_handler
+    render_inline(UI::AvatarComponent.new(src: "/a.png", fallback: "DC", aria_label: "Dave"))
+
+    assert_selector "[data-controller~='avatar'] img[data-action~='error->avatar#showFallback']", visible: :all
+  end
+
+  def test_standby_initials_ship_hidden
+    render_inline(UI::AvatarComponent.new(src: "/a.png", fallback: "DC", aria_label: "Dave"))
+
+    assert_selector "[data-avatar-target='fallback'][hidden]", text: "DC", visible: :all
+  end
+
+  # The img carries the accessible name; the standby initials must not announce a second.
+  def test_avatar_is_named_once
+    render_inline(UI::AvatarComponent.new(src: "/a.png", fallback: "DC", aria_label: "Dave"))
+
+    assert_selector "[aria-label='Dave']", count: 1, visible: :all
+  end
 end

--- a/test/render/breadcrumb_render_test.rb
+++ b/test/render/breadcrumb_render_test.rb
@@ -54,4 +54,44 @@ class BreadcrumbRenderTest < ViewComponent::TestCase
     assert_no_selector "a", visible: :all
     assert_selector "[aria-current='page']", text: "Room 2100", visible: :all
   end
+
+  # max_items collapses the MIDDLE of a long trail. The dropped crumbs go for everyone —
+  # no visually-hidden copy — so the trail never claims a depth the reader cannot reach.
+  def long_trail
+    [
+      {label: "Home", href: "/"},
+      {label: "Projects", href: "/projects"},
+      {label: "Apollo", href: "/projects/1"},
+      {label: "Write the spec"}
+    ]
+  end
+
+  def test_trail_under_the_limit_is_untouched
+    render_inline(UI::BreadcrumbComponent.new(items: long_trail, max_items: 4))
+
+    assert_no_selector "[data-slot='breadcrumb-ellipsis']", visible: :all
+  end
+
+  # max_items: 3 on a 4-crumb trail keeps the root plus the last two, so exactly the
+  # second crumb is dropped.
+  def test_long_trail_collapses_its_middle
+    render_inline(UI::BreadcrumbComponent.new(items: long_trail, max_items: 3))
+
+    assert_selector "[data-slot='breadcrumb-ellipsis'][aria-hidden='true']", count: 1, visible: :all
+    assert_no_link "Projects"
+    assert_link "Apollo"
+  end
+
+  def test_collapsed_trail_keeps_root_and_current_page
+    render_inline(UI::BreadcrumbComponent.new(items: long_trail, max_items: 2))
+
+    assert_link "Home"
+    assert_selector "[aria-current='page']", text: "Write the spec", visible: :all
+  end
+
+  def test_max_items_below_two_raises
+    error = assert_raises(ArgumentError) { UI::BreadcrumbComponent.new(items: long_trail, max_items: 1) }
+
+    assert_match(/max_items/, error.message)
+  end
 end

--- a/test/render/checkbox_render_test.rb
+++ b/test/render/checkbox_render_test.rb
@@ -65,4 +65,25 @@ class CheckboxRenderTest < ViewComponent::TestCase
 
     assert_selector "input[type='checkbox'][aria-describedby='terms_error']"
   end
+
+  # `indeterminate` is a DOM property with no HTML attribute, so the markup can only
+  # DECLARE it; the controller sets the property. Deliberately does not also set
+  # `checked` — a tri-state parent must not win in the form payload.
+  def test_indeterminate_wires_the_controller
+    render_inline(UI::CheckboxComponent.new(label: "Select all", indeterminate: true, name: "all"))
+
+    assert_selector "input[type='checkbox'][data-controller~='indeterminate']", visible: :all
+  end
+
+  def test_indeterminate_does_not_mark_the_input_checked
+    render_inline(UI::CheckboxComponent.new(label: "Select all", indeterminate: true, name: "all"))
+
+    assert_no_selector "input[checked]", visible: :all
+  end
+
+  def test_plain_checkbox_wires_no_indeterminate_controller
+    render_inline(UI::CheckboxComponent.new(label: "Terms", name: "terms"))
+
+    assert_no_selector "[data-controller~='indeterminate']", visible: :all
+  end
 end

--- a/test/render/collapsible_render_test.rb
+++ b/test/render/collapsible_render_test.rb
@@ -69,4 +69,25 @@ class CollapsibleRenderTest < ViewComponent::TestCase
 
     assert_selector "details#faq.mt-4"
   end
+
+  # <details> has no `disabled` attribute: announced via aria-disabled, out of the tab
+  # order, pointer-inert. No JS.
+  def test_disabled_summary_is_announced_and_unreachable
+    render_inline(UI::CollapsibleComponent.new(disabled: true)) { |c| c.with_trigger { "More" } }
+
+    assert_selector "summary[aria-disabled='true'][tabindex='-1'].pointer-events-none", visible: :all
+  end
+
+  def test_enabled_summary_stays_operable
+    render_inline(UI::CollapsibleComponent.new) { |c| c.with_trigger { "More" } }
+
+    assert_no_selector "summary[aria-disabled]", visible: :all
+  end
+
+  # Disabling blocks the control; it does not collapse content out from under a reader.
+  def test_open_disabled_disclosure_stays_open
+    render_inline(UI::CollapsibleComponent.new(disabled: true, open: true)) { |c| c.with_trigger { "More" } }
+
+    assert_selector "details[open]", visible: :all
+  end
 end


### PR DESCRIPTION
Back-ports modelrails_base #706. All four are opt-in — **no existing call site changes shape**.

| Component | Addition |
|---|---|
| checkbox | `indeterminate:` — tri-state parent |
| collapsible | `disabled:` |
| breadcrumb | `max_items:` — collapse a long trail |
| avatar | initials take over when the image **fails**, not only when `src` is nil |

## Design notes worth reviewing

**checkbox** — `indeterminate` is a DOM property with no HTML attribute, so a controller sets it on connect and clears it once the user acts. It deliberately does **not** also set `checked`: a partially-selected parent must not submit as checked.

**collapsible** — `<details>` has no `disabled` attribute, so this is `aria-disabled` + out of the tab order + pointer-inert, still no JS. An already-open disclosure **stays open**; disabling blocks the control, it does not collapse content out from under a reader.

**breadcrumb** — collapsed crumbs are dropped for **everyone**, with no visually-hidden copy. A trail reading as four levels to a screen reader and two on screen describes a structure neither audience can act on.

**avatar** — the `error` event is the only signal for a 404, and CSP forbids inline `onerror`. The controller **removes** the failed `<img>` rather than hiding it, since a hidden-but-present image keeps announcing a picture that never arrived. Wired only when both a `src` and a `fallback` are given, so src-only call sites keep their bare `<img>`.

## Hand-ported, not copied

`breadcrumb` supports **href-less non-final crumbs** rendering as plain text here and **not** in base, so a wholesale copy would have deleted it. checkbox, collapsible and avatar had zero functional drift and were copied with style normalised.

The two new controllers live in their own component template dirs, so the generator routes them without an `EXTRA_STIMULUS` entry.

## Testing

14 new render tests covering both the additions and their defaults — including that a plain checkbox wires **no** indeterminate controller, a `src` without a `fallback` stays a bare `<img>`, and the avatar is named exactly once (the standby initials must not announce a second name).

Runtime behaviour is proven in base (#706), where the browser lane lives, with probes confirming each assertion is sensitive.

One test of mine was wrong on the first run and the suite caught it: `max_items: 3` on a 4-crumb trail drops only the *second* crumb, not the third as I'd asserted.

Full CI green — 533 structural + 940 render runs, RuboCop clean.