### PR TITLE
fix(test): pin calendar test's clock and zone; restore rails-8.0 to CI

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -42,11 +42,8 @@ jobs:
       fail-fast: false
       matrix:
         appraisal:
+          - rails-8.0
           - rails-8.1
-          # rails-8.0 (the new floor, see gemspec) is defined in Appraisals for
-          # local use but not wired into CI: calendar_render_test's travel_to(Date)
-          # trips a pre-existing, host-timezone-dependent activesupport to_time
-          # behavior difference on 8.0 — unrelated to this branch, needs its own fix.
 
     steps:
       - uses: actions/checkout@v6

--- a/test/render/calendar_render_test.rb
+++ b/test/render/calendar_render_test.rb
@@ -16,6 +16,15 @@ class CalendarRenderTest < ViewComponent::TestCase
   # Monday; the 15th is a Monday in the second visible week.
   JUNE = Date.new(2026, 6, 15)
 
+  # `travel_to` a bare Date (or an ActiveSupport::TimeWithZone) round-trips
+  # through Date#to_time / TimeWithZone#to_time, which on Rails <8.1 collapses
+  # back to the HOST's system-local offset (time_helpers.rb: `now.getlocal`).
+  # West of UTC that lands "today" on the day BEFORE JUNE — see #117. Passing
+  # an already-local ::Time (Time.local, not Date/TimeWithZone) skips that
+  # conversion entirely: `getlocal` is a no-op on a Time already in the host's
+  # local zone, so this is same-day regardless of Rails version or host TZ.
+  JUNE_NOON = Time.local(JUNE.year, JUNE.month, JUNE.day, 12)
+
   def render_default(**opts)
     render_inline(UI::CalendarComponent.new(month: JUNE, **opts))
   end
@@ -59,7 +68,7 @@ class CalendarRenderTest < ViewComponent::TestCase
   # `text-text-on-interactive` and put heading text on the bg-interactive fill —
   # a dark-mode contrast failure the app's preview-host axe spec caught.
   def test_today_when_also_selected_keeps_on_interactive_text
-    travel_to(JUNE) do # JUNE is today, so today == the selected day
+    travel_to(JUNE_NOON) do # JUNE is today, so today == the selected day
       render_inline(UI::CalendarComponent.new(month: JUNE, selected: JUNE))
     end
 
@@ -92,10 +101,11 @@ class CalendarRenderTest < ViewComponent::TestCase
   end
 
   def test_today_carries_aria_current_date
-    travel_month = Date.today
-    render_inline(UI::CalendarComponent.new(month: travel_month))
+    travel_to(JUNE_NOON) do
+      render_inline(UI::CalendarComponent.new(month: JUNE))
+    end
 
-    assert_selector "button[aria-current='date']", text: travel_month.day.to_s
+    assert_selector "button[aria-current='date']", text: JUNE.day.to_s
   end
 
   # No selection + a month that is not the current month ⇒ no aria-current/aria-selected.


### PR DESCRIPTION
## Mechanism

`calendar_render_test.rb` used `travel_to(JUNE)` where `JUNE` is a bare `Date`.
On Rails <8.1, ActiveSupport's `travel_to` converts a `Date` argument via
`date_or_time.midnight.to_time`, then unconditionally calls `now.getlocal`
(`time_helpers.rb`) before stubbing `Date.today`. That round-trip re-expresses
the UTC-anchored midnight in the **host's system-local timezone** — for any
host west of UTC (negative offset), midnight UTC on June 15 lands on June 14
local, shifting the stubbed "today" back a day. `Date.today` then disagrees
with the `selected: JUNE` the test passed, so the "today == selected" case
under test never actually happens, and the button gets the plain "today, not
selected" class list instead of the interactive-fill classes the test asserts.

Rails 8.1 changes `to_time`'s default to preserve the receiver's timezone
instead of converting to system-local, which is why this only reproduces on
the rails-8.0 appraisal — and only when the box running the suite isn't UTC
(explaining why it looked like a flake rather than a hard failure).

## Fix

Replaced the bare-`Date` `travel_to(JUNE)` with `travel_to(JUNE_NOON)`, where
`JUNE_NOON = Time.local(JUNE.year, JUNE.month, JUNE.day, 12)` — an
already-local `::Time`. `travel_to`'s `Date`/`TimeWithZone` branches (the ones
that trigger the lossy `to_time` conversion) are skipped entirely for a
`::Time` argument; the trailing `getlocal` is then a no-op since the time is
already in the host's local zone. This is deterministic across Rails versions
and host timezones by construction, not by coincidence. Also converted
`test_today_carries_aria_current_date` off a live `Date.today` call for the
same reason (it wasn't flaky, but it was silently coupled to wall-clock date).

(`Date.stub(:today, ...)` was the first thing I tried — minitest 6, which this
repo pins, dropped `Object#stub`/`Minitest::Mock`, so that path doesn't exist
here.)

## Determinism proof

`test/render/calendar_render_test.rb` alone, rails-8.0 appraisal, across TZs
spanning the full UTC offset range (including the two extremes that bracket
the bug window):

| TZ | Before fix | After fix |
|---|---|---|
| America/New_York (UTC-4) | **1 failure** | 0 failures |
| UTC | pass | pass |
| Pacific/Kiritimati (UTC+14) | pass | pass |
| Pacific/Marquesas (UTC-9:30) | — | pass |
| Asia/Tokyo (UTC+9) | — | pass |

## Full verification

- `bundle exec rake` (default Gemfile): structural 546/546, render 1011/1011,
  system 56/56, rubocop 233 files / 0 offenses — all green.
- `BUNDLE_GEMFILE=gemfiles/rails_8.0.gemfile bundle exec rake test:render`:
  1011 runs, 1546 assertions, 0 failures.
- `BUNDLE_GEMFILE=gemfiles/rails_8.1.gemfile bundle exec rake test:render`:
  1011 runs, 1546 assertions, 0 failures.

## CI

Restored `rails-8.0` to the appraisal matrix in `.github/workflows/main.yml`
and removed the comment explaining its absence.

Closes #117.