### PR TITLE
fix(overlays): trigger_class merges over the a11y floor instead of replacing it

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- `trigger_class:` on Popover and DropdownMenu **replaced** the trigger's classes instead of merging, so a caller restyling the trigger silently removed its focus indicator (WCAG 2.4.11) and 44px target-size floor (2.5.5 AAA) — from the one element the components document as "a real `<button>` trigger". Caller classes are now merged over a non-replaceable `TRIGGER_BASE`. Default rendering is unchanged. (#100)
+
+### Fixed
+
 - **The `focus-ring` utility now ships.** It is emitted by 47 component templates but was never defined in `modelrails_ui.css`, and Tailwind drops unresolvable classes silently — so in every install the design system's own AAA focus treatment (a 2px offset outline on `:focus-visible`) simply did not exist, and components fell back to the browser default. (#98)
 - `.btn-primary`, `.btn-secondary`, `.btn-danger` and `.form-input` used a box-shadow focus ring (`focus:ring-*`), which the library's own rules forbid: a ring is clipped by any `overflow: hidden` ancestor and vanishes in forced-colors mode (WCAG 2.4.7). They now `@apply focus-ring`, matching the reference app. `.btn-*` also fired on `:focus` rather than `:focus-visible`, so the indicator appeared on mouse click. (#99)
 

--- a/docs/components/popover.md
+++ b/docs/components/popover.md
@@ -99,7 +99,7 @@ You supply:
 | `id` | String | auto `popover-<hex>` | Panel element ID; wired to `aria-controls` on the trigger |
 | `align` | Symbol | `:start` | `:start`, `:center`, or `:end` |
 | `side` | Symbol | `:bottom` | `:bottom`, `:top`, `:left`, or `:right` |
-| `trigger_class` | String | `"btn-secondary"` | CSS classes applied to the trigger `<button>` |
+| `trigger_class` | String | `"btn-secondary"` | CSS classes **added to** the trigger's accessibility floor (focus ring + 44px target size), which cannot be replaced |
 | `**html_attrs` | Hash | — | Forwarded to the outer `<div>` |
 
 | Slot | Required | Description |

--- a/lib/generators/modelrails_ui/add/templates/dropdown_menu/dropdown_menu_component.rb.tt
+++ b/lib/generators/modelrails_ui/add/templates/dropdown_menu/dropdown_menu_component.rb.tt
@@ -69,6 +69,14 @@ module UI
       content_tag(tag_name, capture(&block), **attrs, **el)
     end
 
+    # The trigger's accessibility floor — always applied, never replaceable. `trigger_class:`
+    # is merged OVER this rather than replacing it: a caller restyling the trigger was
+    # otherwise able to delete the focus indicator (WCAG 2.4.11) and the 44px target-size
+    # floor (2.5.5 AAA) from the one element this component guarantees is "a real <button>".
+    # Utilities rather than `.btn-touch-target`, so they sit in Tailwind's utilities layer
+    # and merge predictably instead of racing a component class on source order.
+    TRIGGER_BASE = "focus-ring min-h-[var(--form-input-height)]"
+
     PANEL_BASE = "z-50 min-w-[8rem] overflow-hidden rounded-md border border-border " \
                  "bg-surface-overlay p-1 text-text-body shadow-md outline-none"
 
@@ -213,7 +221,9 @@ module UI
     # align:         :start | :end (edge-aligned to the trigger)
     # id:            menu id (auto-generated if omitted; → aria-controls + anchor name)
     # aria_label:    trigger accessible name (REQUIRED for icon-only triggers)
-    # trigger_class: CSS for the trigger button (default canonical .btn-secondary)
+    # trigger_class: CSS ADDED to the trigger's accessibility floor (TRIGGER_BASE);
+    #                defaults to the canonical .btn-secondary. Your classes are merged
+    #                over the floor, so the focus ring and target size cannot be lost.
     def initialize(side: :bottom, align: :start, id: nil, aria_label: nil,
       trigger_class: "btn-secondary", **html_attrs)
       @id = id || "menu-#{SecureRandom.hex(4)}"
@@ -255,7 +265,7 @@ module UI
         "aria-controls": @id,
         "aria-label": @aria_label,
         data: {menu_target: "trigger", action: "click->menu#toggle keydown->menu#triggerKeydown"},
-        class: @trigger_class)
+        class: cn(TRIGGER_BASE, @trigger_class))
     end
 
     def menu_panel

--- a/lib/generators/modelrails_ui/add/templates/popover/popover_component.rb.tt
+++ b/lib/generators/modelrails_ui/add/templates/popover/popover_component.rb.tt
@@ -29,6 +29,14 @@ module UI
   class PopoverComponent < ApplicationComponent
     renders_one :trigger
 
+    # The trigger's accessibility floor — always applied, never replaceable. `trigger_class:`
+    # is merged OVER this rather than replacing it: a caller restyling the trigger was
+    # otherwise able to delete the focus indicator (WCAG 2.4.11) and the 44px target-size
+    # floor (2.5.5 AAA) from the one element this component guarantees is "a real <button>".
+    # Utilities rather than `.btn-touch-target`, so they sit in Tailwind's utilities layer
+    # and merge predictably instead of racing a component class on source order.
+    TRIGGER_BASE = "focus-ring min-h-[var(--form-input-height)]"
+
     PANEL_BASE = "z-50 w-72 rounded-md border border-border bg-surface-overlay p-4 " \
                  "text-sm text-text-body shadow-md outline-none"
 
@@ -63,7 +71,9 @@ module UI
     # id:            panel id (auto-generated if omitted; wired to aria-controls)
     # align:         :start | :center | :end
     # side:          :bottom | :top | :left | :right
-    # trigger_class: CSS for the trigger button (default canonical .btn-secondary)
+    # trigger_class: CSS ADDED to the trigger's accessibility floor (TRIGGER_BASE);
+    #                defaults to the canonical .btn-secondary. Your classes are merged
+    #                over the floor, so the focus ring and target size cannot be lost.
     def initialize(label:, id: nil, align: :start, side: :bottom, trigger_class: "btn-secondary", **html_attrs)
       @label         = label
       @id            = id || "popover-#{SecureRandom.hex(4)}"
@@ -102,7 +112,7 @@ module UI
         "aria-expanded": "false",
         "aria-controls": @id,
         data: {floating_target: "trigger", action: "click->floating#toggle"},
-        class: @trigger_class)
+        class: cn(TRIGGER_BASE, @trigger_class))
     end
 
     def panel

--- a/test/render/dropdown_menu_render_test.rb
+++ b/test/render/dropdown_menu_render_test.rb
@@ -128,4 +128,36 @@ class DropdownMenuRenderTest < ViewComponent::TestCase
                     "[data-turbo-frame='x']" \
                     "[style*='anchor-name: --m9'][style*='color: red']", visible: :all
   end
+
+  # `trigger_class:` used to REPLACE the trigger's classes, so a caller styling the
+  # trigger silently deleted its focus indicator and target-size floor — on the element
+  # whose own docstring promises "a real <button> trigger". Every other class input in
+  # this component merges via cn(); the trigger was the exception, on the one element
+  # carrying an ARIA contract.
+  def test_trigger_keeps_its_accessibility_floor_when_restyled
+    render_inline(UI::DropdownMenuComponent.new(trigger_class: "text-sm text-text-muted")) do |c|
+      c.with_trigger { "Open" }
+      c.with_item { "Edit" }
+    end
+
+    assert_selector "button[data-menu-target='trigger'].focus-ring", visible: :all
+  end
+
+  def test_trigger_still_applies_the_callers_classes
+    render_inline(UI::DropdownMenuComponent.new(trigger_class: "text-sm text-text-muted")) do |c|
+      c.with_trigger { "Open" }
+      c.with_item { "Edit" }
+    end
+
+    assert_selector "button.text-sm.text-text-muted", visible: :all
+  end
+
+  def test_default_trigger_is_unchanged
+    render_inline(UI::DropdownMenuComponent.new) do |c|
+      c.with_trigger { "Open" }
+      c.with_item { "Edit" }
+    end
+
+    assert_selector "button.btn-secondary", visible: :all
+  end
 end

--- a/test/render/popover_render_test.rb
+++ b/test/render/popover_render_test.rb
@@ -88,4 +88,27 @@ class PopoverRenderTest < ViewComponent::TestCase
       UI::PopoverComponent.new(label: "x", align: :middle)
     end
   end
+
+  # `trigger_class:` used to REPLACE the trigger's classes, so a caller styling the
+  # trigger silently deleted its focus indicator and target-size floor — on the element
+  # whose own docstring promises "a real <button> trigger". Every other class input in
+  # these components merges via cn(); the trigger was the exception, on the one element
+  # carrying an ARIA contract.
+  def test_trigger_keeps_its_accessibility_floor_when_restyled
+    render_inline(UI::PopoverComponent.new(label: "Account menu", trigger_class: "text-sm text-text-muted")) { |c| c.with_trigger { "Open" } }
+
+    assert_selector "button[data-floating-target='trigger'].focus-ring", visible: :all
+  end
+
+  def test_trigger_still_applies_the_callers_classes
+    render_inline(UI::PopoverComponent.new(label: "Account menu", trigger_class: "text-sm text-text-muted")) { |c| c.with_trigger { "Open" } }
+
+    assert_selector "button.text-sm.text-text-muted", visible: :all
+  end
+
+  def test_default_trigger_is_unchanged
+    render_inline(UI::PopoverComponent.new(label: "Account menu")) { |c| c.with_trigger { "Open" } }
+
+    assert_selector "button.btn-secondary", visible: :all
+  end
 end


### PR DESCRIPTION
Closes #100. Found by the review panel on decision D2 — Dave Thomas's finding, and the one defect in that area with teeth.

## The bug

Every other class input in these components merges via `cn()`:

- `popover_component.rb.tt:89` — wrapper
- `popover_component.rb.tt:117` — panel
- `dropdown_menu_component.rb.tt:60, 141, 176` — every menu item

The trigger was the exception — `class: @trigger_class`, replaced wholesale — and it is the one element carrying an ARIA contract. A caller writing `trigger_class: "text-sm text-text-muted"` for a subtle trigger silently deleted the focus indicator (WCAG 2.4.11) and the 44px target size (2.5.5 AAA) from an element whose own docstring promises **"a real `<button>` trigger"**.

`dropdown_menu_component.rb.tt:67-69` already states the correct rule for items: *"callers may add attrs but cannot break the menu contract."* The trigger just didn't follow it.

The single real override in the reference app survives today only by accident — `btn-text` happens to carry `focus-ring` and `min-h-11`.

## Two scoping decisions worth review

**Utilities, not `.btn-touch-target`.** The panel suggested that class. I checked it first: it sets `px-2` where `.btn-secondary` sets `px-4`, and both are component classes in the same layer — so applying both would let **stylesheet source order** decide the trigger's padding. `focus-ring min-h-[var(--form-input-height)]` sits in the utilities layer and merges predictably.

**min-width is deliberately NOT added.** `.btn-secondary` never set it, so adding it would *change rendering* rather than restore a guarantee — scope creep dressed as a fix. An icon-only trigger with a custom class still needs its own width; that's a separate question from this bug.

## Testing

Three assertions per component: the floor survives a custom `trigger_class`, the caller's classes are still applied, and **the default renders unchanged**. That last one is the safety control — this fix must be invisible unless you were already broken.

Probe confirms sensitivity: reverting to `class: @trigger_class` fails exactly the floor test.

All lanes green — 535 structural + 948 render + 38 system, RuboCop clean.

**Follow-up:** the same fix is needed in `modelrails_base`, which carries generated copies.