### PR TITLE
fix(generator): form_field template's doc-comment ERB tags crashed add — pin .rb.tt renderability

### DIFF
--- a/lib/generators/modelrails_ui/add/templates/form_field/form_field_component.rb.tt
+++ b/lib/generators/modelrails_ui/add/templates/form_field/form_field_component.rb.tt
@@ -9,10 +9,10 @@ module UI
   # the control. The control arrives as a block, so the component yields its field
   # context (`input_attrs`) and the caller spreads it onto any control:
   #
-  #   <%= ui :form_field, label: "Email", hint: "We'll never share it.",
+  #   <%%= ui :form_field, label: "Email", hint: "We'll never share it.",
   #         error: @user.errors[:email].first, required: true do |f| %>
-  #     <%= ui :input, type: "email", name: "user[email]", **f.input_attrs %>
-  #   <% end %>
+  #     <%%= ui :input, type: "email", name: "user[email]", **f.input_attrs %>
+  #   <%% end %>
   #
   # ## Use when
   # - You're composing a single labelled field by hand (a one-off form, or a control

--- a/test/test_template_erb_renderability.rb
+++ b/test/test_template_erb_renderability.rb
@@ -1,0 +1,28 @@
+# frozen_string_literal: true
+
+require "test_helper"
+require "erb"
+
+# Every .rb.tt template is rendered through ERB by Thor's `template` action at
+# install time — so a literal ERB tag anywhere in the file, INCLUDING inside a
+# Ruby doc comment's usage example, is evaluated as template code and crashes
+# `rails g modelrails_ui:add <name>` for the host. The gem's own render lane
+# never catches this class: `load_component` evals templates as plain Ruby,
+# where comments stay comments. This gate takes the same ERB path Thor does.
+# Doc-comment examples must use the doubled form (`<%%=` / `<%%`), which
+# renders back to a literal tag in the installed file.
+class TestTemplateErbRenderability < Minitest::Test
+  TEMPLATES = File.expand_path("../lib/generators/modelrails_ui/add/templates", __dir__)
+
+  def test_every_rb_tt_template_renders_through_erb_without_error
+    offenders = Dir.glob("#{TEMPLATES}/*/*.rb.tt").sort.filter_map do |path|
+      ERB.new(File.read(path), trim_mode: "-").result(binding)
+      nil
+    rescue Exception => e # rubocop:disable Lint/RescueException -- SyntaxError is not a StandardError
+      "#{path.delete_prefix("#{TEMPLATES}/")}: #{e.class}: #{e.message.lines.first&.strip}"
+    end
+
+    assert_empty offenders,
+      "templates that crash Thor's ERB render at install time:\n  #{offenders.join("\n  ")}"
+  end
+end


### PR DESCRIPTION
Found while executing B1 PR 2: `rails g modelrails_ui:add form_builder` crashed with a SyntaxError because form_field's class-header usage example contains literal ERB tags, and Thor renders every `.rb.tt` through ERB at install time. The render lane never sees this defect class — `load_component` evals templates as plain Ruby, where comments stay comments.

- Doc example now uses the doubled `<%%=` form (installs as a literal tag).
- New structural gate `test_template_erb_renderability.rb` renders EVERY `.rb.tt` through ERB exactly as Thor does — the gate proved form_field was the only offender.

Note: this was first pushed to the just-merged `feat/b1-form-builder` branch by accident (recreating it post-merge); that branch has been deleted again and this PR carries the same commit cherry-picked onto current main. Full suite green (546/1011/56, rubocop clean).