### PR TITLE
docs(dropdown_menu): document trigger_class and the class: confusion

### DIFF
--- a/docs/components/dropdown_menu.md
+++ b/docs/components/dropdown_menu.md
@@ -45,6 +45,29 @@ Icon-only triggers MUST pass `aria_label:` (the menu button's accessible name):
 <% end %>
 ```
 
+## Options
+
+| Arg | Type | Default | Description |
+|-----|------|---------|-------------|
+| `side` | Symbol | `:bottom` | `:bottom` or `:top` |
+| `align` | Symbol | `:start` | `:start` or `:end` (edge-aligned to the trigger) |
+| `id` | String | auto `dropdown-<hex>` | Menu element ID; wired to `aria-controls` on the trigger |
+| `aria_label` | String | — | Trigger's accessible name. **Required for icon-only triggers** |
+| `trigger_class` | String | `"btn-secondary"` | CSS classes **added to** the trigger's accessibility floor (focus ring + 44px target size), which cannot be replaced |
+| `**html_attrs` | Hash | — | Forwarded to the outer `<div>` |
+
+> **`class:` targets the wrapper, not the trigger.** Passing `class:` styles the outer
+> `<div>`; to restyle the button itself use `trigger_class:`. This is the most common
+> point of confusion with this component.
+
+`.btn-secondary` ships in `modelrails_ui.css`. A fork that strips or renames the `.btn-*`
+layer should pass its own `trigger_class:`.
+
+| Slot | Required | Description |
+|------|----------|-------------|
+| `with_trigger` | Yes | Visible content of the trigger button |
+| `with_item` | — | A menu item; see [Items](#items) |
+
 ## Placement
 
 | Arg | Values | Default |


### PR DESCRIPTION
Closes #102.

The page had **no options table at all**. `trigger_class` never appeared; `aria_label:` only in prose. There was no documented way to restyle a dropdown trigger — a user would try `class:`, which lands on the wrapper `<div>` and silently does nothing to the button, then have to read the component source.

Adds the table `popover.md` already carries, plus:

- an explicit callout that **`class:` targets the wrapper, not the trigger**
- a note that `.btn-secondary` ships in `modelrails_ui.css`, so a fork stripping the `.btn-*` layer should pass its own `trigger_class:`

Documentation only, no rendered change. All lanes green.