### PR TITLE
docs(modal): fail-loud id contract in _modal docblock, ModalChrome includer interface, dialog.md id row

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+- Docs: _modal docblock reflects the fail-loud id contract; ModalChrome documents its includer interface (panel, dialog_attrs); dialog.md documents id/body_id/wrapper.
+
 ## [0.11.0] - 2026-08-22
 
 ### Added

--- a/docs/components/dialog.md
+++ b/docs/components/dialog.md
@@ -57,9 +57,16 @@ The dialog closes automatically when the user presses `Escape`.
 | `title` | String | `nil` | Bold heading rendered inside the panel |
 | `description` | String | `nil` | Muted subtext below the title |
 | `role` | Symbol | `:dialog` | `:dialog` or `:alertdialog` — an assertive confirm gate announced immediately by screen readers, capped at `max-w-md` regardless of `size:` |
+| `id` | String | `nil` | Element id; required (or `body_id:`) when `wrapper: true` in dev/test. `modal-{random}` is minted whenever `id:` is omitted, which under `wrapper: true` produces the silent-no-op bug described below. |
+| `body_id` | String | `nil` | Turbo Stream target id for the dialog body; defaults to `"#{id}-body"`. Required (or `id:`) when `wrapper: true` in dev/test. |
+| `wrapper` | Boolean | `true` | Wraps the dialog in a `data-controller="modal"` div with a trigger slot. Set `false` to render only the `<dialog>` and own the wrapper |
 | `**html_attrs` | Hash | — | Forwarded to the outer `<div>` |
 
 | Slot | Required | Description |
 |------|----------|-------------|
 | `trigger` | No | Element that opens the dialog on click |
 | `footer` | No | Action buttons shown at the bottom of the panel |
+
+## Turbo Stream targeting
+
+When using `wrapper: true` without an explicit `id:` or `body_id:`, the component raises an `ArgumentError` in development and test environments. This fail-loud rule surfaces a silent bug: Turbo Streams aimed at a randomly-generated body id silently no-op in production, leaving the page out of sync. Always provide an explicit `id:` when using `wrapper: true`; `body_id` then derives as `"#{id}-body"`.

--- a/lib/generators/modelrails_ui/add/templates/dialog/_modal.html.erb
+++ b/lib/generators/modelrails_ui/add/templates/dialog/_modal.html.erb
@@ -8,8 +8,9 @@
   (turbo_stream.append "modal-body").
 
   Complete (pass trigger:): renders the data-controller="modal" wrapper + a trigger
-  button + the <dialog> as one copy-paste unit (wrapper: true). body_id uses the
-  component's unique default so multiple complete modals on a page don't collide.
+  button + the <dialog> as one copy-paste unit (wrapper: true). Requires an explicit
+  id: or body_id: (dev/test raise otherwise); body_id derives as "#{id}-body".
+  Uniqueness comes from callers choosing distinct ids.
 -%>
 <% if trigger.present? %>
   <%= render UI::DialogComponent.new(

--- a/lib/generators/modelrails_ui/add/templates/dialog/modal_chrome.rb.tt
+++ b/lib/generators/modelrails_ui/add/templates/dialog/modal_chrome.rb.tt
@@ -8,7 +8,8 @@ module UI
   # button, the scrollable body + description, and the footer slot. `dialog` (including
   # its `role: :alertdialog` confirm-gate mode), `sheet`, and `drawer` differ only in
   # panel shape (size classes vs. `role="alertdialog"` vs. side/offset classes) —
-  # everything else is byte-identical chrome.
+  # everything else is byte-identical chrome. Includers supply `panel` and `dialog_attrs`
+  # (called by the `dialog_tag` method).
   #
   # ## Single-writer rationale
   # Before this concern, each of the four templates hand-copied the same eleven methods.


### PR DESCRIPTION
## Summary

Three documentation edits assigned by the B3 gem branch's final review (Minors 2-4):

- `_modal.html.erb` docblock: Reworded to clarify that `wrapper: true` requires an explicit `id:` (dev/test raise otherwise) and derives `body_id` as `"#{id}-body"`. Uniqueness comes from callers choosing distinct ids, not from automatic generation.

- `modal_chrome.rb.tt` module doc header: Added a line documenting that includers supply `panel` and `dialog_attrs` (called by the `dialog_tag` method).

- `docs/components/dialog.md`: Added three API table rows (`id:`, `body_id:`, `wrapper:`) and a new "Turbo Stream targeting" section documenting the dev/test fail-loud rule — `wrapper: true` without an explicit `id:` or `body_id:` raises to surface the silent-in-production bug where Turbo Streams aimed at a random body id silently no-op.

## Motivation

Docs-only follow-up to the B3 modal-chrome base-adoption arc. No behavior changes — rides the next gem release train, at which point base's vendored copies converge on regeneration.