### PR TITLE
fix(css): ship the focus-ring utility and use it in .btn-* / .form-input

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- **The `focus-ring` utility now ships.** It is emitted by 47 component templates but was never defined in `modelrails_ui.css`, and Tailwind drops unresolvable classes silently — so in every install the design system's own AAA focus treatment (a 2px offset outline on `:focus-visible`) simply did not exist, and components fell back to the browser default. (#98)
+- `.btn-primary`, `.btn-secondary`, `.btn-danger` and `.form-input` used a box-shadow focus ring (`focus:ring-*`), which the library's own rules forbid: a ring is clipped by any `overflow: hidden` ancestor and vanishes in forced-colors mode (WCAG 2.4.7). They now `@apply focus-ring`, matching the reference app. `.btn-*` also fired on `:focus` rather than `:focus-visible`, so the indicator appeared on mouse click. (#99)
+
+### Added
+
+- `test/test_shipped_stylesheet_completeness.rb` — guards both of the above: every custom class a template emits must be defined in the shipped stylesheet, and no shipped class may use a box-shadow focus ring. This bug class is invisible by construction, so it needs a test rather than a fix.
+
 ### Added
 
 - Browser lane coverage for tabs, popover, combobox and checkbox — 38 tests over the behaviour the render lane cannot reach: arrow-key models, roving tabindex, filtering, `aria-activedescendant` resolving to a real option, runtime-minted ids staying unique across instances, and the `indeterminate` DOM property.

--- a/lib/generators/modelrails_ui/install/templates/modelrails_ui.css
+++ b/lib/generators/modelrails_ui/install/templates/modelrails_ui.css
@@ -415,6 +415,27 @@
   }
 }
 
+/* ==========================================================================
+   FOCUS RING — the library's focus treatment, referenced by 47 component templates
+   ==========================================================================
+   An offset OUTLINE, never a box-shadow ring: a ring is clipped by any
+   `overflow: hidden` ancestor and disappears entirely in forced-colors mode,
+   both of which are WCAG 2.4.7 failures. `:focus-visible` (not `:focus`) so it
+   does not fire on mouse click.
+
+   Tailwind silently drops classes it cannot resolve, so a component emitting
+   `focus-ring` without this definition renders with no design-system focus
+   indicator and no build error. Guarded by
+   test/test_shipped_stylesheet_completeness.rb.
+   ========================================================================== */
+
+@utility focus-ring {
+  &:focus-visible {
+    outline: 2px solid var(--color-interactive-focus);
+    outline-offset: 2px;
+  }
+}
+
 @layer utilities {
   .page-container {
     @apply max-w-2xl mx-auto px-4;
@@ -488,25 +509,22 @@
      For text-only buttons (no fill), use .btn-text + .btn-text-* (above). */
   .btn-primary {
     @apply inline-flex items-center justify-center px-4 rounded-md font-medium cursor-pointer;
-    @apply focus:outline-none focus:ring-2 focus:ring-offset-2;
+    @apply focus-ring;
     @apply bg-interactive hover:bg-interactive-hover text-text-on-interactive;
-    @apply focus:ring-interactive-focus;
     min-height: var(--form-input-height);
   }
 
   .btn-secondary {
     @apply inline-flex items-center justify-center px-4 rounded-md font-medium cursor-pointer;
-    @apply focus:outline-none focus:ring-2 focus:ring-offset-2;
+    @apply focus-ring;
     @apply border border-border text-text-body hover:bg-surface-sunken;
-    @apply focus:ring-interactive-focus;
     min-height: var(--form-input-height);
   }
 
   .btn-danger {
     @apply inline-flex items-center justify-center px-4 rounded-md font-medium cursor-pointer;
-    @apply focus:outline-none focus:ring-2 focus:ring-offset-2;
+    @apply focus-ring;
     @apply bg-danger hover:bg-danger/90 text-text-on-interactive;
-    @apply focus:ring-danger;
     min-height: var(--form-input-height);
   }
 
@@ -521,7 +539,7 @@
   .form-input {
     @apply px-3 py-2 rounded-md cursor-pointer;
     @apply bg-surface text-text-body border border-border-strong;
-    @apply focus:outline-none focus:ring-2 focus:ring-interactive-focus;
+    @apply focus-ring;
     min-height: var(--form-input-height);
   }
 }

--- a/test/test_shipped_stylesheet_completeness.rb
+++ b/test/test_shipped_stylesheet_completeness.rb
@@ -1,0 +1,66 @@
+# frozen_string_literal: true
+
+require "test_helper"
+
+# Tailwind silently ignores a class it cannot resolve — no warning, no build error, just
+# a rule that never exists. So a component template referencing a custom utility the
+# shipped stylesheet does not define fails ONLY in the host app, visually, long after.
+#
+# That is exactly how `focus-ring` shipped undefined to every install while being emitted
+# by 47 templates: the design system's documented AAA focus treatment (a 2px offset
+# outline) simply did not exist downstream, and components fell back to the browser
+# default. Nothing in the suite could see it.
+class TestShippedStylesheetCompleteness < Minitest::Test
+  STYLESHEET = File.expand_path("../lib/generators/modelrails_ui/install/templates/modelrails_ui.css", __dir__)
+  TEMPLATES = File.expand_path("../lib/generators/modelrails_ui/add/templates", __dir__)
+
+  # Names the stylesheet defines: `@utility foo` blocks and `.foo { }` component rules.
+  def defined_names
+    css = File.read(STYLESHEET)
+    (css.scan(/@utility\s+([a-z0-9-]+)/).flatten + css.scan(/^\s*\.([a-z][a-z0-9-]*)\s*\{/).flatten).to_set
+  end
+
+  # Custom (non-Tailwind) names a template can legitimately reference. Anything matching
+  # this vocabulary MUST be shipped, because Tailwind will not generate it.
+  CUSTOM_PREFIXES = %w[focus-ring btn- page-container prose- lexxy-].freeze
+
+  def referenced_custom_names
+    Dir.glob("#{TEMPLATES}/**/*").select { |f| File.file?(f) && f.match?(/\.(tt|erb|js)\z/) }
+      .flat_map { |f| File.read(f).scan(/[\s"'`]([a-z][a-z0-9-]*)[\s"'`]/).flatten }
+      .select { |n| CUSTOM_PREFIXES.any? { |p| p.end_with?("-") ? n.start_with?(p) : n == p } }
+      .to_set
+  end
+
+  def test_every_custom_class_a_template_uses_is_shipped
+    missing = (referenced_custom_names - defined_names).sort
+
+    assert_empty missing, <<~MSG
+      These custom classes are emitted by component templates but never defined in
+      modelrails_ui.css, so Tailwind silently drops them in a host app:
+
+        #{missing.join("\n  ")}
+
+      Define them in lib/generators/modelrails_ui/install/templates/modelrails_ui.css.
+    MSG
+  end
+
+  # The focus treatment is a stated invariant of the library ("an offset outline, never a
+  # box-shadow ring — a ring is clipped by overflow:hidden ancestors and vanishes in
+  # forced-colors mode"), so the shipped CSS must not contradict it.
+  def test_no_shipped_class_uses_a_box_shadow_focus_ring
+    offenders = File.read(STYLESHEET)
+      .scan(/^\s*\.([a-z][a-z0-9-]*)\s*\{(.*?)^\s*\}/m)
+      .select { |_name, body| body.include?("focus:ring") }
+      .map(&:first)
+
+    assert_empty offenders, <<~MSG
+      These shipped classes use a box-shadow focus ring (focus:ring-*):
+
+        #{offenders.join(", ")}
+
+      The library's rule is an offset outline via the focus-ring utility. A box-shadow
+      ring is clipped by any overflow:hidden ancestor and vanishes entirely in
+      forced-colors mode — both WCAG 2.4.7 failures. Use `@apply focus-ring`.
+    MSG
+  end
+end


### PR DESCRIPTION
Closes #98, closes #99. Found by the review panel on decision D2 — and it **inverted that decision's premise**.

## The bug

`focus-ring` is emitted by **47 component templates**. It was defined in the shipped stylesheet **zero** times:

```
$ grep -c 'focus-ring' lib/generators/modelrails_ui/install/templates/modelrails_ui.css
0
$ grep -c '@utility'  lib/generators/modelrails_ui/install/templates/modelrails_ui.css
0
```

Tailwind drops classes it cannot resolve — no warning, no build error. So in every install the design system's own AAA focus treatment (2px `--color-interactive-focus` outline at 2px offset, on `:focus-visible`) **did not exist downstream**.

### Precise severity

Not "no focus indicator." I checked: nothing in the shipped CSS removes the UA outline globally — the `outline-none` occurrences are scoped to `.btn-*`/`.form-input`, each paired with a replacement. Affected components fall back to the **browser default** — visible, but untokenised and with no contrast guarantee on arbitrary surfaces. Three reviewers stated the stronger version; this is the accurate one.

## Second defect

`.btn-primary`, `.btn-secondary`, `.btn-danger` and `.form-input` used a **box-shadow ring**, which this library's own component source forbids verbatim (`toaster_component.rb.tt:141`): a ring is clipped by any `overflow: hidden` ancestor and vanishes in forced-colors mode — WCAG 2.4.7. `.btn-*` also used `:focus` rather than `:focus-visible`, so the indicator fired on mouse click.

The reference app fixed both long ago (`application.css:95, 201, 219`). The gem's copies were stale.

## Why this needed a test, not just a fix

A missing utility is **invisible by construction**. `test/test_shipped_stylesheet_completeness.rb` guards both properties:

1. Every custom class a template emits must be defined in the shipped stylesheet.
2. No shipped class may use a box-shadow focus ring.

It earned itself immediately: it caught `.btn-danger`, which uses `bg-danger/90` where the others use a hover token, so my first pass missed it. It also found `.form-input` had the same staleness — a class the panel hadn't flagged.

A scan for the general form of the bug (every custom name base defines vs. what the gem ships) found `focus-ring` was the **only** one, so this is bounded.

## Impact on D2

Routing overlay triggers through `Button.variant_classes` would have emitted `focus-ring` in place of a working `.btn-secondary` — trading a real focus treatment for a non-existent one. That is why the panel closed D2 as "leave it", and why this fix had to land first regardless.

All lanes green — 535 structural + 942 render + 38 system, RuboCop clean across 226 files.