### PR TITLE
fix(form_field): stable, label-derived id fallback

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -57,6 +57,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- FormFieldComponent: the no-`id:` fallback now derives a stable id from `label` (constant `form_field` when there's none) instead of `object_id`, which changed on every render and broke Turbo morphing. (#113)
+
 - Sidebar: the toggle exposed no state to assistive technology. Collapse lived entirely in `data-collapsed`, which drives the CSS and is invisible to a screen reader — the button announced no state before, none after, and no indication anything had happened (WCAG 4.1.2). It now carries `aria-expanded` and `aria-controls` pointing at the nav it collapses, kept in step by the controller. (A5)
 
 - Sidebar: a caller-supplied `id:` stopped reaching the root `<aside>` once `id:` became a named argument for the nav wiring. It is rendered on the root again, and derives the nav's id.

--- a/lib/generators/modelrails_ui/add/templates/form_field/form_field_component.rb.tt
+++ b/lib/generators/modelrails_ui/add/templates/form_field/form_field_component.rb.tt
@@ -34,6 +34,11 @@ module UI
   #   adopts the field's id and aria wiring. Rendering a native (non-ViewComponent)
   #   control instead? Use `html_input_attrs`, which translates the same wiring into
   #   real `aria-*` attributes.
+  # - **Id fallback:** without an explicit `id:`, the id is derived from `label` (so
+  #   repeated renders of the same field agree, which Turbo morphing and HTML
+  #   snapshot tests depend on) — pass explicit ids when two fields on one page share
+  #   a label. `UI::FormBuilder` always supplies an id, so this only matters when
+  #   composing a field by hand.
   class FormFieldComponent < ApplicationComponent
     # data-slot adjacency rhythm (the Catalyst model): label→control 12px,
     # control→description 8px, description→description 4px. Self-contained Tailwind
@@ -47,12 +52,15 @@ module UI
     HINT_CLASSES = "text-sm text-text-muted"
     ERROR_CLASSES = "text-sm text-danger"
 
+    # Constant fallback when there's no explicit id and no label to derive one from.
+    FALLBACK_ID = "form_field"
+
     def initialize(label: nil, hint: nil, error: nil, required: false, **html_attrs)
       @label = label
       @hint = hint
       @error = error
       @required = required
-      @id = html_attrs.key?(:id) ? html_attrs.delete(:id) : "form_field_#{object_id}"
+      @id = html_attrs.key?(:id) ? html_attrs.delete(:id) : fallback_id
       @describedby = [("#{@id}-error" if @error.present?), ("#{@id}-hint" if @hint.present?)].compact.join(" ").presence
       @extra_class = html_attrs.delete(:class)
       @html_attrs = html_attrs
@@ -89,6 +97,17 @@ module UI
     end
 
     private
+
+    # Deterministic id fallback so a render doesn't grow a fresh DOM id every time
+    # (breaks Turbo morphing and any HTML-snapshot test). Derived from the label so
+    # two calls with the same label agree; two same-label fields on one page still
+    # need an explicit id: from the caller. UI::FormBuilder always passes one.
+    def fallback_id
+      return FALLBACK_ID if @label.blank?
+
+      slug = @label.to_s.downcase.gsub(/[^a-z0-9]+/, "_").gsub(/\A_+|_+\z/, "")
+      slug.present? ? "#{FALLBACK_ID}_#{slug}" : FALLBACK_ID
+    end
 
     # The caption, via the Label primitive: a real `for=` association + the decorative
     # aria-hidden `*` required mark. data-slot=label drives the adjacency spacing.

--- a/test/render/form_field_render_test.rb
+++ b/test/render/form_field_render_test.rb
@@ -92,4 +92,24 @@ class FormFieldRenderTest < ViewComponent::TestCase
     assert_equal "text-sm text-text-muted", UI::FormFieldComponent::HINT_CLASSES
     assert_equal "text-sm text-danger", UI::FormFieldComponent::ERROR_CLASSES
   end
+
+  def test_fallback_id_is_derived_from_the_label_and_stable_across_instances
+    first = UI::FormFieldComponent.new(label: "Email address")
+    second = UI::FormFieldComponent.new(label: "Email address")
+
+    assert_equal "form_field_email_address", first.input_attrs[:id]
+    assert_equal first.input_attrs[:id], second.input_attrs[:id]
+  end
+
+  def test_fallback_id_with_no_label_and_no_id_is_the_constant_fallback
+    c = UI::FormFieldComponent.new
+
+    assert_equal "form_field", c.input_attrs[:id]
+  end
+
+  def test_explicit_id_wins_over_the_label_derived_fallback
+    c = UI::FormFieldComponent.new(id: "custom_id", label: "Email address")
+
+    assert_equal "custom_id", c.input_attrs[:id]
+  end
 end


### PR DESCRIPTION
## Summary

- `UI::FormFieldComponent`'s no-`id:` fallback derived from `object_id`, which changes on every render — breaking Turbo morphing (the id in the DOM diverges from the id in the newly-rendered fragment) and ruling out HTML snapshot testing.
- The fallback is now derived from `label`: lowercased, non-alphanumeric runs collapsed to `_`, prefixed `form_field_` (e.g. "Email address" -> `form_field_email_address`). Two renders of the same field now agree on their id. When there's no label either, the fallback is the constant `form_field`.
- An explicit `id:` still always wins, and the existing behaviour where an explicitly-passed `id: nil` is honored (rather than falling back) is preserved — verified manually against the `html_attrs.key?(:id)` branch.
- Class doc comment now notes that two same-label fields on one page need explicit ids, and that `UI::FormBuilder` always supplies one.

## Test plan

- [x] Added failing tests first (`test/render/form_field_render_test.rb`): same-label instances share an id; label-less + id-less falls back to `form_field`; explicit id wins. First two failed against the old `object_id` behavior (`form_field_5216` / `form_field_5232`, non-deterministic per run).
- [x] `bundle exec rake test:render` — 1014 runs, 0 failures.
- [x] `bundle exec rake` (full suite incl. RuboCop) — green.

Closes #113.