### PR TITLE
fix(avatar): recovery fallback span keeps the caller's hue

### DIFF
--- a/lib/generators/modelrails_ui/add/templates/avatar/avatar_component.rb.tt
+++ b/lib/generators/modelrails_ui/add/templates/avatar/avatar_component.rb.tt
@@ -65,7 +65,10 @@ module UI
     # Both nodes ship together so the swap needs no network round trip. BOTH carry the
     # accessible name: the <img> is removed on failure, so initials that were unnamed
     # would leave the avatar absent from the accessibility tree entirely. Only one is ever
-    # exposed, because `hidden` keeps the other out.
+    # exposed, because `hidden` keeps the other out. Caller @html_attrs ride the <img>
+    # only — mirroring them onto the standby span would duplicate any caller id while
+    # both nodes are in the DOM. The --hue style IS mirrored: the recovered initials
+    # must render in the caller's hue, not the default.
     def recoverable_image
       content_tag(:span, class: "contents", data: {controller: "avatar"}) do
         concat content_tag(:img, nil, **recoverable_image_attrs)
@@ -73,6 +76,7 @@ module UI
           class: cn(config[:css], config[:text],
             "rounded-full flex items-center justify-center font-semibold", color_classes, @extra_class),
           hidden: true,
+          style: (@hue ? "--hue: #{@hue}" : nil),
           **aria_attrs,
           data: {avatar_target: "fallback"})
       end

--- a/test/render/avatar_render_test.rb
+++ b/test/render/avatar_render_test.rb
@@ -108,6 +108,15 @@ class AvatarRenderTest < ViewComponent::TestCase
     assert_selector "[data-avatar-target='fallback'][role='img'][aria-label='Dave']", visible: :all
   end
 
+  # The recovered initials must render in the CALLER's hue: the standby span carries
+  # the same --hue custom property the initials branch renders, or a 404'd logo for a
+  # custom-color identity silently recovers in the default hue.
+  def test_standby_initials_keep_the_callers_hue
+    render_inline(UI::AvatarComponent.new(src: "/a.png", fallback: "DC", hue: 280))
+
+    assert_selector "[data-avatar-target='fallback'].bg-hue-initials[style*='--hue: 280']", visible: :all
+  end
+
   def test_avatar_is_named_once_among_visible_nodes
     render_inline(UI::AvatarComponent.new(src: "/a.png", fallback: "DC", aria_label: "Dave"))
 


### PR DESCRIPTION
Found by the modelrails_base Panel Checkpoint 2 review (three seats converged on it independently): `recoverable_image`'s standby initials span applies `bg-hue-initials` via `color_classes` but never mirrors the `style="--hue: N"` custom property — only `initials_avatar` sets it. A logo that fails to load therefore recovers into the default hue (210, the CSS `var(--hue, 210)` fallback) instead of the caller's brand hue. The bug was invisible at the default hue precisely because the two values coincide.

**Fix:** the fallback span mirrors `--hue` when `hue:` is given. Failing-first render test added (`test_standby_initials_keep_the_callers_hue`).

**Documented non-change:** caller `html_attrs` continue to ride the `<img>` only — mirroring them onto the standby span would duplicate any caller `id` while both nodes are in the DOM. The docblock now records both decisions.

All three lanes green: render 1021/0, structural 551/0, system 56/0.

The consuming app (modelrails_base PR #749) is the first call site to pass `src:` + `fallback:` + `hue:` together; its vendored copy carries the semantically identical edit.