### PR TITLE
feat(test): browser lane, and the avatar race it immediately caught

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- Browser test lane (`rake test:system`). A real Chrome drives the gem's own controller templates through a real importmap, so behaviour that only exists once JS runs is provable here instead of only in a host app. Includes a structural axe audit (colour-contrast deliberately disabled — the stylesheet ships as Tailwind source, so a contrast pass here would be meaningless).
+
+### Fixed
+
+- Avatar's image-error fallback never fired when the image failed FAST — a quick 404 or a cached failure beats ES-module loading, so the `error` event was dispatched before the controller connected and nothing was listening. The controller now also checks `complete && naturalWidth === 0` on connect. Found by the new browser lane on its first run.
+
 ### Fixed
 
 - Avatar was absent from the accessibility tree after its image failed to load. The `<img>` carries the accessible name and is removed on failure, so the standby initials — hardcoded `aria-hidden` — left screen-reader users with nothing where sighted users saw initials. Both nodes are named now; `hidden` keeps only one exposed.

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -89,6 +89,10 @@ GEM
       rake
       thor (>= 0.14.0)
     ast (2.4.3)
+    axe-core-api (4.13.0)
+      dumb_delegator
+    axe-core-capybara (4.13.0)
+      axe-core-api (= 4.13.0)
     base64 (0.3.0)
     bigdecimal (4.1.2)
     builder (3.3.0)
@@ -104,11 +108,21 @@ GEM
     concurrent-ruby (1.3.8)
     connection_pool (3.0.2)
     crass (1.0.7)
+    cuprite (0.17)
+      capybara (~> 3.0)
+      ferrum (~> 0.17.0)
     date (3.5.1)
     docile (1.4.1)
     drb (2.2.3)
+    dumb_delegator (1.1.0)
     erb (6.0.4)
     erubi (1.13.1)
+    ferrum (0.17.2)
+      addressable (~> 2.5)
+      base64 (~> 0.2)
+      concurrent-ruby (~> 1.1)
+      webrick (~> 1.7)
+      websocket-driver (~> 0.7)
     globalid (1.4.0)
       activesupport (>= 6.1)
     i18n (1.15.2)
@@ -268,6 +282,8 @@ GEM
     standard-performance (1.9.0)
       lint_roller (~> 1.1)
       rubocop-performance (~> 1.26.0)
+    stimulus-rails (1.3.4)
+      railties (>= 6.0.0)
     stringio (3.2.0)
     tailwind_merge (1.5.1)
       sin_lru_redux (~> 2.5)
@@ -285,6 +301,7 @@ GEM
       actionview (>= 7.1.0)
       activesupport (>= 7.1.0)
       concurrent-ruby (~> 1)
+    webrick (1.9.2)
     websocket-driver (0.8.2)
       base64
       websocket-extensions (>= 0.1.0)
@@ -305,7 +322,9 @@ PLATFORMS
 
 DEPENDENCIES
   appraisal
+  axe-core-capybara
   capybara
+  cuprite
   irb
   lefthook
   minitest (>= 5.16)
@@ -316,6 +335,7 @@ DEPENDENCIES
   rubocop-performance
   simplecov (~> 0.21)
   standard
+  stimulus-rails
   tailwind_merge
 
 CHECKSUMS
@@ -334,6 +354,8 @@ CHECKSUMS
   addressable (2.9.0) sha256=7fdf6ac3660f7f4e867a0838be3f6cf722ace541dd97767fa42bc6cfa980c7af
   appraisal (2.5.0) sha256=36989221be127913b0dba8d114da2001e6b2dceea7bd4951200eaba764eed3ce
   ast (2.4.3) sha256=954615157c1d6a382bc27d690d973195e79db7f55e9765ac7c481c60bdb4d383
+  axe-core-api (4.13.0) sha256=6556c36d541090993b0efffd2659e13c289c109a0a6bf65d28271e363fc7ffa3
+  axe-core-capybara (4.13.0) sha256=7929292f4e6906d79df5f39dd1a9cdee288bfb188452a42c04121fc084ea5843
   base64 (0.3.0) sha256=27337aeabad6ffae05c265c450490628ef3ebd4b67be58257393227588f5a97b
   bigdecimal (4.1.2) sha256=53d217666027eab4280346fba98e7d5b66baaae1b9c3c1c0ffe89d48188a3fbd
   builder (3.3.0) sha256=497918d2f9dca528fdca4b88d84e4ef4387256d984b8154e9d5d3fe5a9c8835f
@@ -342,11 +364,14 @@ CHECKSUMS
   concurrent-ruby (1.3.8) sha256=b2f1be836e968ccc78ccfce277ea79c72a88633f22306782c16ff23fb415d1e1
   connection_pool (3.0.2) sha256=33fff5ba71a12d2aa26cb72b1db8bba2a1a01823559fb01d29eb74c286e62e0a
   crass (1.0.7) sha256=94868719948664c89ddcaf0a37c65048413dfcb1c869470a5f7a7ceb5390b295
+  cuprite (0.17) sha256=b140d5dc70d08b97ad54bcf45cd95d0bd430e291e9dffe76fff851fddd57c12b
   date (3.5.1) sha256=750d06384d7b9c15d562c76291407d89e368dda4d4fff957eb94962d325a0dc0
   docile (1.4.1) sha256=96159be799bfa73cdb721b840e9802126e4e03dfc26863db73647204c727f21e
   drb (2.2.3) sha256=0b00d6fdb50995fe4a45dea13663493c841112e4068656854646f418fda13373
+  dumb_delegator (1.1.0) sha256=1ad255e5b095a2206a574c62b40c678f3d5c9151f1b3d0bae1b0463f7e40188e
   erb (6.0.4) sha256=38e3803694be357fe2bfe312487c74beaf9fb4e5beb3e22498952fe1645b95d9
   erubi (1.13.1) sha256=a082103b0885dbc5ecf1172fede897f9ebdb745a4b97a5e8dc63953db1ee4ad9
+  ferrum (0.17.2) sha256=2c2540a850b211a46f4d81de21bfd62048f507e4c327d1807225c3823c17e6ee
   globalid (1.4.0) sha256=037f12fbf1d9d7a014d501c2d5c77356fd4ddd96d7a7991d6700bba96706f427
   i18n (1.15.2) sha256=00f9eb62412fe593b2a65a97daa75300d37abb8f7202ec748e94b6d46a9dd1b5
   io-console (0.8.2) sha256=d6e3ae7a7cc7574f4b8893b4fca2162e57a825b223a177b7afa236c5ef9814cc
@@ -410,6 +435,7 @@ CHECKSUMS
   standard (1.54.0) sha256=7a4b08f83d9893083c8f03bc486f0feeb6a84d48233b40829c03ef4767ea0100
   standard-custom (1.0.2) sha256=424adc84179a074f1a2a309bb9cf7cd6bfdb2b6541f20c6bf9436c0ba22a652b
   standard-performance (1.9.0) sha256=49483d31be448292951d80e5e67cdcb576c2502103c7b40aec6f1b6e9c88e3f2
+  stimulus-rails (1.3.4) sha256=765676ffa1f33af64ce026d26b48e8ffb2e0b94e0f50e9119e11d6107d67cb06
   stringio (3.2.0) sha256=c37cb2e58b4ffbd33fe5cd948c05934af997b36e0b6ca6fdf43afa234cf222e1
   tailwind_merge (1.5.1) sha256=cf307d491870948c0fa19a327b5af1cc799a27931bdd1dcac56c18a85c36c266
   thor (1.5.0) sha256=e3a9e55fe857e44859ce104a84675ab6e8cd59c650a49106a05f55f136425e73
@@ -421,6 +447,7 @@ CHECKSUMS
   uri (1.1.1) sha256=379fa58d27ffb1387eaada68c749d1426738bd0f654d812fcc07e7568f5c57c6
   useragent (0.16.11) sha256=700e6413ad4bb954bb63547fa098dddf7b0ebe75b40cc6f93b8d54255b173844
   view_component (4.12.0) sha256=b9a5979d1c43eba2aa21a06a86f661aab3990104855f2909ef7c3779acdcdcb4
+  webrick (1.9.2) sha256=beb4a15fc474defed24a3bda4ffd88a490d517c9e4e6118c3edce59e45864131
   websocket-driver (0.8.2) sha256=97c556b019bf3410b4961002ac501621e9322d3f8a7bc02161a09301cc4c4146
   websocket-extensions (0.1.5) sha256=1c6ba63092cda343eb53fc657110c71c754c56484aad42578495227d717a8241
   xpath (3.2.0) sha256=6dfda79d91bb3b949b947ecc5919f042ef2f399b904013eb3ef6d20dd3a4082e

--- a/Rakefile
+++ b/Rakefile
@@ -17,7 +17,16 @@ Minitest::TestTask.create(:"test:render") do |t|
   t.warning = false
 end
 
-task test: [:"test:structural", :"test:render"]
+# Browser lane: real Chrome over CDP, the gem's own controller templates loaded through a
+# real importmap. Proves BEHAVIOUR — the render lane asserts markup and is blind to what
+# only happens once JS runs. Separate process for the same reason as the render lane.
+Minitest::TestTask.create(:"test:system") do |t|
+  t.libs << "test/render" << "test/system"
+  t.test_globs = ["test/system/**/*_test.rb"]
+  t.warning = false
+end
+
+task test: [:"test:structural", :"test:render", :"test:system"]
 
 require "rubocop/rake_task"
 RuboCop::RakeTask.new

--- a/lib/generators/modelrails_ui/add/templates/avatar/avatar_controller.js
+++ b/lib/generators/modelrails_ui/add/templates/avatar/avatar_controller.js
@@ -10,6 +10,10 @@ export default class extends Controller {
   // and a cached failure never fires at all. `complete && naturalWidth === 0` is the only
   // way to detect that after the fact, so the swap cannot depend on catching the event.
   connect() {
+    // hasImageTarget: after a swap the <img> is gone, and re-connecting (a DOM move, a
+    // Turbo restore) would otherwise throw on a missing target.
+    if (!this.hasImageTarget) return
+
     const img = this.imageTarget
     if (img.complete && img.naturalWidth === 0) this.showFallback()
   }

--- a/lib/generators/modelrails_ui/add/templates/avatar/avatar_controller.js
+++ b/lib/generators/modelrails_ui/add/templates/avatar/avatar_controller.js
@@ -6,6 +6,14 @@ import { Controller } from "@hotwired/stimulus"
 export default class extends Controller {
   static targets = ["image", "fallback"]
 
+  // The error can fire BEFORE this controller connects — a fast 404 beats module loading,
+  // and a cached failure never fires at all. `complete && naturalWidth === 0` is the only
+  // way to detect that after the fact, so the swap cannot depend on catching the event.
+  connect() {
+    const img = this.imageTarget
+    if (img.complete && img.naturalWidth === 0) this.showFallback()
+  }
+
   showFallback() {
     // The <img> carries the accessible name, so it is removed rather than hidden — a
     // hidden-but-present img would keep announcing a picture that never arrived.

--- a/modelrails_ui.gemspec
+++ b/modelrails_ui.gemspec
@@ -31,7 +31,13 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency "rails", ">= 7.1"
   spec.add_development_dependency "simplecov", "~> 0.21"
   spec.add_development_dependency "appraisal"
-  spec.add_development_dependency "capybara" # render-test assertions (ViewComponent::TestCase matchers)
+  spec.add_development_dependency "capybara" # render-test assertions + the browser lane
+  # Browser lane (test/system): a real Chrome via CDP, plus the Stimulus runtime the
+  # controllers import. Behaviour that only exists once JS runs cannot be proven any
+  # other way — the render lane asserts markup and is blind to it.
+  spec.add_development_dependency "cuprite"
+  spec.add_development_dependency "stimulus-rails"
+  spec.add_development_dependency "axe-core-capybara"
   spec.add_development_dependency "lefthook"
   spec.add_development_dependency "tailwind_merge" # render harness backs cn with real tailwind_merge (host gets it via install generator)
 end

--- a/test/system/avatar_system_test.rb
+++ b/test/system/avatar_system_test.rb
@@ -1,0 +1,45 @@
+# frozen_string_literal: true
+
+require "system_test_helper"
+load_component "avatar", "avatar_component.rb.tt"
+
+BrowserHarness.scenario("avatar/broken_image", controllers: %w[avatar]) do
+  view = ActionController::Base.new.view_context
+  UI::AvatarComponent.new(src: "/definitely-missing.png", fallback: "DC", aria_label: "Dave Chmura")
+    .render_in(view)
+end
+
+# The image-failure path is invisible to the render lane: the swap only happens when the
+# browser actually attempts the request and fires `error`. This is the bug the 2026-08
+# audit found — initials appeared, but the avatar left the accessibility tree entirely.
+class AvatarSystemTest < BrowserTestCase
+  def setup
+    super
+    visit_scenario("avatar/broken_image")
+  end
+
+  def test_initials_replace_the_failed_image
+    assert_selector "[data-avatar-target=fallback]", text: "DC"
+  end
+
+  # A hidden-but-present <img> would keep announcing a picture that never arrived.
+  def test_the_failed_image_is_removed_not_hidden
+    assert_selector "[data-avatar-target=fallback]", text: "DC"
+
+    assert_no_selector "img", visible: :all
+  end
+
+  # The regression: the standby initials were aria-hidden, so once the <img> was removed
+  # the avatar had no accessible name at all.
+  def test_the_avatar_keeps_an_accessible_name_after_the_swap
+    assert_selector "[data-avatar-target=fallback]", text: "DC"
+
+    assert_selector "[role=img][aria-label='Dave Chmura']"
+  end
+
+  def test_the_swapped_avatar_passes_a_structural_axe_audit
+    assert_selector "[data-avatar-target=fallback]", text: "DC"
+
+    assert_axe_clean
+  end
+end

--- a/test/system/avatar_system_test.rb
+++ b/test/system/avatar_system_test.rb
@@ -42,4 +42,19 @@ class AvatarSystemTest < BrowserTestCase
 
     assert_axe_clean
   end
+
+  # After the swap there is no <img>, so a controller re-connecting over that DOM (a move,
+  # a Turbo restore) must not throw on the missing target. js_errors: true means an
+  # exception here fails the test rather than leaving a quietly dead component.
+  def test_reconnecting_after_the_swap_does_not_throw
+    assert_selector "[data-avatar-target=fallback]", text: "DC"
+
+    page.execute_script(<<~JS)
+      const host = document.querySelector("[data-controller~=avatar]");
+      host.replaceWith(host.cloneNode(true));
+    JS
+
+    assert_selector "[data-avatar-target=fallback]", text: "DC"
+    assert_no_stimulus_errors
+  end
 end

--- a/test/system/dropdown_menu_system_test.rb
+++ b/test/system/dropdown_menu_system_test.rb
@@ -1,0 +1,94 @@
+# frozen_string_literal: true
+
+require "system_test_helper"
+require "securerandom"
+load_component "dropdown_menu", "dropdown_menu_component.rb.tt"
+
+# Rendering a slotted component needs a view context, so build the HTML the same way the
+# render lane does rather than going through a controller.
+BrowserHarness.scenario("dropdown_menu/submenu",
+  controllers: %w[menu submenu], modules: %w[overlays/top_layer]) do
+  view = ActionController::Base.new.view_context
+  UI::DropdownMenuComponent.new.render_in(view) do |c|
+    c.with_trigger { "Actions" }
+    c.with_item { "Edit" }
+    c.with_item(submenu: "Share") do |sub|
+      sub.with_item { "Email" }
+      sub.with_item { "Copy link" }
+    end
+    nil
+  end
+end
+
+# The behaviour half of dropdown_menu — the part the render lane explicitly cannot reach.
+# Every assertion here corresponds to something that shipped broken and was found only by
+# driving a browser in the host app.
+class DropdownMenuSystemTest < BrowserTestCase
+  def setup
+    super
+    visit_scenario("dropdown_menu/submenu")
+    open_menu
+  end
+
+  # Not an assertion in setup: Capybara's finder already blocks until the menu appears, so
+  # this both opens the menu and waits for it.
+  def open_menu
+    find("[data-menu-target=trigger]").click
+    find("[data-menu-target=menu]")
+  end
+
+  def test_menu_opens_and_syncs_aria_expanded
+    assert_selector "[data-menu-target=trigger][aria-expanded='true']"
+  end
+
+  def test_arrow_keys_move_roving_focus
+    press(:Down)
+
+    assert_equal "Share", page.evaluate_script("document.activeElement.textContent.trim()")
+  end
+
+  def test_submenu_opens_on_arrow_right
+    press(:Down)
+    press(:Right)
+
+    assert_selector "[data-submenu-target=panel]"
+    assert_equal "Email", page.evaluate_script("document.activeElement.textContent.trim()")
+  end
+
+  # Regression: a submenu is its own controller and did not close when its parent did,
+  # leaving aria-expanded="true" while the menu was shut and reappearing already expanded.
+  def test_closing_the_parent_closes_the_submenu
+    press(:Down)
+    press(:Right)
+
+    assert_selector "[data-submenu-target=panel]"
+
+    find("[data-menu-target=trigger]").click
+
+    assert_no_selector "[data-menu-target=menu]"
+    assert_equal "false", find("[data-submenu-target=trigger]", visible: :all)["aria-expanded"]
+  end
+
+  def test_reopening_the_parent_leaves_the_submenu_collapsed
+    press(:Down)
+    press(:Right)
+    find("[data-menu-target=trigger]").click
+    find("[data-menu-target=trigger]").click
+
+    assert_selector "[data-menu-target=menu]"
+    assert_no_selector "[data-submenu-target=panel]"
+  end
+
+  # Checkable items toggle in place and keep the menu open (APG); plain items close it.
+  def test_escape_closes_only_the_topmost_layer
+    press(:Down)
+    press(:Right)
+
+    assert_selector "[data-submenu-target=panel]"
+
+    press(:Escape)
+
+    assert_no_selector "[data-submenu-target=panel]"
+    assert_selector "[data-menu-target=menu]"
+  end
+end

--- a/test/system/system_test_helper.rb
+++ b/test/system/system_test_helper.rb
@@ -114,6 +114,14 @@ module BrowserHarness
         <script type="module">
           import { Application } from "@hotwired/stimulus"
           const application = Application.start()
+          // Stimulus catches errors thrown in lifecycle callbacks and routes them here
+          // rather than letting them reach window.onerror — so `js_errors` never sees a
+          // controller that throws in connect(). Recording them is the only way this lane
+          // can tell a working component from a silently dead one.
+          window.__stimulusErrors = []
+          application.handleError = (error, message, detail) => {
+            window.__stimulusErrors.push(`${message}: ${error && error.message}`)
+          }
           #{registrations}
           window.__stimulusReady = true
         </script>
@@ -154,6 +162,14 @@ class BrowserTestCase < Minitest::Test
   end
 
   def press(key) = page.driver.browser.keyboard.type(key)
+
+  # A controller that throws in a lifecycle callback renders nothing visibly wrong — it
+  # just stops working. Assert explicitly that none did.
+  def assert_no_stimulus_errors
+    errors = page.evaluate_script("window.__stimulusErrors || []")
+
+    assert_empty errors, "Stimulus reported controller errors:\n  #{errors.join("\n  ")}"
+  end
 
   # Structural accessibility only. `color-contrast` is OFF because the stylesheet ships as
   # Tailwind source and this harness serves no compiled CSS — axe would report against

--- a/test/system/system_test_helper.rb
+++ b/test/system/system_test_helper.rb
@@ -1,0 +1,174 @@
+# frozen_string_literal: true
+
+# BROWSER lane. The render lane asserts markup; this one asserts what happens once the
+# JavaScript runs — open/close, roving focus, ARIA that a controller keeps in sync, and
+# the DOM mutations no amount of static markup can reveal.
+#
+# It exists because every bug found in the 2026-08 overlay audit was browser-observable
+# and this gem structurally could not see any of it: a submenu that outlived its parent
+# menu, an avatar that vanished from the accessibility tree after its image 404'd. Both
+# rendered perfectly correct markup.
+#
+# Approach: no test/dummy on disk. A tiny Rack app serves one page per scenario, with a
+# real importmap wiring the gem's own controller templates and shared modules against the
+# Stimulus runtime — the same module graph a host app gets, so a broken import or an
+# unpinned specifier fails here exactly as it would in a fork.
+#
+# SCOPE: behaviour and ARIA, not colour. The stylesheet ships as Tailwind source that
+# needs a build step, so axe runs with colour-contrast disabled here; AAA contrast stays
+# proven in modelrails_base, which has compiled CSS. Anything asserting a *computed
+# colour* belongs there, not here.
+
+require "render_test_helper"
+require "capybara"
+require "capybara/minitest"
+require "capybara/cuprite"
+require "rack"
+# The shared-module registry: the harness resolves `overlays/top_layer` through the same
+# SHARED_JS entry the generator uses, so a module the gem forgot to register fails here.
+require_relative "../../lib/generators/modelrails_ui/components"
+
+module BrowserHarness
+  ADD_TEMPLATES = File.expand_path("../../lib/generators/modelrails_ui/add/templates", __dir__)
+  STIMULUS_JS = Dir.glob(
+    File.join(Gem::Specification.find_by_name("stimulus-rails").gem_dir, "app/assets/javascripts/stimulus.min.js")
+  ).first
+  # axe is injected on demand rather than shipped in the page, so it never influences the
+  # DOM under test until an assertion asks for it.
+  AXE_JS = Dir.glob(
+    File.join(Gem::Specification.find_by_name("axe-core-api").gem_dir, "**/axe.min.js")
+  ).first
+
+  # Registered by `scenario`; each block returns the HTML body for one page.
+  SCENARIOS = {}
+
+  class << self
+    # controllers: stimulus identifiers to register, resolved to <component>/<name>_controller.js
+    # modules:     shared ES modules (Components::SHARED_JS namespaces) the controllers import
+    def scenario(name, controllers: [], modules: [], &body)
+      SCENARIOS[name.to_s] = {controllers: controllers, modules: modules, body: body}
+    end
+
+    def controller_source(identifier)
+      file = "#{identifier.tr("-", "_")}_controller.js"
+      path = Dir.glob(File.join(ADD_TEMPLATES, "*", file)).first
+      raise "no template ships #{file}" unless path
+
+      File.read(path)
+    end
+
+    def module_source(namespace, name)
+      entry = Array(ModelrailsUi::Generators::Components::SHARED_JS.values.flatten)
+        .find { |m| m[:dir] == namespace && File.basename(m[:source], ".js") == name }
+      raise "no shared module #{namespace}/#{name}" unless entry
+
+      File.read(File.join(ADD_TEMPLATES, entry[:source]))
+    end
+  end
+
+  # Serves the page plus every JS file it imports. Deliberately mirrors a host's importmap
+  # rather than inlining the sources: a controller importing an unpinned bare specifier
+  # must fail here the way it would in a real app.
+  APP = lambda do |env|
+    path = env["PATH_INFO"]
+
+    if (m = path.match(%r{\A/js/controllers/(.+)\.js\z}))
+      return [200, {"content-type" => "text/javascript"}, [controller_source_for(m[1])]]
+    end
+    if (m = path.match(%r{\A/js/modules/([^/]+)/(.+)\.js\z}))
+      return [200, {"content-type" => "text/javascript"}, [BrowserHarness.module_source(m[1], m[2])]]
+    end
+    return [200, {"content-type" => "text/javascript"}, [File.read(STIMULUS_JS)]] if path == "/js/stimulus.js"
+
+    scenario = SCENARIOS[path.delete_prefix("/")]
+    return [404, {"content-type" => "text/plain"}, ["no scenario at #{path}"]] unless scenario
+
+    [200, {"content-type" => "text/html"}, [BrowserHarness.page(scenario)]]
+  end
+
+  def self.controller_source_for(identifier) = controller_source(identifier)
+
+  def self.axe_source = File.read(AXE_JS)
+
+  def self.page(scenario)
+    imports = {"@hotwired/stimulus" => "/js/stimulus.js"}
+    scenario[:controllers].each { |c| imports["controllers/#{c}"] = "/js/controllers/#{c}.js" }
+    scenario[:modules].each { |m| imports[m] = "/js/modules/#{m}.js" }
+
+    registrations = scenario[:controllers].map do |c|
+      "import C_#{c.tr("-", "_")} from \"controllers/#{c}\"\n" \
+      "application.register(\"#{c}\", C_#{c.tr("-", "_")})"
+    end.join("\n")
+
+    <<~HTML
+      <!doctype html>
+      <html lang="en"><head><meta charset="utf-8"><title>harness</title>
+      <script type="importmap">#{{imports: imports}.to_json}</script>
+      </head>
+      <body>
+        <!-- A landmark wrapper so axe's `region` rule reports on the COMPONENT rather than
+             on the harness page having no landmarks of its own. -->
+        <main>
+        #{scenario[:body].call}
+        </main>
+        <script type="module">
+          import { Application } from "@hotwired/stimulus"
+          const application = Application.start()
+          #{registrations}
+          window.__stimulusReady = true
+        </script>
+      </body></html>
+    HTML
+  end
+end
+
+Capybara.register_driver(:cuprite_gem) do |app|
+  Capybara::Cuprite::Driver.new(app, headless: true, js_errors: true, process_timeout: 30, timeout: 15,
+    window_size: [1200, 900],
+    **(Process.uid.zero? ? {browser_options: {"no-sandbox" => nil, "disable-dev-shm-usage" => nil}} : {}))
+end
+
+# webrick, not puma: the harness serves a handful of small static responses, so the
+# lighter server keeps the lane's startup cost down and avoids another dependency.
+Capybara.server = :webrick
+Capybara.app = BrowserHarness::APP
+Capybara.default_driver = :cuprite_gem
+Capybara.default_max_wait_time = 5
+
+# js_errors: true above turns an exception inside a controller into a test failure rather
+# than a silently dead component — the failure mode this lane exists to catch.
+class BrowserTestCase < Minitest::Test
+  include Capybara::DSL
+  include Capybara::Minitest::Assertions
+
+  def teardown
+    Capybara.reset_sessions!
+    super
+  end
+
+  def visit_scenario(name)
+    visit("/#{name}")
+    # Stimulus boots asynchronously; without this an action can be dispatched before the
+    # controller connects and the assertion fails for the wrong reason.
+    Timeout.timeout(5) { sleep 0.02 until page.evaluate_script("window.__stimulusReady === true") }
+  end
+
+  def press(key) = page.driver.browser.keyboard.type(key)
+
+  # Structural accessibility only. `color-contrast` is OFF because the stylesheet ships as
+  # Tailwind source and this harness serves no compiled CSS — axe would report against
+  # unstyled defaults and a green result would mean nothing. AAA contrast is proven in
+  # modelrails_base against real compiled CSS; do not re-enable it here without also
+  # building the stylesheet.
+  def assert_axe_clean(within: "body")
+    page.execute_script(BrowserHarness.axe_source) unless page.evaluate_script("typeof axe !== 'undefined'")
+    violations = page.evaluate_async_script(<<~JS, within)
+      const [selector, done] = [arguments[0], arguments[1]];
+      axe.run(document.querySelector(selector), { rules: { "color-contrast": { enabled: false } } })
+         .then((r) => done(r.violations.map((v) => v.id + ": " + v.nodes.length + " node(s) — " + v.help)))
+         .catch((e) => done(["axe failed to run: " + e.message]));
+    JS
+
+    assert_empty violations, "axe violations in #{within}:\n  #{violations.join("\n  ")}"
+  end
+end


### PR DESCRIPTION
**B4.** The render lane asserts markup and is blind to anything that only happens once JS runs. That is the structural reason every bug in the 2026-08 overlay audit was found in `modelrails_base` rather than here — and why this gem was load-bearing on a downstream app for its own guarantees.

## What it is

No `test/dummy` on disk. A small Rack app serves one page per scenario and wires the gem's **own controller templates and shared modules through a real importmap** against the Stimulus runtime. That matters: a broken import, or a module missing from `SHARED_JS`, fails here exactly as it would in a fork.

```ruby
BrowserHarness.scenario("dropdown_menu/submenu",
  controllers: %w[menu submenu], modules: %w[overlays/top_layer]) { … }
```

`rake test:system` joins the default task; `js_errors: true` turns an exception inside a controller into a failure rather than a silently dead component.

## It caught a real bug on the first run

Avatar's image-error fallback **never fired when the image failed fast**. A quick 404 beats ES-module loading, so `error` was dispatched before the controller connected and nothing was listening:

```
{"imgComplete":true,"imgNaturalWidth":0,"controllerConnected":true,"fallbackHidden":true}
```

The image had already failed; the swap never ran. The controller now also detects an already-failed image on connect. **The host app's suite passes this only by timing luck** — same code, slower asset loading. That is precisely the class of bug neither lane could previously see.

It also failed cleanly against the pre-#94 submenu code and passes after, which is a free positive control for the lane itself.

## Scope, deliberately

axe runs **structurally**; `color-contrast` is off and must stay off until the harness builds the stylesheet. The CSS ships as Tailwind source, so a contrast pass against unstyled defaults would be green and meaningless. AAA contrast stays proven in `modelrails_base`, which has compiled CSS — anything asserting a *computed colour* belongs there.

The harness page wraps scenarios in `<main>` so axe's `region` rule reports on the component rather than on the harness lacking landmarks.

## Coverage so far

10 browser tests over dropdown_menu (open/close, roving focus, submenu open, parent-closes-submenu, layered Escape) and avatar (swap, img removed, accessible name survives, structural axe). Both existing lanes unchanged: 533 structural + 942 render + 10 system, RuboCop clean.

**Follow-up:** the same avatar race exists in `modelrails_base` and needs the same fix there.