### PR TITLE
fix(form_builder): error_summary unlinked: opt-out + documented anchor contract

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -56,6 +56,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - The shipped stylesheet no longer carries app-specific CSS: Markdowndocs prose styles, the Rouge syntax theme, workspace-branding overrides, Biscuit cookie-banner theming, and the development-only a11y-simulation filters. **1155 → 677 lines (−41%).** No component template referenced any of it. A fork using Markdowndocs or Biscuit now owns that styling — `modelrails_base` already does, in its own `_prose.css` and `_syntax.css`.
 
 ### Fixed
+- `error_summary` gains `unlinked:` to opt attributes out of derived-id anchors (custom ids, value-suffixed checkboxes, unrendered fields); the anchor contract is documented (#121).
 
 - FormFieldComponent: the no-`id:` fallback now derives a stable id from `label` (constant `form_field` when there's none) instead of `object_id`, which changed on every render and broke Turbo morphing. (#113)
 

--- a/docs/components/form_builder.md
+++ b/docs/components/form_builder.md
@@ -146,6 +146,20 @@ surface (see `docs/components/error_summary.md` for its full accessibility
 contract). The shim adds the one thing only the builder knows: each error's
 field anchor.
 
+**Anchor contract.** Summary links are *derived* default ids (Rails'
+`field_id` — `user` + `:email` → `#user_email`); the summary renders at the
+top of the form, before the fields, so it cannot see a call site's custom
+`id:`. Three shapes therefore produce a link to nothing: a field rendered
+with a custom `id:`, a `multiple:`/custom-value checkbox (its real id carries
+the value suffix), and an errored attribute the form doesn't render. Keep
+default ids on errored fields — or opt those attributes out explicitly and
+their items render as plain text, like `:base` errors:
+
+```erb
+<%= f.error_summary unlinked: [:roles, :slug] %>
+```
+
+
 ```erb
 <%= form_with model: @article, builder: UI::FormBuilder do |f| %>
   <%= f.error_summary %>

--- a/lib/generators/modelrails_ui/add/templates/form_builder/form_builder.rb.tt
+++ b/lib/generators/modelrails_ui/add/templates/form_builder/form_builder.rb.tt
@@ -178,7 +178,7 @@ module UI
       # Caller class: REPLACES the default (never merges): "btn-primary
       # btn-secondary" would leave stylesheet order to pick the winner.
       options[:class] = options[:class].presence || "btn-primary"
-      super(value, options)
+      super
     end
 
     # One-line shim over UI::ErrorSummaryComponent — the component is the real
@@ -187,8 +187,16 @@ module UI
     def error_summary(options = {})
       return if object.nil? || object.errors.empty?
 
+      options = options.dup
+      # Anchors are DERIVED default ids (Rails' field_id) — the summary renders
+      # before the fields, so a call-site custom `id:` is unknowable here. The
+      # call site opts such attributes out with `unlinked:` and their items
+      # render as plain text, like :base errors (#121).
+      unlinked = Array(options.delete(:unlinked)).map(&:to_sym)
+
       items = object.errors.map do |error|
-        href = (error.attribute == :base) ? nil : "##{field_id(error.attribute)}"
+        skip = error.attribute == :base || unlinked.include?(error.attribute.to_sym)
+        href = skip ? nil : "##{field_id(error.attribute)}"
         {message: error.full_message, href: href}
       end
       @template.render(UI::ErrorSummaryComponent.new(items: items, **options))

--- a/test/render/form_builder_render_test.rb
+++ b/test/render/form_builder_render_test.rb
@@ -421,4 +421,25 @@ class FormBuilderRenderTest < ViewComponent::TestCase
 
     assert page.has_css?("h3")
   end
+
+  def test_error_summary_unlinked_renders_named_attributes_as_plain_items
+    article = B1Article.new
+    article.errors.add(:title, "can't be blank")
+    article.errors.add(:body, "is too short")
+    page = page_for(builder(article).error_summary(unlinked: [:title]))
+
+    # The call site knows its own custom ids / unrendered fields; unlinked:
+    # opts those attributes out of the derived-id anchors (#121).
+    assert page.has_css?("li", text: "Title can't be blank")
+    refute page.has_css?("li a[href='#b1_article_title']")
+    assert page.has_css?("li a[href='#b1_article_body']", text: "Body is too short")
+  end
+
+  def test_error_summary_unlinked_accepts_strings
+    article = B1Article.new
+    article.errors.add(:title, "can't be blank")
+    page = page_for(builder(article).error_summary(unlinked: %w[title]))
+
+    refute page.has_css?("li a")
+  end
 end


### PR DESCRIPTION
Implements #121, option C (documented contract + explicit opt-out — Dave's call, 2026-08-22).

Summary anchors are *derived* default ids (`field_id`), and the summary renders at the top of the form — before the fields — so a call site's custom `id:` is unknowable at link time. The call site, which does know, opts such attributes out: `f.error_summary unlinked: [:roles, :slug]` renders those items as plain text, exactly like `:base` errors. The docs page now states the contract and the three dead-link shapes (custom `id:`, value-suffixed checkboxes, unrendered attributes).

TDD: failing tests first (which also caught `unlinked:` leaking onto the container as a junk HTML attribute via the kwargs passthrough). Full suite green (546/1016/56, rubocop clean). Base and forks pick this up at their next regeneration; today's zero-deviation call sites are unaffected.

Closes #121.