### PR TITLE
fix(templates): invalid-ring width on seven templates; disabled affordance in error state

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+- Invalid-state ring now paints on all seven templates that set only its color (`aria-invalid:ring-2` added; structural gate pins the class); input/textarea keep the disabled affordance in the error state (#122).
+
 ### Added
 
 - Sidebar: the collapsed rail now explains its icons. Items show a hint bubble on hover or focus, `aria-hidden` by construction — the item's label is clipped to width 0 but stays in the accessibility tree, so the link already has its name and announcing the bubble too would name every item twice. It is `fixed` + anchor-positioned because the nav is `overflow-y-auto`, which makes its overflow-x non-visible as well and would clip an `absolute` bubble at the rail edge. (A5)

--- a/lib/generators/modelrails_ui/add/templates/badge/badge_component.rb.tt
+++ b/lib/generators/modelrails_ui/add/templates/badge/badge_component.rb.tt
@@ -44,7 +44,7 @@ module UI
            "border border-transparent px-2 py-0.5 text-xs font-medium whitespace-nowrap " \
            "transition-[color,box-shadow] " \
            "focus-ring " \
-           "aria-invalid:border-danger-border aria-invalid:ring-danger  " \
+           "aria-invalid:border-danger-border aria-invalid:ring-2 aria-invalid:ring-danger  " \
            "[&>svg]:pointer-events-none [&>svg]:size-3"
 
     # The 9 AAA-proven cells, keyed `[variant, tone]`. Signal tones use the TINTED

--- a/lib/generators/modelrails_ui/add/templates/checkbox/checkbox_component.rb.tt
+++ b/lib/generators/modelrails_ui/add/templates/checkbox/checkbox_component.rb.tt
@@ -30,7 +30,7 @@ module UI
     BASE = "peer size-4 shrink-0 rounded-[4px] border border-border-strong shadow-xs transition-shadow outline-none " \
            "focus-ring " \
            "disabled:cursor-not-allowed disabled:opacity-50 " \
-           "aria-invalid:border-danger-border aria-invalid:ring-danger  " \
+           "aria-invalid:border-danger-border aria-invalid:ring-2 aria-invalid:ring-danger  " \
            "checked:border-interactive checked:bg-interactive checked:text-text-on-interactive " \
            " "
 

--- a/lib/generators/modelrails_ui/add/templates/file_input/file_input_component.rb.tt
+++ b/lib/generators/modelrails_ui/add/templates/file_input/file_input_component.rb.tt
@@ -10,7 +10,7 @@ module UI
            "file:bg-interactive file:text-text-on-interactive hover:file:bg-interactive-hover " \
            "file:cursor-pointer file:min-h-[var(--form-input-height)] " \
            "disabled:cursor-not-allowed disabled:opacity-50 " \
-           "aria-invalid:border-danger-border aria-invalid:ring-danger"
+           "aria-invalid:border-danger-border aria-invalid:ring-2 aria-invalid:ring-danger"
 
     # Per-file pill for the show_selection list: the badge chip shape plus the
     # proven [:soft, :primary] color cell (bg-interactive-subtle + text-interactive

--- a/lib/generators/modelrails_ui/add/templates/floating_label/floating_label_component.rb.tt
+++ b/lib/generators/modelrails_ui/add/templates/floating_label/floating_label_component.rb.tt
@@ -9,7 +9,7 @@ module UI
     INPUT_BASE = "peer h-12 w-full min-w-0 rounded-md border border-border-strong bg-transparent px-3 pb-1.5 pt-4 " \
                  "text-base shadow-xs transition-[color,box-shadow] outline-none placeholder:text-transparent " \
                  "focus-ring " \
-                 "aria-invalid:border-danger-border aria-invalid:ring-danger  " \
+                 "aria-invalid:border-danger-border aria-invalid:ring-2 aria-invalid:ring-danger  " \
                  "disabled:pointer-events-none disabled:cursor-not-allowed disabled:opacity-50 " \
                  "md:text-sm "
 

--- a/lib/generators/modelrails_ui/add/templates/input/input_component.rb.tt
+++ b/lib/generators/modelrails_ui/add/templates/input/input_component.rb.tt
@@ -5,9 +5,9 @@ module UI
     # Styling matches the form builder's (`UI::FormBuilder`) field rendering exactly,
     # so `f.text_field`/`f.email_field`/etc. and this component render identically.
     BASE   = "block w-full rounded-md border px-3 py-2 placeholder:text-text-muted " \
+             "disabled:cursor-not-allowed disabled:opacity-50 " \
              "focus-ring min-h-[var(--form-input-height)]"
-    NORMAL = "border-border-strong bg-surface-raised text-text-heading " \
-             "disabled:cursor-not-allowed disabled:opacity-50"
+    NORMAL = "border-border-strong bg-surface-raised text-text-heading"
     ERROR  = "border-danger ring-2 ring-danger bg-danger-surface text-danger"
 
     # First-class accessibility/form params so the component is usable standalone

--- a/lib/generators/modelrails_ui/add/templates/number_input/number_input_component.rb.tt
+++ b/lib/generators/modelrails_ui/add/templates/number_input/number_input_component.rb.tt
@@ -44,7 +44,7 @@ module UI
            "transition-[color,box-shadow] outline-none " \
            "placeholder:text-text-muted " \
            "focus-visible:border-border-focus focus-ring " \
-           "aria-invalid:border-danger-border aria-invalid:ring-danger " \
+           "aria-invalid:border-danger-border aria-invalid:ring-2 aria-invalid:ring-danger " \
            "disabled:pointer-events-none disabled:cursor-not-allowed disabled:opacity-50 " \
            "[appearance:textfield] [&::-webkit-inner-spin-button]:appearance-none [&::-webkit-outer-spin-button]:appearance-none " \
            "md:text-sm"

--- a/lib/generators/modelrails_ui/add/templates/search_input/search_input_component.rb.tt
+++ b/lib/generators/modelrails_ui/add/templates/search_input/search_input_component.rb.tt
@@ -40,7 +40,7 @@ module UI
                  "transition-[color,box-shadow] outline-none " \
                  "placeholder:text-text-muted " \
                  "focus-visible:border-border-focus focus-ring " \
-                 "aria-invalid:border-danger-border aria-invalid:ring-danger " \
+                 "aria-invalid:border-danger-border aria-invalid:ring-2 aria-invalid:ring-danger " \
                  "disabled:pointer-events-none disabled:cursor-not-allowed disabled:opacity-50 " \
                  "md:text-sm "
 

--- a/lib/generators/modelrails_ui/add/templates/textarea/textarea_component.rb.tt
+++ b/lib/generators/modelrails_ui/add/templates/textarea/textarea_component.rb.tt
@@ -5,9 +5,9 @@ module UI
     # Styling matches the form builder's (`UI::FormBuilder`) field rendering (shared
     # with UI::InputComponent) so `f.text_area` delegates to it invisibly.
     BASE   = "block w-full rounded-md border px-3 py-2 placeholder:text-text-muted " \
+             "disabled:cursor-not-allowed disabled:opacity-50 " \
              "focus-ring min-h-[var(--form-input-height)]"
-    NORMAL = "border-border-strong bg-surface-raised text-text-heading " \
-             "disabled:cursor-not-allowed disabled:opacity-50"
+    NORMAL = "border-border-strong bg-surface-raised text-text-heading"
     ERROR  = "border-danger ring-2 ring-danger bg-danger-surface text-danger"
 
     # value:       textarea body (builder-driven); falls back to block content for standalone use

--- a/lib/generators/modelrails_ui/add/templates/toggle/toggle_component.rb.tt
+++ b/lib/generators/modelrails_ui/add/templates/toggle/toggle_component.rb.tt
@@ -34,7 +34,7 @@ module UI
            "data-[state=off]:hover:bg-surface-sunken data-[state=off]:hover:text-text-body " \
            "focus-ring " \
            "disabled:pointer-events-none disabled:opacity-50 " \
-           "aria-invalid:border-danger-border aria-invalid:ring-danger  " \
+           "aria-invalid:border-danger-border aria-invalid:ring-2 aria-invalid:ring-danger  " \
            "data-[state=on]:bg-interactive-subtle data-[state=on]:text-interactive " \
            "[&_svg]:pointer-events-none [&_svg]:shrink-0 [&_svg:not([class*='size-'])]:size-4"
 

--- a/test/render/file_input_render_test.rb
+++ b/test/render/file_input_render_test.rb
@@ -203,4 +203,12 @@ class FileInputRenderTest < ViewComponent::TestCase
 
     assert_selector "div[data-controller='file-input'] input.block.w-full.text-text-body"
   end
+
+  def test_invalid_ring_has_a_width_not_just_a_color
+    render_inline(UI::FileInputComponent.new(invalid: true))
+
+    # aria-invalid:ring-danger without aria-invalid:ring-2 paints nothing —
+    # a ring colour needs a ring width (gem issue #122, same class as #112).
+    assert_selector "input[class*='aria-invalid:ring-2'][class*='aria-invalid:ring-danger']"
+  end
 end

--- a/test/render/input_render_test.rb
+++ b/test/render/input_render_test.rb
@@ -85,4 +85,12 @@ class InputRenderTest < ViewComponent::TestCase
 
     assert_no_selector "input[aria-describedby]"
   end
+
+  def test_invalid_state_keeps_the_disabled_affordance
+    render_inline(UI::InputComponent.new(invalid: true, disabled: true))
+
+    # disabled: utilities live in BASE so the affordance survives every state —
+    # an invalid+disabled control must not render opaque with a default cursor (#122).
+    assert_selector "input[class*='disabled:cursor-not-allowed'][class*='disabled:opacity-50']"
+  end
 end

--- a/test/render/textarea_render_test.rb
+++ b/test/render/textarea_render_test.rb
@@ -84,4 +84,11 @@ class TextareaRenderTest < ViewComponent::TestCase
 
     assert_no_selector "textarea[aria-describedby]"
   end
+
+  def test_invalid_state_keeps_the_disabled_affordance
+    render_inline(UI::TextareaComponent.new(invalid: true, disabled: true))
+
+    # disabled: utilities live in BASE so the affordance survives every state (#122).
+    assert_selector "textarea[class*='disabled:cursor-not-allowed'][class*='disabled:opacity-50']"
+  end
 end

--- a/test/test_invalid_ring_width.rb
+++ b/test/test_invalid_ring_width.rb
@@ -1,0 +1,25 @@
+# frozen_string_literal: true
+
+require "test_helper"
+
+# A ring color with no ring width paints nothing: `aria-invalid:ring-danger`
+# alone is inert, and the invalid state silently loses its ring cue (issue
+# #112 fixed this for select; #122 found the same gap shipped in seven more
+# templates). This gate pins the class: every template string that sets the
+# invalid ring COLOR must set an invalid ring WIDTH in the same file.
+class TestInvalidRingWidth < Minitest::Test
+  TEMPLATES = File.expand_path("../lib/generators/modelrails_ui/add/templates", __dir__)
+
+  def test_every_invalid_ring_color_has_an_invalid_ring_width
+    offenders = Dir.glob("#{TEMPLATES}/*/*.rb.tt").sort.filter_map do |path|
+      src = File.read(path)
+      next unless src.include?("aria-invalid:ring-danger")
+      next if src.match?(/aria-invalid:ring-\d/)
+
+      path.delete_prefix("#{TEMPLATES}/")
+    end
+
+    assert_empty offenders,
+      "templates with an invalid ring color but no ring width (inert ring):\n  #{offenders.join("\n  ")}"
+  end
+end


### PR DESCRIPTION
Implements #122 — and the widen grep proved the class was seven templates wide, not one: badge, checkbox, file_input, floating_label, number_input, search_input, and toggle all set the invalid ring color with no width (inert ring). Range's `ring-1` is a deliberate width; select was fixed in #112.

- All seven gain `aria-invalid:ring-2`, and a new structural gate (`test_invalid_ring_width.rb`) pins the class permanently: any template with an invalid ring color but no width fails the suite.
- input/textarea move their `disabled:` utilities from NORMAL into BASE — an invalid+disabled control keeps the disabled affordance. Positive-controlled: the render test fails against the pre-fix template.

Full suite green (547 structural / 1017 render / 56 system, rubocop clean). Base picks these up at its next regeneration.

Closes #122.