### PR TITLE
feat(sidebar): collapse state assistive tech can see and navigation can't lose (A5)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- Sidebar: the collapsed rail now explains its icons. Items show a hint bubble on hover or focus, `aria-hidden` by construction — the item's label is clipped to width 0 but stays in the accessibility tree, so the link already has its name and announcing the bubble too would name every item twice. It is `fixed` + anchor-positioned because the nav is `overflow-y-auto`, which makes its overflow-x non-visible as well and would clip an `absolute` bubble at the rail edge. (A5)
+
+- Sidebar: `remember:` (default `true`) persists the collapse choice to a `sidebar_collapsed` cookie. A cookie rather than localStorage so the server can render the rail in the remembered shape on the first paint instead of painting it expanded and collapsing after; the component doc comment carries the one-line host helper. (A5)
+
 - Drawer drag-to-dismiss. The component already rendered a grab handle that ignored the pointer. Drag starts from the handle only (dragging from the body would mean telling a drag from a scroll on every pointerdown, and getting that wrong breaks scrolling inside the drawer); the dismiss threshold is a fraction of the panel's own height rather than a fixed distance, because a bottom-anchored drawer has only its own height of travel below the handle. Drag is an addition — Escape and the close button are untouched, and the handle stays `aria-hidden` and unfocusable rather than advertising a control keyboard users cannot operate. (A8)
 
 - Command palette fuzzy ranking. The filter was substring-only and preserved source order; it now scores with cmdk's scorer (vendored, MIT — full notice in the file header) and ranks matches within each group. `data-command-keywords` lets an item be found by a synonym it does not display. Group order is left alone deliberately: it is authored intent, and reordering groups between keystrokes moves the palette's shape under the reader. (A7)
@@ -42,6 +46,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - The shipped stylesheet no longer carries app-specific CSS: Markdowndocs prose styles, the Rouge syntax theme, workspace-branding overrides, Biscuit cookie-banner theming, and the development-only a11y-simulation filters. **1155 → 677 lines (−41%).** No component template referenced any of it. A fork using Markdowndocs or Biscuit now owns that styling — `modelrails_base` already does, in its own `_prose.css` and `_syntax.css`.
 
 ### Fixed
+
+- Sidebar: the toggle exposed no state to assistive technology. Collapse lived entirely in `data-collapsed`, which drives the CSS and is invisible to a screen reader — the button announced no state before, none after, and no indication anything had happened (WCAG 4.1.2). It now carries `aria-expanded` and `aria-controls` pointing at the nav it collapses, kept in step by the controller. (A5)
+
+- Sidebar: a caller-supplied `id:` stopped reaching the root `<aside>` once `id:` became a named argument for the nav wiring. It is rendered on the root again, and derives the nav's id.
 
 - `modal` warned "Stacked modals are not supported" and then called `showModal()` anyway. The browser has always supported it: a second `showModal()` puts that dialog above the first in the top layer, moves the focus trap, and gives it Escape. The warning is gone and browser tests hold the behaviour it was wrong about.
 

--- a/docs/testing.md
+++ b/docs/testing.md
@@ -27,8 +27,9 @@ browser lane exists.
 ### The browser lane cannot see anything that needs compiled CSS
 
 The harness serves the components and their JavaScript, **but no stylesheet**. The gem
-ships CSS as Tailwind source, which needs a build step the harness does not run. Two
-things therefore cannot be proven here:
+ships CSS as Tailwind source, which needs a build step the harness does not run. Nothing
+whose behaviour is decided by a stylesheet can be proven here. Three cases have come up
+so far; treat them as examples of the rule, not as the whole list:
 
 **1. Colour contrast.** `assert_axe_clean` disables the `color-contrast` rule. Against
 unstyled defaults axe would report on the browser's own colours, so a green result would
@@ -43,9 +44,18 @@ declines to promote, and `:popover-open` is never true here.
 That is the guard working, not a harness bug. Do **not** inject a style to make it fire:
 the assertion would then prove the injected style rather than the component.
 
-Both are proven in **`modelrails_base`**, which generates the components into a real app
-with compiled Tailwind. Anything asserting a computed colour, a stacking context, or
-promotion belongs in that repo's `spec/system/ui/`.
+**3. Escaping a clip.** The sidebar's collapsed-rail hint is `fixed` + anchor-positioned
+precisely so it escapes the nav's `overflow-y-auto` clip. Unstyled it computes to
+`static` and never moves, so its geometry here would prove nothing.
+
+Note also that geometry alone is the wrong assertion for a clip even where CSS *is*
+available: `getBoundingClientRect` reports the unclipped box either way, so such a test
+passes just as happily on the broken version. Assert the computed `position` — the
+mechanism that does the escaping.
+
+All three are proven in **`modelrails_base`**, which generates the components into a real
+app with compiled Tailwind. If an assertion would read a computed style — a colour, a
+position, a stacking context, a size — it belongs in that repo's `spec/system/ui/`.
 
 ## Writing a browser test
 

--- a/lib/generators/modelrails_ui/add/templates/sidebar/sidebar_component.rb.tt
+++ b/lib/generators/modelrails_ui/add/templates/sidebar/sidebar_component.rb.tt
@@ -28,12 +28,34 @@ module UI
                   "transition-opacity group-data-[collapsed=true]:opacity-0 group-data-[collapsed=true]:h-0 " \
                   "group-data-[collapsed=true]:overflow-hidden group-data-[collapsed=true]:mb-0"
 
-    ITEM_CLS = "flex min-h-11 items-center gap-3 rounded-md px-3 py-2 text-sm font-medium transition-colors " \
+    ITEM_CLS = "group/item flex min-h-11 items-center gap-3 rounded-md px-3 py-2 text-sm font-medium transition-colors " \
                "overflow-hidden " \
                "group-data-[collapsed=true]:justify-center group-data-[collapsed=true]:gap-0 " \
                "hover:bg-surface-sunken hover:text-text-heading " \
                "aria-[current]:bg-surface-sunken aria-[current]:text-text-heading aria-[current]:font-semibold " \
                "focus-ring"
+
+    # The collapsed rail's icon hint. Only a visual affordance: the item's label is clipped
+    # to width 0 but stays in the accessibility tree, so the link already has its name —
+    # announcing this too would name every item twice. Hence aria-hidden.
+    #
+    # It must be `fixed` on the modern path: the nav is `overflow-y-auto`, which makes its
+    # overflow-x non-visible too, so an `absolute` bubble is clipped at the 64px rail edge.
+    # Anchor positioning tethers the fixed bubble back to its item. Pre-Baseline browsers
+    # take the `absolute` fallback and lose the hint to that clip — the accessible name is
+    # unaffected, so this degrades a nicety, not the semantics.
+    RAIL_TOOLTIP = "pointer-events-none z-50 w-max max-w-48 rounded-md px-2 py-1 " \
+                   "bg-text-heading text-surface-raised text-xs whitespace-nowrap " \
+                   "opacity-0 transition-opacity duration-150 " \
+                   "group-hover/item:opacity-100 group-focus-within/item:opacity-100 " \
+                   "hidden group-data-[collapsed=true]:block " \
+                   "ml-2 supports-[position-area:bottom]:fixed " \
+                   "supports-[position-area:bottom]:[position-area:center_right] " \
+                   "supports-[position-area:bottom]:[position-try-fallbacks:flip-inline] " \
+                   "not-supports-[position-area:bottom]:absolute " \
+                   "not-supports-[position-area:bottom]:left-full " \
+                   "not-supports-[position-area:bottom]:top-1/2 " \
+                   "not-supports-[position-area:bottom]:-translate-y-1/2"
 
     ITEM_LABEL = "transition-[opacity,width] group-data-[collapsed=true]:w-0 " \
                  "group-data-[collapsed=true]:opacity-0 group-data-[collapsed=true]:overflow-hidden " \
@@ -45,9 +67,22 @@ module UI
     # brand:     text shown in the header
     # collapsed: initial collapsed state (default: false)
     # label:     accessible name for the <nav> landmark (default: i18n "Sidebar")
-    def initialize(brand: nil, collapsed: false, label: nil, **html_attrs)
+    # brand:     text shown in the header
+    # collapsed: initial collapsed state. To honour the visitor's remembered choice on
+    #            the first paint (rather than painting expanded and collapsing after),
+    #            read the cookie the toggle writes:
+    #
+    #              # app/helpers/application_helper.rb
+    #              def sidebar_collapsed? = cookies[:sidebar_collapsed] == "true"
+    #
+    #            then `ui :sidebar, collapsed: sidebar_collapsed?`.
+    # remember:  persist the choice to a cookie the server can read back (default true)
+    # label:     accessible name for the <nav> landmark
+    def initialize(brand: nil, collapsed: false, remember: true, label: nil, id: nil, **html_attrs)
       @brand       = brand
       @collapsed   = collapsed
+      @remember    = remember
+      @id          = id || "sidebar-#{SecureRandom.hex(4)}"
       @label       = label
       @extra_class = html_attrs.delete(:class)
       @html_attrs  = html_attrs
@@ -55,9 +90,10 @@ module UI
 
     def call
       content_tag(:aside,
+        id: @id,
         class: cn(RAIL_CLS, @extra_class),
         "data-collapsed": @collapsed.to_s,
-        data: { controller: "sidebar" },
+        data: { controller: "sidebar", sidebar_remember_value: @remember.to_s },
         **@html_attrs) do
         concat header
         concat nav_body
@@ -78,17 +114,21 @@ module UI
       content_tag(:button, type: "button",
         class: TOGGLE_CLS,
         "aria-label": I18n.t("modelrails_ui.sidebar.toggle", default: "Toggle sidebar"),
-        data: { action: "click->sidebar#toggle" }) { chevron_icon }
+        "aria-expanded": (!@collapsed).to_s,
+        "aria-controls": nav_id,
+        data: { sidebar_target: "toggle", action: "click->sidebar#toggle" }) { chevron_icon }
     end
 
     def nav_body
-      content_tag(:nav, class: NAV_CLS,
+      content_tag(:nav, id: nav_id, class: NAV_CLS,
         "aria-label": @label || I18n.t("modelrails_ui.sidebar.nav_label", default: "Sidebar")) do
         concat safe_join(groups) if groups.any?
         concat content_tag(:div, safe_join(items), class: "space-y-0.5") if items.any?
         concat content if content?
       end
     end
+
+    def nav_id = "#{@id}-nav"
 
     def chevron_icon
       content_tag(:svg,
@@ -128,10 +168,11 @@ module UI
         mail:        "M4 4h16c1.1 0 2 .9 2 2v12c0 1.1-.9 2-2 2H4c-1.1 0-2-.9-2-2V6c0-1.1.9-2 2-2z M22 6l-10 7L2 6",
         bell:        "M18 8A6 6 0 0 0 6 8c0 7-3 9-3 9h18s-3-2-3-9 M13.73 21a2 2 0 0 1-3.46 0",
         credit_card: "M1 4h22v16H1z M1 10h22",
-        logout:      "M9 21H5a2 2 0 0 1-2-2V5a2 2 0 0 1 2-2h4 M16 17l5-5-5-5 M21 12H9",
+        logout:      "M9 21H5a2 2 0 0 1-2-2V5a2 2 0 0 1 2-2h4 M16 17l5-5-5-5 M21 12H9"
       }.freeze
 
       def initialize(label:, href: "#", active: false, icon: nil, **html_attrs)
+        @anchor     = "--sb-item-#{SecureRandom.hex(4)}"
         @label      = label
         @href       = href
         @active     = active
@@ -143,14 +184,24 @@ module UI
         content_tag(:a,
           href: @href,
           class: SidebarComponent::ITEM_CLS,
+          style: "anchor-name: #{@anchor}",
           "aria-current": (@active ? "page" : nil),
           **@html_attrs) do
           concat icon_or_fallback
           concat content_tag(:span, @label, class: SidebarComponent::ITEM_LABEL)
+          concat rail_tooltip
         end
       end
 
       private
+
+      def rail_tooltip
+        content_tag(:span, @label,
+          class: SidebarComponent::RAIL_TOOLTIP,
+          style: "position-anchor: #{@anchor}",
+          data: { slot: "rail-tooltip" },
+          "aria-hidden": "true")
+      end
 
       def icon_or_fallback
         path = @icon && ICONS[@icon.to_sym]

--- a/lib/generators/modelrails_ui/add/templates/sidebar/sidebar_controller.js
+++ b/lib/generators/modelrails_ui/add/templates/sidebar/sidebar_controller.js
@@ -1,11 +1,37 @@
 import { Controller } from "@hotwired/stimulus"
 
+// Collapse state lives in three places, and all three have to move together:
+// data-collapsed drives the CSS, aria-expanded is the only one assistive tech can see,
+// and the cookie is the only one that survives navigation.
 export default class extends Controller {
+  static targets = [ "toggle" ]
+  static values = { remember: { type: Boolean, default: true } }
+
+  // A year, matching the theme preference. Lax so it rides same-site navigation.
+  static COOKIE = "sidebar_collapsed"
+  static MAX_AGE = 31536000
+
   toggle() {
-    const collapsed = this.element.dataset.collapsed === "true"
-    this.element.dataset.collapsed = String(!collapsed)
+    this.collapsed = !this.collapsed
   }
 
-  open()  { this.element.dataset.collapsed = "false" }
-  close() { this.element.dataset.collapsed = "true"  }
+  open()  { this.collapsed = false }
+  close() { this.collapsed = true  }
+
+  get collapsed() {
+    return this.element.dataset.collapsed === "true"
+  }
+
+  set collapsed(value) {
+    this.element.dataset.collapsed = String(value)
+
+    if (this.hasToggleTarget) {
+      this.toggleTarget.setAttribute("aria-expanded", String(!value))
+    }
+
+    if (this.rememberValue) {
+      document.cookie =
+        `${this.constructor.COOKIE}=${value};path=/;max-age=${this.constructor.MAX_AGE};SameSite=Lax`
+    }
+  }
 }

--- a/test/render/sidebar_render_test.rb
+++ b/test/render/sidebar_render_test.rb
@@ -75,6 +75,56 @@ class SidebarRenderTest < ViewComponent::TestCase
     assert_selector "nav a[href='/']", text: "Dashboard"
   end
 
+  # data-collapsed drives the CSS and is invisible to assistive tech; aria-expanded is
+  # the only representation of collapse state a screen reader can perceive.
+  def test_toggle_reports_expanded_state
+    render_basic
+
+    assert_selector "button[aria-label='Toggle sidebar'][aria-expanded='true']"
+  end
+
+  def test_toggle_reports_collapsed_state
+    render_basic(collapsed: true)
+
+    assert_selector "button[aria-label='Toggle sidebar'][aria-expanded='false']"
+  end
+
+  # aria-controls has to resolve to a real element, or it names nothing.
+  def test_toggle_controls_the_nav_it_collapses
+    render_basic(id: "app-sidebar")
+
+    assert_selector "button[aria-controls='app-sidebar-nav']"
+    assert_selector "nav#app-sidebar-nav"
+  end
+
+  # The rail hint is decorative BY CONSTRUCTION: the item's label is clipped to width 0
+  # but stays in the a11y tree, so the link already has its name. Announcing the bubble
+  # too would name every item twice.
+  def test_rail_hint_is_hidden_from_assistive_technology
+    render_basic
+
+    assert_selector "nav a [data-slot='rail-tooltip'][aria-hidden='true']", visible: :all, count: 2
+  end
+
+  # The bubble is anchor-positioned, so each item's anchor-name must be unique or every
+  # hint tethers to the same item.
+  def test_each_item_anchors_its_own_hint
+    render_basic
+    anchors = page.all("nav a", visible: :all).map { |a| a[:style] }
+
+    assert_equal 2, anchors.uniq.size
+  end
+
+  def test_persistence_is_on_by_default_and_opt_outable
+    render_basic
+
+    assert_selector "aside[data-sidebar-remember-value='true']"
+
+    render_basic(remember: false)
+
+    assert_selector "aside[data-sidebar-remember-value='false']"
+  end
+
   # html_attrs pass through onto the root <aside>.
   def test_passes_through_html_attrs_onto_the_root
     render_inline(UI::SidebarComponent.new(id: "app-sidebar", data: {testid: "sb"})) do |s|

--- a/test/system/sidebar_system_test.rb
+++ b/test/system/sidebar_system_test.rb
@@ -1,0 +1,81 @@
+# frozen_string_literal: true
+
+require "system_test_helper"
+load_component "sidebar", "sidebar_component.rb.tt"
+
+# What the controller keeps in sync once it runs. Collapse state has three
+# representations — data-collapsed for the CSS, aria-expanded for assistive tech, a
+# cookie for the next page — and the bug this guards against is any one of them drifting.
+#
+# ── NOT PROVEN HERE ──────────────────────────────────────────────────────────────────
+# The collapsed rail's hint bubble is CSS-only: `fixed` + anchor positioning is what
+# lets it escape the nav's overflow-y-auto clip, and this harness serves no compiled
+# stylesheet, so the bubble computes to `static` and never moves. Asserting its geometry
+# here would prove nothing. It is proven in modelrails_base against real CSS:
+# spec/system/ui/sidebar_behaviours_spec.rb. See docs/testing.md.
+%w[default collapsed unremembered].each do |name|
+  BrowserHarness.scenario("sidebar/#{name}", controllers: %w[sidebar]) do
+    view = ActionController::Base.new.view_context
+    UI::SidebarComponent.new(
+      brand: "Acme", collapsed: name == "collapsed", remember: name != "unremembered"
+    ).render_in(view) do |s|
+      s.with_item(label: "Dashboard", href: "#", icon: :home, active: true)
+      s.with_item(label: "Tasks", href: "#", icon: :tasks)
+      nil
+    end
+  end
+end
+
+class SidebarSystemTest < BrowserTestCase
+  COOKIE = "sidebar_collapsed"
+
+  def toggle = find("aside button[aria-controls]")
+
+  def cookie = page.driver.browser.cookies.all[COOKIE]&.value
+
+  def test_reports_expanded_before_the_first_toggle
+    visit_scenario("sidebar/default")
+
+    assert_equal "true", toggle["aria-expanded"]
+  end
+
+  def test_toggling_moves_aria_expanded_with_the_css_state
+    visit_scenario("sidebar/default")
+    toggle.click
+
+    assert_equal "false", toggle["aria-expanded"]
+    assert_selector "aside[data-collapsed='true']"
+    assert_no_stimulus_errors
+  end
+
+  # The two representations must not drift in either direction.
+  def test_toggling_back_restores_both
+    visit_scenario("sidebar/collapsed")
+
+    assert_equal "false", toggle["aria-expanded"]
+
+    toggle.click
+
+    assert_equal "true", toggle["aria-expanded"]
+    assert_selector "aside[data-collapsed='false']"
+  end
+
+  def test_the_choice_is_recorded_for_the_next_page
+    visit_scenario("sidebar/default")
+    toggle.click
+
+    assert_equal "true", cookie
+
+    toggle.click
+
+    assert_equal "false", cookie
+  end
+
+  def test_remember_false_leaves_no_cookie
+    visit_scenario("sidebar/unremembered")
+    toggle.click
+
+    assert_selector "aside[data-collapsed='true']"
+    assert_nil cookie
+  end
+end


### PR DESCRIPTION
Ports the A5 sidebar work from `modelrails_base` ([#712](https://github.com/dschmura/modelrails_base/pull/712)), where the CSS-dependent half is proven against compiled Tailwind.

## The toggle announced no state

Collapse lived entirely in `data-collapsed` — which drives the CSS and is invisible to assistive technology. There was no `aria-expanded` anywhere in the component, so a screen-reader user pressing "Toggle sidebar" got a button with no state before, no state after, and no indication anything had happened. WCAG 4.1.2.

The toggle now carries `aria-expanded` and `aria-controls` pointing at the `<nav>` it collapses. One setter in the controller owns all three representations of the state, so they cannot drift:

```js
set collapsed(value) {
  this.element.dataset.collapsed = String(value)
  if (this.hasToggleTarget) this.toggleTarget.setAttribute("aria-expanded", String(!value))
  if (this.rememberValue) document.cookie = `sidebar_collapsed=${value};…`
}
```

## The collapsed rail didn't explain its icons

At 64px the labels clip to nothing, leaving an unlabelled icon column. Items now show a hint bubble on hover or focus.

It is **`aria-hidden` by construction**. The clipped label is `w-0 opacity-0`, which keeps it in the accessibility tree — the link already has its accessible name, so announcing the bubble too would name every item twice.

It also has to be `fixed`, not `absolute`: the nav is `overflow-y-auto`, and a non-visible overflow on one axis makes the other non-visible too, so an absolutely-positioned bubble is clipped at the rail edge. Anchor positioning tethers the fixed bubble back to its item. Pre-Baseline browsers take the `absolute` fallback and lose the hint to that clip — the accessible name is unaffected, so what degrades is a nicety.

`UI::TooltipComponent` was not reusable here; its own docs rule it out — *"Don't use when you wrap an already-interactive control."* A sidebar item is an `<a>`, so wrapping would add a second tab stop per item.

## The choice didn't survive navigation

`remember:` (default `true`) writes a `sidebar_collapsed` cookie. A cookie rather than localStorage so a host can paint the remembered shape **first** rather than painting expanded and collapsing after — avoiding that flash is the entire reason. The component's doc comment carries the one-line host helper, since a fresh fork has no such helper:

```ruby
def sidebar_collapsed? = cookies[:sidebar_collapsed] == "true"
```

## A regression this port surfaced

Capturing `id:` as a named argument for the nav wiring took it out of `**html_attrs` — so `ui :sidebar, id: "app-sidebar"` silently stopped rendering that id on the root `<aside>`. The render suite caught it here; `modelrails_base`'s specs never named a sidebar, so nothing there could see it. Fixed in both repos, and base gained the component spec that closes the gap.

## Lane split

Divided by what each lane can honestly prove:

| lane | takes |
|---|---|
| render | the markup contract — `aria-expanded` initial value, `aria-controls` resolving to a real nav, bubble `aria-hidden`, per-item anchor uniqueness, `remember:` wiring |
| browser | what the controller keeps in sync once it runs — `aria-expanded` tracking `data-collapsed`, the cookie, `remember: false` |
| `modelrails_base` | the bubble's positioning, which is CSS-decided |

The bubble's `fixed` positioning joins colour contrast and top-layer promotion as things this harness structurally cannot prove. `docs/testing.md` now states that as a **rule with three examples** rather than a closed list of two — the previous wording ("a computed colour, a stacking context, or promotion") wouldn't have covered this case, and the next one won't be on the list either.

It also records a trap worth keeping: **geometry is the wrong assertion for a clip even where CSS is available.** `getBoundingClientRect` reports the *unclipped* box either way, so a geometry-only test passes just as happily on the broken version. Assert the computed `position` — the mechanism that does the escaping.

## Verification

Positive controls — each behaviour broken on purpose, confirming the matching tests fail:

| broken on purpose | failures |
|---|---|
| never update `aria-expanded` | 2 |
| suppress the cookie write | 1 |
| ignore `remember:` | 1 |
| give every item the same `anchor-name` | 1 |

Full CI green: **534 structural, 954 render, 56 system**, RuboCop clean across 229 files.

## Scope and non-coverage

- No mobile Sheet. The handoff proposed one; `modelrails_base` already answers mobile with a `md:hidden`, zero-JS section-nav strip, and shipping a Sheet would put a second contradictory pattern in the template. Worth deciding deliberately rather than by default — say the word if you want the component to carry its own mobile story.
- The cookie's consent classification follows the host app's existing `theme` precedent (user-initiated UI choice treated as necessary). The gem takes no position; a fork with a stricter consent model can pass `remember: false`.
