### PR TITLE
feat(drawer): drag-to-dismiss, and stacked dialogs were never broken

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- Drawer drag-to-dismiss. The component already rendered a grab handle that ignored the pointer. Drag starts from the handle only (dragging from the body would mean telling a drag from a scroll on every pointerdown, and getting that wrong breaks scrolling inside the drawer); the dismiss threshold is a fraction of the panel's own height rather than a fixed distance, because a bottom-anchored drawer has only its own height of travel below the handle. Drag is an addition — Escape and the close button are untouched, and the handle stays `aria-hidden` and unfocusable rather than advertising a control keyboard users cannot operate. (A8)
+
+### Fixed
+
+- `modal` warned "Stacked modals are not supported" and then called `showModal()` anyway. The browser has always supported it: a second `showModal()` puts that dialog above the first in the top layer, moves the focus trap, and gives it Escape. The warning is gone and browser tests hold the behaviour it was wrong about.
+
+### Added
+
 - Command palette fuzzy ranking. The filter was substring-only and preserved source order; it now scores with cmdk's scorer (vendored, MIT — full notice in the file header) and ranks matches within each group. `data-command-keywords` lets an item be found by a synonym it does not display. Group order is left alone deliberately: it is authored intent, and reordering groups between keystrokes moves the palette's shape under the reader. (A7)
 
 ### Fixed

--- a/lib/generators/modelrails_ui/add/templates/dialog/modal_controller.js
+++ b/lib/generators/modelrails_ui/add/templates/dialog/modal_controller.js
@@ -42,13 +42,11 @@ export default class extends Controller {
     }
   }
 
+  // Stacking is supported and needs no help: a second showModal() puts that dialog above
+  // this one in the top layer, moves the focus trap, and gives it Escape. This used to
+  // warn that stacked modals were unsupported and then stack them anyway.
   open() {
     if (this.dialogTarget.open) return
-
-    const openDialogs = document.querySelectorAll("dialog[open]")
-    if (openDialogs.length > 0) {
-      console.warn("Modal: another dialog is already open. Stacked modals are not supported.")
-    }
 
     this.previouslyFocused = document.activeElement
     this.dialogTarget.showModal()

--- a/lib/generators/modelrails_ui/add/templates/drawer/drawer_component.rb.tt
+++ b/lib/generators/modelrails_ui/add/templates/drawer/drawer_component.rb.tt
@@ -73,13 +73,13 @@ module UI
         modal_leave_transform_value: "translateY(100%)"
       }
       data[:modal_open_value] = "true" if @open
-      { data: data, class: cn("inline", @extra_class) }.merge(@html_attrs)
+      {data: data, class: cn("inline", @extra_class)}.merge(@html_attrs)
     end
 
     def trigger_area
       return unless trigger?
 
-      content_tag(:span, trigger, class: "contents", data: { action: "click->modal#open" })
+      content_tag(:span, trigger, class: "contents", data: {action: "click->modal#open"})
     end
 
     def dialog_tag
@@ -92,7 +92,14 @@ module UI
         role: "dialog",
         "aria-modal": "true",
         "aria-labelledby": "#{@id}-title",
-        data: { modal_target: "dialog" },
+        data: {
+          modal_target: "dialog",
+          controller: "drawer-drag",
+          action: "drawer-drag:dismiss->modal#close " \
+                  "pointermove@document->drawer-drag#move " \
+                  "pointerup@document->drawer-drag#end " \
+                  "pointercancel@document->drawer-drag#end"
+        },
         class: "bg-transparent backdrop:bg-transparent m-0 mt-auto w-full max-w-full p-0"
       }
       attrs["aria-describedby"] = "#{@id}-description" if @description
@@ -101,14 +108,18 @@ module UI
 
     def panel
       content_tag(:div, safe_join([drag_handle, header, body, footer_area].compact),
-        data: { modal_target: "panel" },
+        data: {modal_target: "panel", drawer_drag_target: "panel"},
         class: PANEL)
     end
 
+    # aria-hidden and not focusable: dragging is pointer-only, so announcing a control
+    # that keyboard and switch users cannot operate would promise something untrue. They
+    # dismiss with Escape or the close button, which drag never replaces.
     def drag_handle
       content_tag(:div, content_tag(:div, nil, class: "h-1.5 w-12 rounded-full bg-surface-sunken"),
-        class: "flex justify-center pt-3 pb-1",
-        "aria-hidden": "true")
+        class: "flex justify-center pt-3 pb-1 cursor-grab touch-none active:cursor-grabbing",
+        "aria-hidden": "true",
+        data: {action: "pointerdown->drawer-drag#start"})
     end
 
     def header
@@ -124,7 +135,7 @@ module UI
       content_tag(:button, close_icon,
         type: "button",
         "aria-label": close_label,
-        data: { action: "click->modal#close" },
+        data: {action: "click->modal#close"},
         class: "btn-touch-target rounded-md -m-2 hover:bg-surface-sunken text-text-muted hover:text-text-body focus-ring")
     end
 

--- a/lib/generators/modelrails_ui/add/templates/drawer/drawer_drag_controller.js
+++ b/lib/generators/modelrails_ui/add/templates/drawer/drawer_drag_controller.js
@@ -1,0 +1,83 @@
+import { Controller } from "@hotwired/stimulus"
+
+// Drag-to-dismiss for the drawer. The component already rendered a grab handle; without
+// this it was an affordance that promised draggability and ignored the pointer.
+//
+// SCOPE: the drag starts from the HANDLE only, never the body. Dragging from anywhere in
+// the panel means distinguishing a drag from a scroll on every pointerdown, and getting
+// that wrong breaks scrolling inside the drawer — a worse failure than not having drag.
+// The handle is also the only part a user is invited to grab.
+//
+// Drag is an ADDITION. Escape and the close button are untouched: this is pointer-only,
+// so it is unavailable to keyboard and switch users by nature and can never be the sole
+// way out.
+export default class extends Controller {
+  static targets = ["panel"]
+  static values = {
+    // A FRACTION of the panel's own height, not a fixed pixel distance. A short drawer
+    // sits close to the bottom of the screen, so there is only its own height of travel
+    // available — a fixed 120px threshold is literally unreachable on one, and the drawer
+    // would refuse to dismiss no matter how far the user dragged.
+    fraction: { type: Number, default: 0.25 },
+    // Below this the gesture reads as a nudge rather than intent, however short the panel.
+    minimum: { type: Number, default: 48 },
+    // A flick dismisses regardless of distance: px per ms.
+    velocity: { type: Number, default: 0.5 }
+  }
+
+  // The panel's open position is an inline transform set by `modal` when it animates in.
+  // Dragging writes to the same property, so the rest position has to be restored rather
+  // than cleared — clearing it drops the panel back to the class-level `translate-y-full`
+  // and the drawer vanishes while still open.
+  static OPEN_TRANSFORM = "translateY(0)"
+
+  start(event) {
+    if (!this.hasPanelTarget) return
+
+    this.dragging = true
+    this.startY = event.clientY
+    this.startedAt = event.timeStamp
+    this.offset = 0
+    this.panelTarget.style.transition = "none"
+  }
+
+  // Bound at document level, not on the handle: once a drag starts the pointer routinely
+  // leaves the handle, and listeners scoped to it stop receiving moves mid-gesture.
+  move(event) {
+    if (!this.dragging) return
+
+    // Downward only. Dragging up would lift the drawer off its own edge.
+    this.offset = Math.max(0, event.clientY - this.startY)
+    this.panelTarget.style.transform = `translate3d(0, ${this.offset}px, 0)`
+  }
+
+  end(event) {
+    if (!this.dragging) return
+    this.dragging = false
+    this.panelTarget.style.transition = ""
+
+    // The pointerup position, not the last pointermove: browsers coalesce moves under
+    // load, and a fast flick is exactly when they drop the most — so the last move can
+    // report a fraction of the distance the user actually travelled.
+    const travelled = Math.max(0, event.clientY - this.startY)
+    const elapsed = event.timeStamp - this.startedAt
+    const velocity = elapsed > 0 ? travelled / elapsed : 0
+
+    const threshold = Math.max(this.minimumValue, this.panelTarget.offsetHeight * this.fractionValue)
+
+    if (travelled >= threshold || velocity >= this.velocityValue) {
+      // Hand off to the modal controller rather than closing the dialog directly, so the
+      // exit animation and focus restoration still run.
+      this.dispatch("dismiss")
+    } else {
+      this.#springBack()
+    }
+  }
+
+  // Leave no inline transform behind: the panel's open/closed position is the
+  // component's business, and a stale transform would fight it on the next open.
+  #springBack() {
+    this.panelTarget.style.transform = this.constructor.OPEN_TRANSFORM
+    this.offset = 0
+  }
+}

--- a/test/system/dialog_system_test.rb
+++ b/test/system/dialog_system_test.rb
@@ -1,0 +1,68 @@
+# frozen_string_literal: true
+
+require "system_test_helper"
+require "securerandom"
+load_component "dialog", "dialog_component.rb.tt"
+
+# Two dialogs, the second opened from inside the first — the ordinary reason to stack.
+BrowserHarness.scenario("dialog/stacked", controllers: %w[modal]) do
+  view = ActionController::Base.new.view_context
+  inner = UI::DialogComponent.new(title: "Discard changes?").render_in(view) do |c|
+    c.with_trigger { "Discard" }
+    view.tag.p("The confirm sits above the form it was opened from.")
+  end
+  UI::DialogComponent.new(title: "Edit project").render_in(view) do |c|
+    c.with_trigger { "Open form" }
+    inner
+  end
+end
+
+# `modal_controller` warned "Stacked modals are not supported" and then called showModal()
+# anyway. The browser has always supported it; these hold the behaviour the warning was
+# wrong about. None of it is visible to the render lane.
+class DialogSystemTest < BrowserTestCase
+  def setup
+    super
+    visit_scenario("dialog/stacked")
+    # Trigger slots render inside a span carrying the open action, not a button. The
+    # inner trigger is scoped to the dialog so it is not confused with the outer one.
+    find("[data-action='click->modal#open']", match: :first).click
+    find("dialog[open]") # blocks until it opens; not an assertion in a lifecycle hook
+    within("dialog[open]") { find("[data-action='click->modal#open']").click }
+  end
+
+  def open_dialogs = page.all("dialog[open]", visible: :all).length
+
+  def test_the_second_dialog_opens_above_the_first
+    assert_equal 2, open_dialogs
+  end
+
+  def test_focus_moves_into_the_topmost_dialog
+    inner = page.evaluate_script(<<~JS)
+      (() => {
+        const dialogs = [...document.querySelectorAll("dialog[open]")];
+        const top = dialogs[dialogs.length - 1];
+        return top.contains(document.activeElement);
+      })()
+    JS
+
+    assert inner
+  end
+
+  def test_escape_closes_only_the_topmost
+    press(:Escape)
+
+    assert_selector "dialog[open]", count: 1, visible: :all
+  end
+
+  def test_a_second_escape_closes_the_one_beneath
+    press(:Escape)
+
+    assert_selector "dialog[open]", count: 1, visible: :all
+
+    press(:Escape)
+
+    assert_no_selector "dialog[open]", visible: :all
+    assert_no_stimulus_errors
+  end
+end

--- a/test/system/drawer_system_test.rb
+++ b/test/system/drawer_system_test.rb
@@ -1,0 +1,86 @@
+# frozen_string_literal: true
+
+require "system_test_helper"
+require "securerandom"
+load_component "drawer", "drawer_component.rb.tt"
+
+BrowserHarness.scenario("drawer/basic", controllers: %w[modal drawer-drag]) do
+  view = ActionController::Base.new.view_context
+  UI::DrawerComponent.new(title: "More options", description: "Pick one.").render_in(view) do |c|
+    c.with_trigger { "Open drawer" }
+    view.tag.p("Body content.")
+  end
+end
+
+# Drag-to-dismiss only exists at runtime, and only in response to real pointer input —
+# the render lane sees a handle and cannot tell whether it does anything.
+#
+# NOTE: this harness serves no compiled CSS, so the drawer is UA-styled rather than
+# bottom-anchored. That is fine for the gesture logic under test (thresholds derive from
+# the panel's own measured height), but anything depending on the drawer's real position
+# belongs in modelrails_base. See docs/testing.md.
+class DrawerSystemTest < BrowserTestCase
+  def setup
+    super
+    visit_scenario("drawer/basic")
+    find("[data-action='click->modal#open']").click
+    find("dialog[open]") # blocks until it opens; not an assertion in a lifecycle hook
+    settle
+  end
+
+  # The drawer animates in; measuring the handle mid-animation gives a position the
+  # pointer never lands on, so the press hits whatever has slid into that spot.
+  def settle
+    Timeout.timeout(5) do
+      loop do
+        first = handle_box["y"]
+        sleep 0.05
+        break if (handle_box["y"] - first).abs < 0.5
+      end
+    end
+  end
+
+  def handle_box
+    JSON.parse(page.evaluate_script(
+      %{JSON.stringify(document.querySelector("[data-action*='drawer-drag#start']").getBoundingClientRect().toJSON())}
+    ))
+  end
+
+  def drag(by:)
+    box = handle_box
+    x = (box["x"] + box["width"] / 2).round
+    y = (box["y"] + box["height"] / 2).round
+    mouse = page.driver.browser.mouse
+    mouse.move(x: x, y: y).down
+    mouse.move(x: x, y: y + by, steps: 8) if by.positive?
+    mouse.up
+  end
+
+  def test_dragging_past_the_threshold_dismisses
+    drag(by: 200)
+
+    assert_no_selector "dialog[open]"
+  end
+
+  def test_a_small_drag_springs_back
+    drag(by: 6)
+
+    assert_selector "dialog[open]"
+  end
+
+  # The control: without it, "dragging dismisses" could be passing because any pointer
+  # interaction closes the drawer.
+  def test_press_and_release_without_moving_keeps_it_open
+    drag(by: 0)
+
+    assert_selector "dialog[open]"
+    assert_no_stimulus_errors
+  end
+
+  # Drag is an addition, never the only way out — it is pointer-only by nature.
+  def test_escape_still_closes_it
+    press(:Escape)
+
+    assert_no_selector "dialog[open]"
+  end
+end


### PR DESCRIPTION
Back-ports modelrails_base #711 (A8).

## The stacked-modal warning was false

`modal` warned *"Stacked modals are not supported"* and then called `showModal()` anyway. Verified before touching it — two dialogs open, no exception, the second takes the top layer, the focus trap **and** Escape. Warning removed; a browser test now holds the behaviour it was wrong about.

## Drawer drag-to-dismiss

The component already rendered a grab handle that **ignored the pointer**. Three decisions carried over from base:

**Handle only, not the panel body** — dragging from the body means telling a drag from a scroll on every `pointerdown`, and breaking scroll *inside* the drawer is worse than having no drag.

**Threshold is a fraction of panel height** — a fixed 120px is physically unreachable on a short bottom-anchored drawer, which has only its own height of travel below the handle.

**`pointerup` position is authoritative** — browsers coalesce `pointermove` and drop the most during a fast flick, exactly when the user is most clearly asking to dismiss.

Drag is an **addition**: Escape and the close button are untouched, and the handle stays `aria-hidden` and unfocusable rather than advertising a control keyboard and switch users cannot operate. Both are asserted.

## Browser coverage, with its limit stated

8 new system tests. The drawer ones note what this harness cannot speak to: with no compiled CSS the drawer is UA-styled rather than bottom-anchored. That's fine for gesture logic whose thresholds derive from the panel's own measured height, but anything depending on the drawer's real position belongs in base — the same boundary `docs/testing.md` draws for contrast and top-layer promotion.

Both suites also wait for the open animation to settle before measuring the handle: `dialog[open]` is true while the panel is still moving, so measuring early gives a position the pointer never lands on.

All lanes green — 537 structural + 948 render + 51 system, RuboCop clean across 230 files.