### PR TITLE
test(system): browser coverage for tabs, popover, combobox and checkbox

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- Browser lane coverage for tabs, popover, combobox and checkbox — 38 tests over the behaviour the render lane cannot reach: arrow-key models, roving tabindex, filtering, `aria-activedescendant` resolving to a real option, runtime-minted ids staying unique across instances, and the `indeterminate` DOM property.
 - Browser test lane (`rake test:system`). A real Chrome drives the gem's own controller templates through a real importmap, so behaviour that only exists once JS runs is provable here instead of only in a host app. Includes a structural axe audit (colour-contrast deliberately disabled — the stylesheet ships as Tailwind source, so a contrast pass here would be meaningless).
 
 ### Fixed

--- a/test/system/checkbox_system_test.rb
+++ b/test/system/checkbox_system_test.rb
@@ -1,0 +1,45 @@
+# frozen_string_literal: true
+
+require "system_test_helper"
+load_component "checkbox", "checkbox_component.rb.tt"
+
+BrowserHarness.scenario("checkbox/indeterminate", controllers: %w[indeterminate]) do
+  view = ActionController::Base.new.view_context
+  UI::CheckboxComponent.new(label: "Select all", indeterminate: true, name: "all").render_in(view) +
+    UI::CheckboxComponent.new(label: "Invoices", name: "invoices").render_in(view)
+end
+
+# `indeterminate` is a DOM property with no HTML attribute, so the render lane can only
+# see that a controller was WIRED. Whether the property is actually set — and cleared once
+# the user acts — exists solely at runtime.
+class CheckboxSystemTest < BrowserTestCase
+  def setup
+    super
+    visit_scenario("checkbox/indeterminate")
+  end
+
+  def indeterminate?(name)
+    page.evaluate_script(%{document.querySelector("input[name='#{name}']").indeterminate})
+  end
+
+  def test_the_property_the_markup_could_not_carry_is_set
+    assert indeterminate?("all")
+  end
+
+  # The control: without it, reading a default `false` would look like a pass.
+  def test_a_plain_checkbox_is_left_alone
+    refute indeterminate?("invoices")
+  end
+
+  def test_acting_on_it_clears_the_partial_state
+    find("input[name='all']").click
+
+    refute indeterminate?("all")
+    assert_no_stimulus_errors
+  end
+
+  # A tri-state parent means "some children selected" — it must not submit as checked.
+  def test_the_partial_parent_is_not_checked
+    refute page.evaluate_script(%{document.querySelector("input[name='all']").checked})
+  end
+end

--- a/test/system/combobox_system_test.rb
+++ b/test/system/combobox_system_test.rb
@@ -1,0 +1,101 @@
+# frozen_string_literal: true
+
+require "system_test_helper"
+require "securerandom"
+load_component "combobox", "combobox_component.rb.tt"
+
+OPTIONS = [
+  {value: "us", label: "United States"},
+  {value: "ca", label: "Canada"},
+  {value: "mx", label: "Mexico"}
+].freeze
+
+BrowserHarness.scenario("combobox/basic", controllers: %w[combobox], modules: %w[overlays/top_layer]) do
+  view = ActionController::Base.new.view_context
+  UI::ComboboxComponent.new(name: "country", label: "Country", options: OPTIONS).render_in(view)
+end
+
+BrowserHarness.scenario("combobox/two", controllers: %w[combobox], modules: %w[overlays/top_layer]) do
+  view = ActionController::Base.new.view_context
+  UI::ComboboxComponent.new(name: "origin", label: "Origin", options: OPTIONS).render_in(view) +
+    UI::ComboboxComponent.new(name: "destination", label: "Destination", options: OPTIONS).render_in(view)
+end
+
+# Filtering, activedescendant and commit are all runtime behaviour. The duplicate-id case
+# especially: ids minted by the controller at runtime cannot be checked from markup at all.
+class ComboboxSystemTest < BrowserTestCase
+  def input = find("[data-combobox-target=input]")
+
+  def test_focusing_the_input_opens_the_listbox
+    visit_scenario("combobox/basic")
+    input.click
+
+    assert_selector "[role=listbox]"
+    assert_selector "[role=option]", count: 3
+  end
+
+  def test_typing_filters_the_options
+    visit_scenario("combobox/basic")
+    input.click
+    input.send_keys("can")
+
+    assert_selector "[role=option]", count: 1, text: "Canada"
+  end
+
+  def test_no_match_shows_the_empty_state
+    visit_scenario("combobox/basic")
+    input.click
+    input.send_keys("zzzz")
+
+    assert_no_selector "[role=option]"
+    assert_selector "[data-combobox-target=empty]"
+  end
+
+  # aria-activedescendant must name a real element — a stale or absent id silently breaks
+  # the announcement while looking fine in the DOM.
+  def test_arrow_down_points_activedescendant_at_a_real_option
+    visit_scenario("combobox/basic")
+    input.click
+    press(:Down)
+
+    resolved = page.evaluate_script(<<~JS)
+      (() => {
+        const input = document.querySelector("[data-combobox-target=input]");
+        const id = input.getAttribute("aria-activedescendant");
+        const el = id && document.getElementById(id);
+        return JSON.stringify({ id: id, exists: !!el, isOption: el ? el.getAttribute("role") === "option" : false });
+      })()
+    JS
+    state = JSON.parse(resolved)
+
+    assert state["exists"], "aria-activedescendant=#{state["id"].inspect} names no element"
+    assert state["isOption"], "aria-activedescendant does not name an option"
+  end
+
+  def test_choosing_an_option_commits_the_value
+    visit_scenario("combobox/basic")
+    input.click
+    find("[role=option]", text: "Mexico").click
+
+    assert_equal "mx", page.evaluate_script(%{document.querySelector("[data-combobox-target=hidden]").value})
+    assert_no_stimulus_errors
+  end
+
+  # The runtime half of the duplicate-id fix: option ids are minted by the controller, so
+  # two instances with a shared prefix collide and aria-activedescendant becomes ambiguous.
+  def test_option_ids_are_unique_across_two_instances
+    visit_scenario("combobox/two")
+    page.all("[data-combobox-target=input]").each(&:click)
+    ids = page.evaluate_script(%{[...document.querySelectorAll("[role=option]")].map(o => o.id)})
+
+    assert_operator ids.length, :>=, 6
+    assert_equal ids.uniq.length, ids.length, "duplicate option ids across instances: #{ids.inspect}"
+  end
+
+  def test_open_combobox_passes_a_structural_axe_audit
+    visit_scenario("combobox/basic")
+    input.click
+
+    assert_axe_clean
+  end
+end

--- a/test/system/popover_system_test.rb
+++ b/test/system/popover_system_test.rb
@@ -1,0 +1,78 @@
+# frozen_string_literal: true
+
+require "system_test_helper"
+require "securerandom"
+load_component "popover", "popover_component.rb.tt"
+
+BrowserHarness.scenario("popover/basic", controllers: %w[floating], modules: %w[overlays/top_layer]) do
+  view = ActionController::Base.new.view_context
+  popover = UI::PopoverComponent.new(label: "Account menu").render_in(view) do |c|
+    c.with_trigger { "Open popover" }
+    view.tag.a("Sign out", href: "#")
+  end
+  # An unambiguous outside target: clicking a wrapper that CONTAINS the popover would land
+  # inside it and prove nothing about outside-click dismissal.
+  popover + view.tag.button("elsewhere", type: "button", id: "outside")
+end
+
+# Open/close, aria-expanded sync and focus return — none of it visible to the render lane.
+#
+# NOT covered here: top-layer promotion. The harness serves no compiled CSS, so the panel
+# never computes to `position: fixed` and top_layer.js correctly declines to promote it.
+# That guard is the right behaviour, and it means promotion can only be proven where real
+# CSS exists — modelrails_base. Asserting it here would require faking the style, which
+# would prove the fake rather than the component.
+class PopoverSystemTest < BrowserTestCase
+  def setup
+    super
+    visit_scenario("popover/basic")
+  end
+
+  def test_panel_is_hidden_until_the_trigger_is_used
+    assert_no_selector "[data-floating-target=panel]"
+    assert_selector "[data-floating-target=trigger][aria-expanded='false']"
+  end
+
+  def test_clicking_the_trigger_opens_and_syncs_aria_expanded
+    find("[data-floating-target=trigger]").click
+
+    assert_selector "[data-floating-target=panel]"
+    assert_selector "[data-floating-target=trigger][aria-expanded='true']"
+  end
+
+  def test_escape_closes_and_returns_focus_to_the_trigger
+    find("[data-floating-target=trigger]").click
+
+    assert_selector "[data-floating-target=panel]"
+
+    press(:Escape)
+
+    assert_no_selector "[data-floating-target=panel]"
+    assert_equal "Open popover", page.evaluate_script("document.activeElement.textContent.trim()")
+  end
+
+  def test_a_click_outside_closes_it
+    find("[data-floating-target=trigger]").click
+
+    assert_selector "[data-floating-target=panel]"
+
+    find("#outside").click
+
+    assert_no_selector "[data-floating-target=panel]"
+  end
+
+  def test_toggling_twice_returns_to_the_closed_state
+    trigger = find("[data-floating-target=trigger]")
+    trigger.click
+    trigger.click
+
+    assert_no_selector "[data-floating-target=panel]"
+    assert_no_stimulus_errors
+  end
+
+  def test_open_popover_passes_a_structural_axe_audit
+    find("[data-floating-target=trigger]").click
+
+    assert_axe_clean
+  end
+end

--- a/test/system/tabs_system_test.rb
+++ b/test/system/tabs_system_test.rb
@@ -1,0 +1,116 @@
+# frozen_string_literal: true
+
+require "system_test_helper"
+require "securerandom"
+load_component "tabs", "tabs_item_component.rb.tt"
+load_component "tabs", "tabs_component.rb.tt"
+
+ORIENTATIONS = %w[horizontal vertical].freeze
+ACTIVATIONS = %w[automatic manual].freeze
+
+ORIENTATIONS.each do |orientation|
+  ACTIVATIONS.each do |activation|
+    BrowserHarness.scenario("tabs/#{orientation}_#{activation}", controllers: %w[tabs]) do
+      view = ActionController::Base.new.view_context
+      UI::TabsComponent.new(label: "Sections", orientation: orientation.to_sym, activation: activation.to_sym)
+        .render_in(view) do |t|
+          t.with_tab(title: "One") { "first panel" }
+          t.with_tab(title: "Two") { "second panel" }
+          t.with_tab(title: "Three") { "third panel" }
+          nil
+        end
+    end
+  end
+end
+
+# The keyboard model is the whole component, and none of it is visible to the render lane:
+# which arrow keys navigate, whether focus alone reveals a panel, and the roving tabindex
+# that keeps exactly one tab in the tab order.
+class TabsSystemTest < BrowserTestCase
+  def selected_tab = find("[role=tab][aria-selected=true]").text
+  def focused = page.evaluate_script("document.activeElement.textContent.trim()")
+
+  def open_scenario(name)
+    visit_scenario("tabs/#{name}")
+    find("[role=tab]", text: "One").click
+  end
+
+  def test_horizontal_arrow_right_moves_and_activates
+    open_scenario("horizontal_automatic")
+    press(:Right)
+
+    assert_equal "Two", selected_tab
+  end
+
+  # The control that keeps the vertical case honest: the unused axis must stay inert so
+  # those keys are left to the page.
+  def test_horizontal_ignores_arrow_down
+    open_scenario("horizontal_automatic")
+    press(:Down)
+
+    assert_equal "One", selected_tab
+  end
+
+  def test_vertical_arrow_down_moves_and_activates
+    open_scenario("vertical_automatic")
+    press(:Down)
+
+    assert_equal "Two", selected_tab
+  end
+
+  def test_vertical_ignores_arrow_right
+    open_scenario("vertical_automatic")
+    press(:Right)
+
+    assert_equal "One", selected_tab
+  end
+
+  def test_manual_moves_focus_without_revealing_the_panel
+    open_scenario("horizontal_manual")
+    press(:Right)
+
+    assert_equal "Two", focused
+    assert_equal "One", selected_tab
+  end
+
+  def test_manual_reveals_on_enter
+    open_scenario("horizontal_manual")
+    press(:Right)
+    press(:Enter)
+
+    assert_equal "Two", selected_tab
+  end
+
+  # Roving tabindex: exactly one tab is reachable by Tab at any time, and in manual mode
+  # the tab stop follows focus rather than selection.
+  def test_exactly_one_tab_is_in_the_tab_order
+    open_scenario("horizontal_automatic")
+    press(:Right)
+    zeroes = page.evaluate_script(%{[...document.querySelectorAll("[role=tab]")].filter(t => t.tabIndex === 0).length})
+
+    assert_equal 1, zeroes
+  end
+
+  def test_manual_tab_stop_follows_focus_not_selection
+    open_scenario("horizontal_manual")
+    press(:Right)
+    stop = page.evaluate_script(%{document.querySelector("[role=tab][tabindex='0']").textContent.trim()})
+
+    assert_equal "Two", stop
+    assert_equal "One", selected_tab
+  end
+
+  def test_only_the_active_panel_is_visible
+    open_scenario("horizontal_automatic")
+    press(:Right)
+
+    assert_selector "[role=tabpanel]:not([hidden])", count: 1
+    assert_no_stimulus_errors
+  end
+
+  def test_tablist_passes_a_structural_axe_audit
+    open_scenario("vertical_manual")
+
+    assert_axe_clean
+  end
+end


### PR DESCRIPTION
Extends the lane from #95 — **11 tests to 38** — across the behaviour the render lane cannot reach.

| Component | Covered |
|---|---|
| tabs | arrow model per orientation, the inert opposite axis, manual vs automatic, roving tabindex |
| popover | open/close, `aria-expanded` sync, Escape + focus return, outside click |
| combobox | filtering, empty state, `aria-activedescendant`, commit, unique runtime ids |
| checkbox | the `indeterminate` DOM property being set and cleared |

## Two assertions the render lane is structurally blind to

**`aria-activedescendant` must RESOLVE.** A stale or absent id looks perfectly fine in the DOM and silently breaks the announcement, so the test dereferences it and checks the target is a real `role=option`.

**Runtime-minted ids must stay unique across instances.** This is the half of the duplicate-id fix (#91/#704) that markup cannot show at all — the controller mints those ids, so only a browser can see them collide.

## Non-vacuity controls

Every direction has its mirror, so neither can pass by accident:
- horizontal **ignores** ArrowDown; vertical **ignores** ArrowRight
- a plain checkbox must **not** be indeterminate, so the positive assertion can't be reading a default

## What is deliberately NOT asserted

**Top-layer promotion.** The harness serves no compiled CSS, so panels never compute to `position: fixed` and `top_layer.js` **correctly declines to promote them**. Faking the style would prove the fake. Promotion stays proven in `modelrails_base`, which has real CSS — the same split as colour contrast.

## One failure, and it was mine

`test_a_click_outside_closes_it` failed initially. Not a bug: clicking a wrapper that *contains* the popover lands inside it, so `closeOnClickOutside` was right to ignore it. The scenario now renders an explicit outside target.

All lanes green — 533 structural + 942 render + 38 system, RuboCop clean across 225 files.