### PR TITLE
fix(ui): submenu left open by its parent, and avatar lost after a swap

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- Avatar was absent from the accessibility tree after its image failed to load. The `<img>` carries the accessible name and is removed on failure, so the standby initials — hardcoded `aria-hidden` — left screen-reader users with nothing where sighted users saw initials. Both nodes are named now; `hidden` keeps only one exposed.
+- A caller-supplied `data:` on Avatar clobbered the Stimulus wiring and silently disabled the image-error fallback. The wiring is merged over caller data now.
+- A DropdownMenu submenu stayed open when its parent menu closed — `aria-expanded="true"` while the menu was shut, and already expanded on reopen. The parent now closes its submenus.
+
 ### Added
 
 - Checkbox: `indeterminate:` for tri-state parents. Ships an `indeterminate` controller, since the property has no HTML attribute; deliberately does not also set `checked`.

--- a/lib/generators/modelrails_ui/add/templates/avatar/avatar_component.rb.tt
+++ b/lib/generators/modelrails_ui/add/templates/avatar/avatar_component.rb.tt
@@ -62,22 +62,34 @@ module UI
       :md
     end
 
-    # Both nodes ship together so the swap needs no network round trip. Only the <img>
-    # is named; the standby initials stay unnamed so the avatar is announced once.
+    # Both nodes ship together so the swap needs no network round trip. BOTH carry the
+    # accessible name: the <img> is removed on failure, so initials that were unnamed
+    # would leave the avatar absent from the accessibility tree entirely. Only one is ever
+    # exposed, because `hidden` keeps the other out.
     def recoverable_image
       content_tag(:span, class: "contents", data: {controller: "avatar"}) do
-        concat content_tag(:img, nil,
-          src: @src, alt: (@aria_label.presence || @alt),
-          class: cn(config[:css], "rounded-full object-cover", @extra_class),
-          data: {avatar_target: "image", action: "error->avatar#showFallback"},
-          **aria_attrs, **@html_attrs)
+        concat content_tag(:img, nil, **recoverable_image_attrs)
         concat content_tag(:span, @fallback,
           class: cn(config[:css], config[:text],
             "rounded-full flex items-center justify-center font-semibold", color_classes, @extra_class),
           hidden: true,
-          "aria-hidden": "true",
+          **aria_attrs,
           data: {avatar_target: "fallback"})
       end
+    end
+
+    # The Stimulus wiring is merged over any caller `data:` rather than splatted before
+    # it: a caller passing `data: { testid: ... }` used to clobber the whole hash and
+    # silently disable the fallback.
+    def recoverable_image_attrs
+      caller_attrs = @html_attrs.dup
+      caller_data = caller_attrs.delete(:data) || {}
+      {
+        src: @src, alt: (@aria_label.presence || @alt),
+        class: cn(config[:css], "rounded-full object-cover", @extra_class),
+        **aria_attrs, **caller_attrs,
+        data: caller_data.merge(avatar_target: "image", action: "error->avatar#showFallback")
+      }
     end
 
     def image_avatar

--- a/lib/generators/modelrails_ui/add/templates/dropdown_menu/dropdown_menu_component.rb.tt
+++ b/lib/generators/modelrails_ui/add/templates/dropdown_menu/dropdown_menu_component.rb.tt
@@ -121,7 +121,10 @@ module UI
       id = "submenu-#{SecureRandom.hex(4)}"
 
       content_tag(:div,
-        data: {controller: "submenu", action: "mouseleave->submenu#scheduleClose"},
+        data: {
+          controller: "submenu",
+          action: "mouseleave->submenu#scheduleClose menu:close->submenu#forceClose"
+        },
         style: "anchor-name: --#{id}") do
         safe_join([submenu_trigger(label, id, disabled, **attrs), submenu_panel(id, builder.items)])
       end

--- a/lib/generators/modelrails_ui/add/templates/dropdown_menu/menu_controller.js
+++ b/lib/generators/modelrails_ui/add/templates/dropdown_menu/menu_controller.js
@@ -55,11 +55,20 @@ export default class extends Controller {
   close({ restoreFocus = true } = {}) {
     if (!this.openValue) return
     this.openValue = false
+    // A submenu is its own controller, so it does not close just because this one did.
+    // Left alone it stays popover-open with aria-expanded="true" and reappears already
+    // expanded the next time this menu opens.
+    this.#closeSubmenus()
     topLayer.hide(this.menuTarget)
     topLayer.disable(this.menuTarget)
     this.menuTarget.hidden = true
     this.triggerTarget.setAttribute("aria-expanded", "false")
     if (restoreFocus) this.triggerTarget.focus()
+  }
+
+  #closeSubmenus() {
+    this.element.querySelectorAll("[data-controller~='submenu']")
+      .forEach((el) => el.dispatchEvent(new CustomEvent("menu:close")))
   }
 
   closeOnClickOutside(event) {

--- a/lib/generators/modelrails_ui/add/templates/dropdown_menu/submenu_controller.js
+++ b/lib/generators/modelrails_ui/add/templates/dropdown_menu/submenu_controller.js
@@ -49,6 +49,12 @@ export default class extends Controller {
     if (restoreFocus) this.triggerTarget.focus()
   }
 
+  // The parent menu closing is not a dismissal the user aimed at this layer, so focus
+  // stays wherever the parent puts it.
+  forceClose() {
+    this.close({ restoreFocus: false })
+  }
+
   // Hovering away closes after a beat so the pointer can cross the gap between the
   // sub-trigger and its panel without the submenu vanishing.
   scheduleClose() {

--- a/test/render/avatar_render_test.rb
+++ b/test/render/avatar_render_test.rb
@@ -99,10 +99,27 @@ class AvatarRenderTest < ViewComponent::TestCase
     assert_selector "[data-avatar-target='fallback'][hidden]", text: "DC", visible: :all
   end
 
-  # The img carries the accessible name; the standby initials must not announce a second.
-  def test_avatar_is_named_once
+  # BOTH nodes are named: the <img> is REMOVED on failure and carries the name, so
+  # unnamed initials would leave the avatar absent from the accessibility tree entirely.
+  # `hidden` keeps only one of them exposed at a time.
+  def test_standby_initials_are_named_for_after_the_swap
     render_inline(UI::AvatarComponent.new(src: "/a.png", fallback: "DC", aria_label: "Dave"))
 
-    assert_selector "[aria-label='Dave']", count: 1, visible: :all
+    assert_selector "[data-avatar-target='fallback'][role='img'][aria-label='Dave']", visible: :all
+  end
+
+  def test_avatar_is_named_once_among_visible_nodes
+    render_inline(UI::AvatarComponent.new(src: "/a.png", fallback: "DC", aria_label: "Dave"))
+
+    assert_selector "[aria-label='Dave']", count: 1
+  end
+
+  # A caller `data:` used to splat over the wiring and silently disable the fallback —
+  # the component rendered, looked right, and never recovered from a 404.
+  def test_caller_data_does_not_clobber_the_error_wiring
+    render_inline(UI::AvatarComponent.new(src: "/a.png", fallback: "DC", aria_label: "Dave",
+      data: {testid: "user-avatar"}))
+
+    assert_selector "img[data-action~='error->avatar#showFallback'][data-testid='user-avatar']", visible: :all
   end
 end


### PR DESCRIPTION
Back-ports modelrails_base #707. **Forks currently inherit the accessibility bug**, which is why this follows immediately rather than batching.

## 1. Avatar disappeared from the accessibility tree

The standby initials were hardcoded `aria-hidden="true"`. The `<img>` carries the accessible name and is **removed** on failure, so after a 404:

```
{"text":"DC","ariaHidden":"true","anyNamedAvatarLeft":0}
```

Sighted users saw initials; screen-reader users got **nothing**. Both nodes are named now, and `hidden` keeps only one exposed at a time. WCAG 4.1.2.

## 2. A caller `data:` silently disabled the fallback

`data: { testid: "…" }` splatted over the Stimulus wiring — `data-action=nil`. The component rendered, looked correct, and never recovered from a 404. Merged over caller data now.

## 3. A submenu outlived its parent menu

A submenu is its own controller, so closing the parent didn't close it: `aria-expanded="true"` while the menu was shut, and already expanded on reopen. The parent now tells its submenus to close.

## Test note

`test_avatar_is_named_once` counted **hidden** nodes and so failed once the initials became named. It was retargeted to visible nodes rather than relaxed — the standby initials are *deliberately* named now, for after the swap, and a second assertion covers that directly.

## Port method

`submenu_controller` had zero drift and was copied. `dropdown_menu` and `avatar` had brace-spacing drift only, verified mechanically before copying, then normalised with RuboCop. `menu_controller` carries gem-only section comments, so only the cascade was hand-applied.

Full CI green — 533 structural + 942 render runs, RuboCop clean.