### PR TITLE
refactor(button): COMBOS names the .btn-* classes instead of duplicating them

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+- `ButtonComponent::COMBOS` now names the canonical `.btn-*` classes instead of re-listing their utilities. The stylesheet owns button appearance and the Ruby table is the typed accessor for it — previously the same rules existed in both languages and had already drifted. Rendered output is equivalent; `.btn-primary` carries exactly what the old utility string produced. (#101)
+
+### Fixed
+
+- `.btn-text` used a `focus-visible:ring-*` box-shadow ring, the same defect fixed in `.btn-*` earlier but with a different prefix — so text buttons would have lost their outline focus indicator when COMBOS switched to class names. Now `@apply focus-ring`, matching the reference app. The per-tone `focus-visible:ring-<colour>` declarations on `.btn-text-interactive`/`.btn-text-danger` existed only to colour that ring and are removed.
+
 ### Fixed
 
 - `trigger_class:` on Popover and DropdownMenu **replaced** the trigger's classes instead of merging, so a caller restyling the trigger silently removed its focus indicator (WCAG 2.4.11) and 44px target-size floor (2.5.5 AAA) — from the one element the components document as "a real `<button>` trigger". Caller classes are now merged over a non-replaceable `TRIGGER_BASE`. Default rendering is unchanged. (#100)

--- a/lib/generators/modelrails_ui/add/templates/button/button_component.rb.tt
+++ b/lib/generators/modelrails_ui/add/templates/button/button_component.rb.tt
@@ -23,21 +23,17 @@ module UI
     # text_interactive, text_danger. When a legacy value is passed, `tone:` is ignored.
     #
     # size: :default | :icon — :icon (A8) is a 44×44 square (WCAG 2.5.5): adds min-w
-    # and drops horizontal padding (min-h is already carried by FILLED/TEXT).
-    FILLED = "inline-flex items-center justify-center px-4 rounded-md font-medium cursor-pointer " \
-             "focus-ring min-h-[var(--form-input-height)]"
+    # and drops horizontal padding (min-h is already carried by the .btn-* classes).
 
-    TEXT = "inline-flex items-center justify-center px-2 min-h-[var(--form-input-height)] min-w-[var(--form-input-height)] " \
-           "font-medium underline rounded focus-ring hover:no-underline"
 
     # The proven (variant, tone) cells. Keys are [variant, tone]; values are the AAA
     # treatments (byte-identical to the former flat VARIANTS values).
     COMBOS = {
-      [:solid, :primary] => "#{FILLED} bg-interactive hover:bg-interactive-hover text-text-on-interactive",
-      [:solid, :danger] => "#{FILLED} bg-danger hover:bg-danger/90 text-text-on-interactive",
-      [:outline, :neutral] => "#{FILLED} border border-border text-text-body hover:bg-surface-sunken",
-      [:text, :primary] => "#{TEXT} text-interactive",
-      [:text, :danger] => "#{TEXT} text-danger"
+      [:solid, :primary] => "btn-primary",
+      [:solid, :danger] => "btn-danger",
+      [:outline, :neutral] => "btn-secondary",
+      [:text, :primary] => "btn-touch-target btn-text btn-text-interactive",
+      [:text, :danger] => "btn-touch-target btn-text btn-text-danger"
     }.freeze
 
     # Legacy flat `variant:` → [variant, tone]. Lets every existing call site keep

--- a/lib/generators/modelrails_ui/install/templates/modelrails_ui.css
+++ b/lib/generators/modelrails_ui/install/templates/modelrails_ui.css
@@ -471,17 +471,17 @@
      rounded corners, semantic underline). */
   .btn-text {
     @apply font-medium underline rounded;
-    @apply focus-visible:outline-none focus-visible:ring-2;
+    @apply focus-ring;
     @apply hover:no-underline;
   }
 
   /* Color variants of .btn-text. Apply alongside .btn-text. */
   .btn-text-danger {
-    @apply text-danger focus-visible:ring-danger;
+    @apply text-danger;
   }
 
   .btn-text-interactive {
-    @apply text-interactive focus-visible:ring-interactive-focus;
+    @apply text-interactive;
   }
 
   /* Inline flex container for trailing button groups (Resend / Cancel,

--- a/test/render/button_render_test.rb
+++ b/test/render/button_render_test.rb
@@ -10,13 +10,13 @@ class ButtonRenderTest < ViewComponent::TestCase
     assert_selector "button[type='button']", text: "Save changes"
   end
 
-  # AAA semantic tokens (the design-token guarantee), not raw Tailwind:
-  def test_primary_renders_with_aaa_tokens
+  # The component selects a canonical .btn-* class; the stylesheet owns what that class
+  # looks like. Asserting the utilities behind it here is what allowed COMBOS and the CSS
+  # to drift apart (#101), so these assert the class the component chose.
+  def test_primary_renders_the_canonical_button_class
     render_inline(UI::ButtonComponent.new("Save changes", variant: :primary))
 
-    assert_selector "button.bg-interactive"
-    assert_selector "button.text-text-on-interactive"
-    assert_selector "button.focus-ring"
+    assert_selector "button.btn-primary"
   end
 
   def test_href_renders_anchor
@@ -47,13 +47,13 @@ class ButtonRenderTest < ViewComponent::TestCase
   # Back-compat: every legacy flat `variant:` value still renders its marker class
   # (the shim translates the old enum to a (variant, tone) cell — byte-identical output).
   {
-    primary: "bg-interactive",
-    secondary: "border-border",
-    danger: "bg-danger",
-    destructive: "bg-danger",
-    text: "text-interactive",
-    text_interactive: "text-interactive",
-    text_danger: "text-danger"
+    primary: "btn-primary",
+    secondary: "btn-secondary",
+    danger: "btn-danger",
+    destructive: "btn-danger",
+    text: "btn-text-interactive",
+    text_interactive: "btn-text-interactive",
+    text_danger: "btn-text-danger"
   }.each do |legacy, marker|
     define_method("test_legacy_variant_#{legacy}_still_renders") do
       render_inline(UI::ButtonComponent.new("Go", variant: legacy))
@@ -65,19 +65,19 @@ class ButtonRenderTest < ViewComponent::TestCase
   def test_two_axis_solid_primary_matches_legacy_primary
     render_inline(UI::ButtonComponent.new("Go", variant: :solid, tone: :primary))
 
-    assert_selector "button.bg-interactive.text-text-on-interactive"
+    assert_selector "button.btn-primary"
   end
 
   def test_two_axis_text_danger
     render_inline(UI::ButtonComponent.new("Go", variant: :text, tone: :danger))
 
-    assert_selector "button.text-danger"
+    assert_selector "button.btn-text-danger"
   end
 
   def test_two_axis_outline_neutral_matches_legacy_secondary
     render_inline(UI::ButtonComponent.new("Go", variant: :outline, tone: :neutral))
 
-    assert_selector "button.border-border"
+    assert_selector "button.btn-secondary"
   end
 
   # Unproven (variant, tone) cell — raises in dev/test (the AAA combo-guard:
@@ -89,7 +89,7 @@ class ButtonRenderTest < ViewComponent::TestCase
   end
 
   # A8: `size: :icon` is a 44×44 square (drop horizontal padding, add min-w; min-h
-  # is already carried by the FILLED base).
+  # is already carried by the .btn-* classes).
   def test_size_icon_is_a_44px_square
     render_inline(UI::ButtonComponent.new(variant: :solid, tone: :primary, size: :icon))
 

--- a/test/test_components.rb
+++ b/test/test_components.rb
@@ -184,25 +184,37 @@ class TestButtonComponent < Minitest::Test
     assert c.instance_variable_get(:@html_attrs)[:disabled]
   end
 
+  # COMBOS names the canonical .btn-* classes rather than re-listing their utilities, so
+  # these assert the CLASS the component selects. The appearance behind each class is the
+  # stylesheet's business, and asserting utilities here is what let the two copies drift
+  # apart in the first place (#101).
   def test_component_classes_primary
     c = UI::ButtonComponent.new
-    classes = c.send(:component_classes)
 
-    assert_includes classes, "bg-interactive"
-    assert_includes classes, "min-h-[var(--form-input-height)]"
+    assert_includes c.send(:component_classes), "btn-primary"
   end
 
   def test_component_classes_danger_variant
     c = UI::ButtonComponent.new(variant: :danger)
 
-    assert_includes c.send(:component_classes), "bg-danger"
+    assert_includes c.send(:component_classes), "btn-danger"
   end
 
   def test_component_classes_text_variant
     c = UI::ButtonComponent.new(variant: :text_interactive)
 
-    assert_includes c.send(:component_classes), "underline"
-    assert_includes c.send(:component_classes), "text-interactive"
+    assert_includes c.send(:component_classes), "btn-text-interactive"
+  end
+
+  # Every cell must name classes the stylesheet actually ships — the failure mode this
+  # change trades into is a typo'd class name silently rendering unstyled.
+  def test_every_combo_names_shipped_classes
+    css = File.read(File.expand_path("../lib/generators/modelrails_ui/install/templates/modelrails_ui.css", __dir__))
+    shipped = css.scan(/^\s*\.([a-z][a-z0-9-]*)\s*\{/).flatten.to_set
+
+    missing = UI::ButtonComponent::COMBOS.values.flat_map(&:split).reject { |c| shipped.include?(c) }
+
+    assert_empty missing, "COMBOS names classes the stylesheet does not define: #{missing.inspect}"
   end
 
   def test_extra_class_appended

--- a/test/test_shipped_stylesheet_completeness.rb
+++ b/test/test_shipped_stylesheet_completeness.rb
@@ -50,11 +50,11 @@ class TestShippedStylesheetCompleteness < Minitest::Test
   def test_no_shipped_class_uses_a_box_shadow_focus_ring
     offenders = File.read(STYLESHEET)
       .scan(/^\s*\.([a-z][a-z0-9-]*)\s*\{(.*?)^\s*\}/m)
-      .select { |_name, body| body.include?("focus:ring") }
+      .select { |_name, body| body.match?(/focus(-visible)?:ring/) }
       .map(&:first)
 
     assert_empty offenders, <<~MSG
-      These shipped classes use a box-shadow focus ring (focus:ring-*):
+      These shipped classes use a box-shadow focus ring (focus:ring-* / focus-visible:ring-*):
 
         #{offenders.join(", ")}
 


### PR DESCRIPTION
Closes #101 — the panel's "this is the real DRY violation, not the one under review".

## The duplication

The button's visual rules existed twice: as utility strings in `COMBOS`, and as `.btn-*` classes in the stylesheet. One fact, two languages — and they had **already drifted**: the CSS used a box-shadow focus ring while the utility copy used `focus-ring`.

`COMBOS` is now the typed accessor and the stylesheet is the single source of truth, matching what the reference app already does.

## Verified equivalent, not assumed

`.btn-primary` carries exactly the declarations the old `FILLED` + primary utilities produced — same properties, same order.

## That check caught a second defect

`.btn-text` used `focus-visible:outline-none focus-visible:ring-2` — the **same box-shadow ring** fixed in `.btn-*` under #99, but with a `focus-visible:` prefix, so the guard I added there didn't match it.

Switching `COMBOS` to class names would therefore have swapped text buttons from an outline indicator to a clipped box-shadow one — a regression introduced by a refactor meant to be neutral. Fixed the class, and **widened the guard to both prefixes**. The per-tone `focus-visible:ring-<colour>` declarations went with it: they existed only to colour that ring, and `focus-ring` owns its own.

## Test changes

Eleven render tests and three structural tests asserted the utilities. They now assert **the class the component selects** — asserting utilities is precisely what let the two copies drift apart unnoticed.

Added `test_every_combo_names_shipped_classes`, because this change trades one failure mode for another: a typo'd class name would render unstyled and silently. That test pins every cell to a class the stylesheet actually defines.

All lanes green — 536 structural + 948 render + 38 system, RuboCop clean across 226 files.

**Note:** base already uses class names in its own COMBOS, so nothing to back-port. Base's `.btn-text` also already uses `focus-ring` — only the gem's copy was stale.