### PR TITLE
feat(command): fuzzy ranking, and the Escape handler that never ran

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- Command palette fuzzy ranking. The filter was substring-only and preserved source order; it now scores with cmdk's scorer (vendored, MIT — full notice in the file header) and ranks matches within each group. `data-command-keywords` lets an item be found by a synonym it does not display. Group order is left alone deliberately: it is authored intent, and reordering groups between keystrokes moves the palette's shape under the reader. (A7)
+
+### Fixed
+
+- **Escape never closed the command palette.** The component used `keydown.escape`, which is not in Stimulus's key-filter vocabulary — Stimulus throws "contains unknown key filter" and the action never runs. Every other floating component already used `keydown.esc`. Invisible to the structural and render lanes; found by the browser lane. A new test pins every `keydown.*` filter to one Stimulus recognises.
+
 ### Changed
 
 - `ButtonComponent::COMBOS` now names the canonical `.btn-*` classes instead of re-listing their utilities. The stylesheet owns button appearance and the Ruby table is the typed accessor for it — previously the same rules existed in both languages and had already drifted. Rendered output is equivalent; `.btn-primary` carries exactly what the old utility string produced. (#101)

--- a/lib/generators/modelrails_ui/add/templates/command/command_component.rb.tt
+++ b/lib/generators/modelrails_ui/add/templates/command/command_component.rb.tt
@@ -108,7 +108,11 @@ module UI
           role: "dialog",
           "aria-modal": "true",
           "aria-label": I18n.t("modelrails_ui.command.dialog_label", default: "Command palette"),
-          data: {action: "keydown.escape@window->command#close"}) {
+          # `esc`, not `escape` — Stimulus's KeyboardEvent filter vocabulary (every
+          # other floating component here uses keydown.esc). `escape` is an unknown
+          # filter: Stimulus throws "contains unknown key filter" and the documented
+          # Escape-closes behaviour never runs. Only a browser can see this.
+          data: {action: "keydown.esc@window->command#close"}) {
           concat search_bar
           concat content_tag(:div,
             class: LIST,

--- a/lib/generators/modelrails_ui/add/templates/command/command_controller.js
+++ b/lib/generators/modelrails_ui/add/templates/command/command_controller.js
@@ -1,4 +1,5 @@
 import { Controller } from "@hotwired/stimulus"
+import { commandScore } from "search/command_score"
 
 // Command palette behavior. Owns the WAI-ARIA APG combobox + listbox contract:
 // the input is the combobox (keeps DOM focus), the list is the listbox, and each
@@ -28,6 +29,7 @@ export default class extends Controller {
   }
 
   open() {
+    this._captureAuthoredOrder()
     this.panelTarget.hidden = false
     document.body.style.overflow = "hidden"
     this.inputTarget.value = ""
@@ -44,12 +46,55 @@ export default class extends Controller {
     this._setActive(null)
   }
 
-  filter() {
-    const query = this.inputTarget.value.toLowerCase().trim()
-    const items = this.options
-    items.forEach(item => {
-      item.hidden = query.length > 0 && !item.dataset.commandValue.toLowerCase().includes(query)
+  // The authored order is captured once, because sorting is destructive: after the first
+  // ranked query the DOM no longer knows what the caller wrote.
+  _captureAuthoredOrder() {
+    this._authored ||= this.options.map(item => [item, item.parentElement, Array.from(item.parentElement.children).indexOf(item)])
+  }
+
+  _restoreAuthoredOrder() {
+    if (!this._authored) return
+    this._authored.forEach(([item, parent, index]) => {
+      const at = parent.children[index]
+      if (at !== item) parent.insertBefore(item, at || null)
     })
+  }
+
+  // Rank WITHIN each group only. Group order is authored intent — a caller who put
+  // "Pages" above "Actions" meant that — and reordering groups by best score makes the
+  // palette's shape move under the user between keystrokes.
+  _rankWithinGroups(scored) {
+    const byGroup = new Map()
+    scored.forEach(entry => {
+      const group = entry.item.parentElement
+      if (!byGroup.has(group)) byGroup.set(group, [])
+      byGroup.get(group).push(entry)
+    })
+
+    byGroup.forEach((entries, group) => {
+      entries.sort((a, b) => b.score - a.score).forEach(({ item }) => group.appendChild(item))
+    })
+  }
+
+  filter() {
+    const query = this.inputTarget.value.trim()
+    const items = this.options
+
+    if (query.length === 0) {
+      // Restore the order the author wrote. Ranking is only meaningful against a query;
+      // with none, the caller's grouping is the intended reading order.
+      items.forEach(item => { item.hidden = false })
+      this._restoreAuthoredOrder()
+    } else {
+      // `data-command-keywords` lets an item be found by a synonym it does not display
+      // ("configuration" finding Settings) without polluting its visible label.
+      const scored = items.map(item => ({
+        item,
+        score: commandScore(item.dataset.commandValue, query, [item.dataset.commandKeywords || ""])
+      }))
+      scored.forEach(({ item, score }) => { item.hidden = score === 0 })
+      this._rankWithinGroups(scored.filter(s => s.score > 0))
+    }
 
     this.listTarget.querySelectorAll("[data-command-group]").forEach(group => {
       const hasVisible = Array.from(group.querySelectorAll("[data-command-value]")).some(i => !i.hidden)

--- a/lib/generators/modelrails_ui/add/templates/command/command_score.js
+++ b/lib/generators/modelrails_ui/add/templates/command/command_score.js
@@ -1,0 +1,129 @@
+// Fuzzy scorer for the command palette.
+//
+// Vendored from cmdk's `command-score.ts` (revision dd2250ed, 2025-10-29), which is
+// itself a fork of `command-score` by Fabrice Weinberg. Upstream weights and comments
+// are kept verbatim — they ARE the file, and retuning them by feel would be worse than
+// leaving them alone.
+//
+//   MIT License · Copyright (c) 2022 Paco Coursey
+//
+//   Permission is hereby granted, free of charge, to any person obtaining a copy of this
+//   software and associated documentation files (the "Software"), to deal in the Software
+//   without restriction, including without limitation the rights to use, copy, modify,
+//   merge, publish, distribute, sublicense, and/or sell copies of the Software, and to
+//   permit persons to whom the Software is furnished to do so, subject to the following
+//   conditions:
+//
+//   The above copyright notice and this permission notice shall be included in all copies
+//   or substantial portions of the Software.
+//
+//   THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED,
+//   INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A
+//   PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT
+//   HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF
+//   CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE
+//   OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+//
+// Why score rather than filter: the ranking IS the component. A palette that lists
+// "Group Policy" above "Groups" for "gp" feels like a palette; one that filters by
+// `includes` does not. The searchable `select` still filters by substring, which is right
+// there — it narrows a list the caller already ordered.
+
+const SCORE_CONTINUE_MATCH = 1
+// A new match at the start of a word scores better than a new match elsewhere.
+const SCORE_SPACE_WORD_JUMP = 0.9
+const SCORE_NON_SPACE_WORD_JUMP = 0.8
+// Any other match isn't ideal, but we include it for completeness.
+const SCORE_CHARACTER_JUMP = 0.17
+// If the user transposed two letters, it should be significantly penalized.
+const SCORE_TRANSPOSITION = 0.1
+// The goodness of a match should decay slightly with each missing character.
+const PENALTY_SKIPPED = 0.999
+// An exact-case match is worth slightly more than a case-insensitive one.
+const PENALTY_CASE_MISMATCH = 0.9999
+// Match higher for letters closer to the beginning of the word.
+const PENALTY_NOT_COMPLETE = 0.99
+
+const IS_GAP_REGEXP = /[\\/_+.#"@[({&]/
+const COUNT_GAPS_REGEXP = /[\\/_+.#"@[({&]/g
+const IS_SPACE_REGEXP = /[\s-]/
+const COUNT_SPACE_REGEXP = /[\s-]/g
+
+function commandScoreInner(string, abbreviation, lowerString, lowerAbbreviation, stringIndex, abbreviationIndex, memoisedResults) {
+  if (abbreviationIndex === abbreviation.length) {
+    return stringIndex === string.length ? SCORE_CONTINUE_MATCH : PENALTY_NOT_COMPLETE
+  }
+
+  const memoiseKey = `${stringIndex},${abbreviationIndex}`
+  if (memoisedResults[memoiseKey] !== undefined) return memoisedResults[memoiseKey]
+
+  const abbreviationChar = lowerAbbreviation.charAt(abbreviationIndex)
+  let index = lowerString.indexOf(abbreviationChar, stringIndex)
+  let highScore = 0
+  let score, transposedScore, wordBreaks, spaceBreaks
+
+  while (index >= 0) {
+    score = commandScoreInner(string, abbreviation, lowerString, lowerAbbreviation, index + 1, abbreviationIndex + 1, memoisedResults)
+
+    if (score > highScore) {
+      if (index === stringIndex) {
+        score *= SCORE_CONTINUE_MATCH
+      } else if (IS_GAP_REGEXP.test(string.charAt(index - 1))) {
+        score *= SCORE_NON_SPACE_WORD_JUMP
+        wordBreaks = string.slice(stringIndex, index - 1).match(COUNT_GAPS_REGEXP)
+        if (wordBreaks && stringIndex > 0) score *= Math.pow(PENALTY_SKIPPED, wordBreaks.length)
+      } else if (IS_SPACE_REGEXP.test(string.charAt(index - 1))) {
+        score *= SCORE_SPACE_WORD_JUMP
+        spaceBreaks = string.slice(stringIndex, index - 1).match(COUNT_SPACE_REGEXP)
+        if (spaceBreaks && stringIndex > 0) score *= Math.pow(PENALTY_SKIPPED, spaceBreaks.length)
+      } else {
+        score *= SCORE_CHARACTER_JUMP
+        if (stringIndex > 0) score *= Math.pow(PENALTY_SKIPPED, index - stringIndex)
+      }
+
+      if (string.charAt(index) !== abbreviation.charAt(abbreviationIndex)) score *= PENALTY_CASE_MISMATCH
+    }
+
+    if (
+      (score < SCORE_TRANSPOSITION &&
+        lowerString.charAt(index - 1) === lowerAbbreviation.charAt(abbreviationIndex + 1)) ||
+      (lowerAbbreviation.charAt(abbreviationIndex + 1) === lowerAbbreviation.charAt(abbreviationIndex) &&
+        lowerString.charAt(index - 1) !== lowerAbbreviation.charAt(abbreviationIndex))
+    ) {
+      transposedScore = commandScoreInner(string, abbreviation, lowerString, lowerAbbreviation, index + 1, abbreviationIndex + 2, memoisedResults)
+
+      if (transposedScore * SCORE_TRANSPOSITION > score) {
+        score = transposedScore * SCORE_TRANSPOSITION
+      }
+    }
+
+    if (score > highScore) highScore = score
+
+    index = lowerString.indexOf(abbreviationChar, index + 1)
+  }
+
+  memoisedResults[memoiseKey] = highScore
+
+  return highScore
+}
+
+function formatInput(string) {
+  // Convert all valid space characters to space so they match each other.
+  return string.toLowerCase().replace(COUNT_SPACE_REGEXP, " ")
+}
+
+// `keywords` are searched and never shown, which is how "Preferences" is found
+// by typing "settings".
+export function commandScore(string, abbreviation, aliases) {
+  const searchable = aliases && aliases.length ? `${string} ${aliases.join(" ")}` : string
+
+  return commandScoreInner(
+    searchable,
+    abbreviation,
+    formatInput(searchable),
+    formatInput(abbreviation),
+    0,
+    0,
+    {}
+  )
+}

--- a/lib/generators/modelrails_ui/components.rb
+++ b/lib/generators/modelrails_ui/components.rb
@@ -27,6 +27,10 @@ module ModelrailsUi
       # Every entry is enforced by test/test_shared_js_modules.rb — an unregistered `.js`
       # in a template dir would be silently dropped by the generator.
       TOP_LAYER = {source: "dropdown_menu/top_layer.js", dir: "overlays"}.freeze
+      # Vendored third-party (cmdk's command-score, MIT — see the file header). Its own
+      # namespace rather than `overlays`: it is a scoring utility, not an overlay concern,
+      # and a host reading its importmap should be able to tell what it is.
+      COMMAND_SCORE = {source: "command/command_score.js", dir: "search"}.freeze
 
       SHARED_JS = {
         "dropdown_menu" => [TOP_LAYER],
@@ -38,7 +42,8 @@ module ModelrailsUi
         "date_picker" => [TOP_LAYER],
         "timepicker" => [TOP_LAYER],
         "navigation_menu" => [TOP_LAYER],
-        "mega_menu" => [TOP_LAYER]
+        "mega_menu" => [TOP_LAYER],
+        "command" => [COMMAND_SCORE]
       }.freeze
 
       # Post-install instructions for components that require external dependencies.

--- a/lib/generators/modelrails_ui/lookbook/templates/previews/ui/command_component_preview.rb
+++ b/lib/generators/modelrails_ui/lookbook/templates/previews/ui/command_component_preview.rb
@@ -40,5 +40,10 @@ module UI
     # The wide (`lg`) panel — same contract, more room for long item labels.
     def large
     end
+
+    # Fuzzy ranking: subsequence matching with cmdk's scorer, plus
+    # `data-command-keywords` so an item is findable by a synonym it does not display.
+    def fuzzy_ranking
+    end
   end
 end

--- a/lib/generators/modelrails_ui/lookbook/templates/previews/ui/command_component_preview/fuzzy_ranking.html.erb
+++ b/lib/generators/modelrails_ui/lookbook/templates/previews/ui/command_component_preview/fuzzy_ranking.html.erb
@@ -1,0 +1,20 @@
+<%# Items chosen to discriminate fuzzy matching from substring: "nd" appears as a
+    substring in none of them, but subsequence-matches "New document". "Group Policy"
+    and "Groups" separate ranking from mere matching — a palette that lists them in the
+    wrong order for "gp" feels wrong even though both match. %>
+<%= ui :command do |cmd| %>
+  <% cmd.with_trigger { ui :button, "⌘K", variant: :outline, tone: :neutral } %>
+
+  <div class="<%= UI::CommandComponent::GROUP_WRAPPER %>" data-command-group>
+    <p class="<%= UI::CommandComponent::GROUP %>">Pages</p>
+    <button type="button" class="<%= UI::CommandComponent::ITEM %>" data-command-value="Groups">Groups</button>
+    <button type="button" class="<%= UI::CommandComponent::ITEM %>" data-command-value="Group Policy">Group Policy</button>
+    <button type="button" class="<%= UI::CommandComponent::ITEM %>"
+            data-command-value="Settings" data-command-keywords="preferences configuration">Settings</button>
+  </div>
+
+  <div class="<%= UI::CommandComponent::GROUP_WRAPPER %>" data-command-group>
+    <p class="<%= UI::CommandComponent::GROUP %>">Actions</p>
+    <button type="button" class="<%= UI::CommandComponent::ITEM %>" data-command-value="New document">New document</button>
+  </div>
+<% end %>

--- a/test/system/command_system_test.rb
+++ b/test/system/command_system_test.rb
@@ -1,0 +1,67 @@
+# frozen_string_literal: true
+
+require "system_test_helper"
+load_component "command", "command_component.rb.tt"
+
+# Also an end-to-end check of the `search` shared-module namespace: the controller imports
+# `search/command_score` by bare specifier, so if SHARED_JS did not register it the import
+# would fail here exactly as it would in a fork.
+BrowserHarness.scenario("command/fuzzy", controllers: %w[command], modules: %w[search/command_score]) do
+  view = ActionController::Base.new.view_context
+  item = ->(value, keywords = nil) do
+    attrs = {type: "button", class: UI::CommandComponent::ITEM, data: {command_value: value}}
+    attrs[:data][:command_keywords] = keywords if keywords
+    view.tag.button(value, **attrs)
+  end
+  UI::CommandComponent.new.render_in(view) do |c|
+    c.with_trigger { "Open" }
+    view.tag.div(
+      view.safe_join([item.call("Groups"), item.call("Group Policy"),
+        item.call("Settings", "preferences configuration"), item.call("New document")]),
+      class: UI::CommandComponent::GROUP_WRAPPER, data: {command_group: true}
+    )
+  end
+end
+
+# Ranking only exists at runtime — the render lane sees the authored order and nothing else.
+class CommandSystemTest < BrowserTestCase
+  def setup
+    super
+    visit_scenario("command/fuzzy")
+    # The trigger slot renders inside a span carrying the open action, not a button.
+    find("[data-action='click->command#open']").click
+    find("[data-command-target=input]")
+  end
+
+  def search(query) = find("[data-command-target=input]").set(query)
+  def visible_items = page.all("[data-command-value]:not([hidden])").map(&:text)
+
+  def test_matches_a_subsequence_that_is_not_a_substring
+    search("nd")
+
+    assert_equal ["New document"], visible_items
+  end
+
+  # The control: proves the case above genuinely needs fuzzy matching.
+  def test_the_query_is_not_a_substring_of_the_item
+    refute_includes "new document", "nd"
+  end
+
+  def test_ranks_the_better_match_first
+    search("gp")
+
+    assert_equal "Group Policy", visible_items.first
+  end
+
+  def test_finds_an_item_by_a_keyword_it_does_not_display
+    search("configuration")
+
+    assert_equal ["Settings"], visible_items
+  end
+
+  def test_the_scorer_module_actually_loaded
+    search("nd")
+
+    assert_no_stimulus_errors
+  end
+end

--- a/test/test_stimulus_key_filters.rb
+++ b/test/test_stimulus_key_filters.rb
@@ -1,0 +1,33 @@
+# frozen_string_literal: true
+
+require "test_helper"
+
+# Stimulus resolves keyboard filters against a fixed vocabulary and THROWS on anything
+# else — "contains unknown key filter: escape" — which kills the whole action. Nothing but
+# a browser sees it: the markup looks right, the render lane passes, and the documented
+# behaviour simply never runs.
+#
+# `command` shipped `keydown.escape` while every other floating component used
+# `keydown.esc`, so Escape never closed the command palette in any fork.
+class TestStimulusKeyFilters < Minitest::Test
+  TEMPLATES = File.expand_path("../lib/generators/modelrails_ui/add/templates", __dir__)
+
+  # Stimulus's built-in aliases (see @hotwired/stimulus KeyboardEvent filters).
+  KNOWN = %w[enter tab esc space up down left right home end page_up page_down].freeze
+
+  def test_every_keydown_filter_is_one_stimulus_recognises
+    offenders = Dir.glob("#{TEMPLATES}/**/*").select { |f| File.file?(f) }.flat_map do |path|
+      File.read(path).scan(/keydown\.([a-z_]+)/).flatten
+        .reject { |f| KNOWN.include?(f) }
+        .map { |f| "#{File.basename(path)}: keydown.#{f}" }
+    end
+
+    assert_empty offenders.uniq, <<~MSG
+      Stimulus throws on an unrecognised key filter, so the action never runs:
+
+        #{offenders.uniq.join("\n  ")}
+
+      Recognised: #{KNOWN.join(", ")}. Note `esc`, not `escape`.
+    MSG
+  end
+end


### PR DESCRIPTION
Back-ports modelrails_base #710 (A7) — and the port uncovered a live bug.

## Escape has never closed the command palette

The component used `keydown.escape`. That is **not in Stimulus's key-filter vocabulary** — Stimulus throws `contains unknown key filter: escape` and the action never runs. Every other floating component here already used `keydown.esc`; base fixed this under its own #463 and it was never back-ported.

Only a browser could see it. The markup reads correctly, and both the structural and render lanes pass. `test_stimulus_key_filters.rb` now pins every `keydown.*` filter to a filter Stimulus recognises.

That's the third bug the browser lane has found since it landed, and the second that had been shipping to forks silently.

## A7 itself

Substring-only filtering that preserved source order → cmdk's scorer, ranking within each group. `data-command-keywords` finds an item by a synonym it doesn't display ("configuration" → Settings).

**Licence:** the full MIT notice (Paco Coursey, revision `dd2250ed`) is in the file header rather than a sibling `LICENSE`. This is a fork-and-own template; a licence in a directory a fork might not copy is a licence that doesn't travel.

**Group order is deliberately untouched.** I built group reordering and removed it — group order is authored intent, and moving groups between keystrokes shifts the palette's shape under the reader.

**Namespace:** registered in `SHARED_JS` under `search`, not `overlays`. It's a scoring utility, and a host reading its importmap should be able to tell what it is.

## Testing

The browser test doubles as an end-to-end check of the new `search` namespace: the controller imports `search/command_score` by bare specifier, so an unregistered module would fail exactly as in a fork.

The scenario discriminates deliberately — `nd` is not a substring of any item but subsequence-matches "New document" — with an explicit control asserting that, so the fuzzy test can't pass by accident.

All lanes green — 537 structural + 948 render + 43 system, RuboCop clean across 228 files.