### PR TITLE
chore: consolidate the 0.10.0 changelog

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,8 +7,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
-### Fixed
-- Invalid-state ring now paints on all seven templates that set only its color (`aria-invalid:ring-2` added; structural gate pins the class); input/textarea keep the disabled affordance in the error state (#122).
 ## [0.10.0] - 2026-08-22
 
 ### Added
@@ -60,6 +58,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - The shipped stylesheet no longer carries app-specific CSS: Markdowndocs prose styles, the Rouge syntax theme, workspace-branding overrides, Biscuit cookie-banner theming, and the development-only a11y-simulation filters. **1155 → 677 lines (−41%).** No component template referenced any of it. A fork using Markdowndocs or Biscuit now owns that styling — `modelrails_base` already does, in its own `_prose.css` and `_syntax.css`.
 
 ### Fixed
+- Invalid-state ring now paints on all seven templates that set only its color (`aria-invalid:ring-2` added; structural gate pins the class); input/textarea keep the disabled affordance in the error state (#122).
 - `error_summary` gains `unlinked:` to opt attributes out of derived-id anchors (custom ids, value-suffixed checkboxes, unrendered fields); the anchor contract is documented (#121).
 - Legacy I18n keys (`ui.toaster.*`, `ui.resizable.*`, `modals.close`) migrated to the `modelrails_ui.*` namespace; old keys keep working as fallbacks for hosts that translated them (#116).
 


### PR DESCRIPTION
The release PR (#123) merged before the three fix PRs, stranding #122's entry under Unreleased while #125/#126's landed under 0.10.0 via merge resolution. This moves the one stray entry so v0.10.0's section matches the tag content. Tag gets cut on this merge.