### PR TITLE
fix(i18n): migrate legacy keys to the modelrails_ui namespace with fallback

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -56,6 +56,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - The shipped stylesheet no longer carries app-specific CSS: Markdowndocs prose styles, the Rouge syntax theme, workspace-branding overrides, Biscuit cookie-banner theming, and the development-only a11y-simulation filters. **1155 → 677 lines (−41%).** No component template referenced any of it. A fork using Markdowndocs or Biscuit now owns that styling — `modelrails_base` already does, in its own `_prose.css` and `_syntax.css`.
 
 ### Fixed
+- Legacy I18n keys (`ui.toaster.*`, `ui.resizable.*`, `modals.close`) migrated to the `modelrails_ui.*` namespace; old keys keep working as fallbacks for hosts that translated them (#116).
 
 - FormFieldComponent: the no-`id:` fallback now derives a stable id from `label` (constant `form_field` when there's none) instead of `object_id`, which changed on every render and broke Turbo morphing. (#113)
 

--- a/lib/generators/modelrails_ui/add/templates/alert_dialog/alert_dialog_component.rb.tt
+++ b/lib/generators/modelrails_ui/add/templates/alert_dialog/alert_dialog_component.rb.tt
@@ -136,7 +136,7 @@ module UI
     end
 
     def close_label
-      I18n.t("modals.close", default: "Close")
+      I18n.t("modelrails_ui.modal.close", default: [ :"modals.close", "Close" ])
     end
 
     def close_icon

--- a/lib/generators/modelrails_ui/add/templates/dialog/dialog_component.rb.tt
+++ b/lib/generators/modelrails_ui/add/templates/dialog/dialog_component.rb.tt
@@ -139,7 +139,7 @@ module UI
     end
 
     def close_label
-      I18n.t("modals.close", default: "Close")
+      I18n.t("modelrails_ui.modal.close", default: [ :"modals.close", "Close" ])
     end
 
     def close_icon

--- a/lib/generators/modelrails_ui/add/templates/drawer/drawer_component.rb.tt
+++ b/lib/generators/modelrails_ui/add/templates/drawer/drawer_component.rb.tt
@@ -157,7 +157,7 @@ module UI
     end
 
     def close_label
-      I18n.t("modals.close", default: "Close")
+      I18n.t("modelrails_ui.modal.close", default: [ :"modals.close", "Close" ])
     end
 
     def close_icon

--- a/lib/generators/modelrails_ui/add/templates/resizable/resizable_component.rb.tt
+++ b/lib/generators/modelrails_ui/add/templates/resizable/resizable_component.rb.tt
@@ -93,7 +93,7 @@ module UI
         "data-direction": @direction,
         tabindex: "0",
         role: "separator",
-        "aria-label": @aria_label || I18n.t("ui.resizable.handle", default: "Resize panels"),
+        "aria-label": @aria_label || I18n.t("modelrails_ui.resizable.handle", default: [ :"ui.resizable.handle", "Resize panels" ]),
         "aria-orientation": spec[:orientation],
         "aria-valuenow": now,
         "aria-valuemin": leading_panel.min,

--- a/lib/generators/modelrails_ui/add/templates/sheet/sheet_component.rb.tt
+++ b/lib/generators/modelrails_ui/add/templates/sheet/sheet_component.rb.tt
@@ -160,7 +160,7 @@ module UI
     end
 
     def close_label
-      I18n.t("modals.close", default: "Close")
+      I18n.t("modelrails_ui.modal.close", default: [ :"modals.close", "Close" ])
     end
 
     def close_icon

--- a/lib/generators/modelrails_ui/add/templates/toaster/toaster_component.rb.tt
+++ b/lib/generators/modelrails_ui/add/templates/toaster/toaster_component.rb.tt
@@ -89,7 +89,7 @@ module UI
 
     # t() is resolved at RENDER time (here, not in initialize — no view context there).
     def region_label
-      @region_label || I18n.t("ui.toaster.label", default: "Notifications")
+      @region_label || I18n.t("modelrails_ui.toaster.label", default: [ :"ui.toaster.label", "Notifications" ])
     end
 
     class ToastComponent < ApplicationComponent
@@ -213,7 +213,7 @@ module UI
       def close_btn
         content_tag(:button, dismiss_icon,
           type: "button",
-          "aria-label": I18n.t("ui.toaster.dismiss", default: "Dismiss"),
+          "aria-label": I18n.t("modelrails_ui.toaster.dismiss", default: [ :"ui.toaster.dismiss", "Dismiss" ]),
           class: CLOSE_CLS,
           data: { action: "click->toaster#dismiss" })
       end

--- a/lib/generators/modelrails_ui/install/templates/modelrails_ui.en.yml
+++ b/lib/generators/modelrails_ui/install/templates/modelrails_ui.en.yml
@@ -8,6 +8,13 @@
 # convention and stay put; a separate issue tracks migrating them onto it.
 en:
   modelrails_ui:
+    modal:
+      close: "Close"
+    resizable:
+      handle: "Resize panels"
+    toaster:
+      label: "Notifications"
+      dismiss: "Dismiss"
     bottom_nav:
       nav_label: "Bottom navigation"
     calendar:

--- a/test/render/dialog_render_test.rb
+++ b/test/render/dialog_render_test.rb
@@ -79,4 +79,37 @@ class DialogRenderTest < ViewComponent::TestCase
 
     assert_text "Footer actions"
   end
+
+  # Key migration (#116): templates read the namespaced key first, fall back to
+  # the legacy key a host may already translate, then to inline English.
+  def test_close_label_prefers_the_namespaced_key
+    with_translations(modelrails_ui: {modal: {close: "Shut it"}}) do
+      render_inline(UI::DialogComponent.new(title: "T")) { "body" }
+
+      assert_selector "button[aria-label='Shut it']", visible: :all
+    end
+  end
+
+  def test_close_label_falls_back_to_a_legacy_host_translation
+    with_translations(modals: {close: "Fermer"}) do
+      render_inline(UI::DialogComponent.new(title: "T")) { "body" }
+
+      assert_selector "button[aria-label='Fermer']", visible: :all
+    end
+  end
+
+  def test_close_label_defaults_to_english_with_no_translations
+    render_inline(UI::DialogComponent.new(title: "T")) { "body" }
+
+    assert_selector "button[aria-label='Close']", visible: :all
+  end
+
+  private
+
+  def with_translations(hash)
+    I18n.backend.store_translations(:en, hash)
+    yield
+  ensure
+    I18n.backend.reload!
+  end
 end


### PR DESCRIPTION
Implements #116: seven call sites across five templates (toaster ×2, resizable, and the four modal-family close labels) now read `modelrails_ui.*` first, fall back to the legacy key (`ui.toaster.*` / `ui.resizable.*` / `modals.close`) for hosts that already translated it, then to inline English — via I18n's array `default:`. The consolidated locale template gains the new keys and documents the fallback window in its header.

Chain proven by render tests: namespaced key wins; a legacy-only host keeps its copy; English renders with neither. Full suite green (546/1017/56, rubocop clean). Hosts pick the call-site changes up at their next regeneration; nothing breaks meanwhile.

Closes #116.