### PR TITLE
docs(testing): make the browser lane's limits findable

### DIFF
--- a/README.md
+++ b/README.md
@@ -105,7 +105,8 @@ the rules; your house-rules edits are preserved.
 
 ## Testing & accessibility
 
-The gem's suite (`rake test`) runs two lanes:
+The gem's suite (`rake test`) runs three lanes — see **[docs/testing.md](docs/testing.md)**
+for what each one can and, importantly, cannot prove:
 
 - **`test:structural`** — fast, no Rails: reads the `.rb.tt` templates as text and asserts
   structure (`test/test_components.rb` and friends).
@@ -113,6 +114,15 @@ The gem's suite (`rake test`) runs two lanes:
   a component, asserting actual HTML/ARIA. AAA contrast is guaranteed by
   `test/test_aaa_contrast.rb` (token ratios), so a render test that asserts a component
   uses the semantic token classes inherits AAA.
+- **`test:system`** — a real Chrome: proves what only happens once JavaScript runs
+  (open/close, roving focus, ARIA a controller keeps in sync, runtime-minted ids).
+
+> **Two things the browser lane cannot prove.** It serves no compiled stylesheet, so
+> **colour contrast** and **top-layer promotion** are both out of reach there — `axe` runs
+> with `color-contrast` disabled, and `top_layer.js` correctly declines to promote a panel
+> that never computes to `position: fixed`. Both are proven in `modelrails_base` against a
+> real app with built CSS. Do not inject styles to make them fire locally; the assertion
+> would prove the injected style. Details in [docs/testing.md](docs/testing.md).
 
 ### Verifying components (render tests)
 

--- a/docs/testing.md
+++ b/docs/testing.md
@@ -1,0 +1,104 @@
+# Testing
+
+`rake test` runs three lanes, in increasing cost and decreasing breadth. Each proves
+something the others structurally cannot, so a component is only fully covered when the
+right assertion sits in the right lane.
+
+| Lane | Task | Boots | Proves |
+|---|---|---|---|
+| Structural | `test:structural` | nothing | the `.rb.tt` templates as text — registries, catalog completeness, conventions |
+| Render | `test:render` | Rails + ViewComponent | real HTML and ARIA from a rendered component |
+| Browser | `test:system` | Chrome over CDP | what happens once JavaScript runs |
+
+## What each lane cannot prove
+
+This is the part worth knowing **before** you write an assertion, because a test placed in
+the wrong lane either fails confusingly or — worse — passes for the wrong reason.
+
+### The render lane cannot see behaviour
+
+It renders markup and stops. Anything a Stimulus controller does at runtime is invisible
+to it: open/close, roving focus, `aria-expanded` kept in sync, ids minted by a controller,
+`aria-activedescendant` actually resolving to an element, a DOM node removed on failure.
+
+Every bug found in the 2026-08 overlay audit was of exactly this kind, which is why the
+browser lane exists.
+
+### The browser lane cannot see anything that needs compiled CSS
+
+The harness serves the components and their JavaScript, **but no stylesheet**. The gem
+ships CSS as Tailwind source, which needs a build step the harness does not run. Two
+things therefore cannot be proven here:
+
+**1. Colour contrast.** `assert_axe_clean` disables the `color-contrast` rule. Against
+unstyled defaults axe would report on the browser's own colours, so a green result would
+mean nothing. Re-enabling it without first building the stylesheet produces a test that
+looks strict and asserts nothing.
+
+**2. Top-layer promotion.** `top_layer.js` promotes a panel only when it already computes
+to `position: fixed` — the invariant that keeps an `absolute`-placed panel from being torn
+off its trigger. With no stylesheet nothing computes to `fixed`, so the guard correctly
+declines to promote, and `:popover-open` is never true here.
+
+That is the guard working, not a harness bug. Do **not** inject a style to make it fire:
+the assertion would then prove the injected style rather than the component.
+
+Both are proven in **`modelrails_base`**, which generates the components into a real app
+with compiled Tailwind. Anything asserting a computed colour, a stacking context, or
+promotion belongs in that repo's `spec/system/ui/`.
+
+## Writing a browser test
+
+```ruby
+require "system_test_helper"
+load_component "popover", "popover_component.rb.tt"
+
+BrowserHarness.scenario("popover/basic",
+  controllers: %w[floating],            # Stimulus identifiers to register
+  modules: %w[overlays/top_layer]) do   # shared ES modules the controllers import
+  view = ActionController::Base.new.view_context
+  UI::PopoverComponent.new(label: "Account menu").render_in(view) { |c| c.with_trigger { "Open" } }
+end
+
+class PopoverSystemTest < BrowserTestCase
+  def test_the_trigger_opens_it
+    visit_scenario("popover/basic")
+    find("[data-floating-target=trigger]").click
+
+    assert_selector "[data-floating-target=panel]"
+  end
+end
+```
+
+The page is served with a **real importmap** wiring the gem's own controller templates and
+shared modules. A controller importing a bare specifier that nothing pins fails here the
+same way it would in a fork — which is the point.
+
+### Helpers
+
+- `visit_scenario(name)` — loads the page and waits for Stimulus to boot. Without the wait
+  an action can be dispatched before the controller connects, and the test fails for the
+  wrong reason.
+- `press(:Escape)` — real key input. **Do not use Capybara's `send_keys`**: it resolves an
+  element and *clicks it* to take focus, which on a menu activates an item and closes it
+  before the key is ever sent. A spec written that way passes regardless of the handler.
+- `assert_axe_clean(within: "body")` — structural audit, contrast excluded (above).
+- `assert_no_stimulus_errors` — Stimulus catches errors thrown in lifecycle callbacks and
+  routes them to `application.handleError` rather than `window.onerror`, so a controller
+  that throws in `connect()` leaves the page looking fine and simply stops working. Assert
+  this anywhere a controller's connect path matters.
+
+## Non-vacuity
+
+An assertion that cannot fail is worse than no assertion, because it reads as coverage.
+Two habits the suite relies on:
+
+- **Give every positive a control.** Horizontal tabs ignore ↑/↓ *and* vertical ignore ←/→;
+  one checkbox is indeterminate *and* a sibling is not. Either alone can pass by reading a
+  default.
+- **Assert the fixture's shape first.** A "all ids are unique" check over a
+  single-instance page is trivially true. `test_renders_two_instances` runs before the
+  uniqueness assertion for exactly this reason.
+
+When adding a guard for a bug, confirm it fails against the unfixed code before trusting
+it.

--- a/test/system/popover_system_test.rb
+++ b/test/system/popover_system_test.rb
@@ -17,11 +17,8 @@ end
 
 # Open/close, aria-expanded sync and focus return — none of it visible to the render lane.
 #
-# NOT covered here: top-layer promotion. The harness serves no compiled CSS, so the panel
-# never computes to `position: fixed` and top_layer.js correctly declines to promote it.
-# That guard is the right behaviour, and it means promotion can only be proven where real
-# CSS exists — modelrails_base. Asserting it here would require faking the style, which
-# would prove the fake rather than the component.
+# NOT covered here: top-layer promotion — unprovable without compiled CSS. See
+# docs/testing.md; `assert_promoted_to_top_layer` fails with the reason if you try.
 class PopoverSystemTest < BrowserTestCase
   def setup
     super

--- a/test/system/system_test_helper.rb
+++ b/test/system/system_test_helper.rb
@@ -14,10 +14,20 @@
 # Stimulus runtime — the same module graph a host app gets, so a broken import or an
 # unpinned specifier fails here exactly as it would in a fork.
 #
-# SCOPE: behaviour and ARIA, not colour. The stylesheet ships as Tailwind source that
-# needs a build step, so axe runs with colour-contrast disabled here; AAA contrast stays
-# proven in modelrails_base, which has compiled CSS. Anything asserting a *computed
-# colour* belongs there, not here.
+# ── WHAT THIS LANE CANNOT PROVE ──────────────────────────────────────────────────────
+# The harness serves the components and their JavaScript but NO STYLESHEET: the gem ships
+# CSS as Tailwind source, which needs a build step this harness does not run. So:
+#
+#   * COLOUR CONTRAST — assert_axe_clean disables the color-contrast rule. Against
+#     unstyled defaults axe reports on the browser's own colours, so a green result would
+#     mean nothing.
+#   * TOP-LAYER PROMOTION — top_layer.js promotes only what already computes to
+#     `position: fixed`. With no stylesheet nothing does, so it correctly declines and
+#     `:popover-open` is never true here. That is the guard working, not a harness bug.
+#
+# Do NOT inject a style to make either fire — the assertion would prove the injected
+# style. Both are proven in modelrails_base against a real app with compiled CSS.
+# See docs/testing.md. assert_promoted_to_top_layer below fails loudly to say so.
 
 require "render_test_helper"
 require "capybara"
@@ -162,6 +172,24 @@ class BrowserTestCase < Minitest::Test
   end
 
   def press(key) = page.driver.browser.keyboard.type(key)
+
+  # A tripwire, not a helper. Promotion is unprovable here (no compiled CSS — see the
+  # header), and the mistake is easy to make because the assertion LOOKS reasonable. Rather
+  # than let someone write it and watch it fail for an opaque reason, fail with the reason.
+  def assert_promoted_to_top_layer(*)
+    flunk <<~MSG
+      Top-layer promotion cannot be proven in the browser lane.
+
+      This harness serves no compiled stylesheet, so nothing computes to `position: fixed`
+      and top_layer.js correctly declines to promote. `:popover-open` is never true here.
+
+      Do not inject a style to force it — the test would prove the injected style rather
+      than the component. Assert promotion in modelrails_base instead:
+      spec/system/ui/overlay_stacking_context_spec.rb
+
+      See docs/testing.md.
+    MSG
+  end
 
   # A controller that throws in a lifecycle callback renders nothing visibly wrong — it
   # just stops working. Assert explicitly that none did.


### PR DESCRIPTION
Raised in review: *is the top-layer limitation well documented and easy to find?* It was not, and the README was actively wrong.

## What was actually there

- README said the suite **"runs two lanes"** — stale since #95 added `test:system`.
- The two things the browser lane cannot prove lived in **two code comments inside test files**.
- **No markdown mentioned `test:system` at all.**

So a developer adding an overlay to the lane would write a promotion assertion, watch it fail for an opaque reason, and either dig through `top_layer.js` — or "fix" it by injecting a style, producing a test that proves the injected style.

## Three levels of discoverability

**1. README** — corrected to three lanes, with both limits called out inline and a link to the guide.

**2. `docs/testing.md`** — what each lane proves and what it cannot; why contrast *and* promotion both need compiled CSS; where each **is** proven (`modelrails_base`). It also records the two traps that cost real time in this arc: Capybara's `send_keys` clicking the element it focuses (a menu spec written that way passes regardless of the handler), and Stimulus routing lifecycle errors to `handleError` rather than `window.onerror`.

**3. A tripwire** — `assert_promoted_to_top_layer` is deliberately not a helper. It flunks with the explanation and points at the base spec:

```
Top-layer promotion cannot be proven in the browser lane.
This harness serves no compiled stylesheet, so nothing computes to `position: fixed`
and top_layer.js correctly declines to promote. `:popover-open` is never true here.
Do not inject a style to force it — the test would prove the injected style rather
than the component. Assert promotion in modelrails_base instead: …
```

Documentation nobody reads doesn't help; failing at the moment of the mistake does. Verified it fires.

The popover test's comment now points at the guide instead of restating it, so there's one source of truth.

All lanes green — 533 + 942 + 38, RuboCop clean.