### PR TITLE
fix(badge): BASE hygiene — no focus-ring on spans, no aria-invalid ring

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Docs: _modal docblock reflects the fail-loud id contract; ModalChrome documents its includer interface (panel, dialog_attrs); dialog.md documents id/body_id/wrapper.
 
+### Fixed
+
+- Badge no longer ships `focus-ring` on non-focusable spans or an `aria-invalid` box-shadow ring; link badges (`href:`) keep `focus-ring` explicitly. (#147)
+
 ## [0.11.0] - 2026-08-22
 
 ### Added

--- a/lib/generators/modelrails_ui/add/templates/badge/badge_component.rb.tt
+++ b/lib/generators/modelrails_ui/add/templates/badge/badge_component.rb.tt
@@ -42,9 +42,8 @@ module UI
   class BadgeComponent < ApplicationComponent
     BASE = "inline-flex w-fit shrink-0 items-center justify-center gap-1 overflow-hidden rounded-full " \
            "border border-transparent px-2 py-0.5 text-xs font-medium whitespace-nowrap " \
-           "transition-[color,box-shadow] " \
-           "focus-ring " \
-           "aria-invalid:border-danger-border aria-invalid:ring-2 aria-invalid:ring-danger  " \
+           "transition-colors " \
+           "aria-invalid:border-danger-border " \
            "[&>svg]:pointer-events-none [&>svg]:size-3"
 
     # The 9 AAA-proven cells, keyed `[variant, tone]`. Signal tones use the TINTED
@@ -92,7 +91,7 @@ module UI
       if href
         @html_attrs[:href] = href
         @tag ||= :a
-        @extra_class = [@extra_class, "min-h-11"].compact.join(" ")
+        @extra_class = [@extra_class, "min-h-11 focus-ring"].compact.join(" ")
       end
     end
 

--- a/test/render/badge_render_test.rb
+++ b/test/render/badge_render_test.rb
@@ -42,12 +42,12 @@ class BadgeRenderTest < ViewComponent::TestCase
 
   # The canonical `danger` signal uses the TINTED treatment (soft danger-surface +
   # saturated text-danger + danger-border), not a solid fill. Never raw palette /
-  # text-white; focus ring is the uniform focus-ring utility.
+  # text-white. No focus-ring here — a span is not focusable (#147); see
+  # test_span_badge_carries_no_focus_ring_or_invalid_ring below.
   def test_danger_uses_tinted_surface
     render_inline(UI::BadgeComponent.new("Error", variant: :danger))
 
     assert_selector "span.bg-danger-surface.text-danger.border-danger-border"
-    assert_selector "span.focus-ring"
     refute_selector "span.text-white"
   end
 
@@ -116,5 +116,23 @@ class BadgeRenderTest < ViewComponent::TestCase
     assert_raises(ArgumentError) do
       render_inline(UI::BadgeComponent.new("X", variant: :bogus))
     end
+  end
+
+  # BASE hygiene (#147): a span is not focusable and must not carry focus-ring
+  # or the aria-invalid box-shadow ring (both are agent-rules violations —
+  # forced-colors/overflow failure modes; focus-ring belongs only on focusables).
+  def test_span_badge_carries_no_focus_ring_or_invalid_ring
+    render_inline(UI::BadgeComponent.new("Draft", variant: :soft, tone: :success))
+
+    refute_selector "span.focus-ring"
+    refute_selector "span[class*='aria-invalid:ring']"
+  end
+
+  # Link badges (href:) ARE focusable, so they keep focus-ring explicitly via
+  # the href branch's @extra_class, alongside the existing min-h-11 target size.
+  def test_link_badge_carries_focus_ring
+    render_inline(UI::BadgeComponent.new("Docs", variant: :soft, tone: :success, href: "/docs"))
+
+    assert_selector "a.focus-ring.min-h-11"
   end
 end


### PR DESCRIPTION
Closes #147.

## What changed

Badge's `BASE` constant carried two agent-rules violations, both flagged by a downstream panel review:

- `focus-ring` on the default `<span>` render — a span is not focusable, so an offset outline there is dead weight (and the class name misleadingly implies it works).
- `aria-invalid:ring-2 aria-invalid:ring-danger` — a box-shadow ring, which the design system forbids everywhere (`.modelrails_ui/agent-rules.md`): it's clipped by `overflow:hidden` ancestors and disappears in forced-colors mode, both WCAG 2.4.7 failures. `aria-invalid:border-danger-border` (a border, not a ring) already carries the invalid-state signal and stays.

`transition-[color,box-shadow]` was narrowed to `transition-colors` since nothing in BASE animates box-shadow anymore. Also fixed a stray double space in the old ring declaration.

Link badges (`href:`) render an `<a>`, which *is* focusable — those keep `focus-ring` explicitly, added alongside the existing `min-h-11` target-size class in the `href` branch of `initialize`.

## Why

`.modelrails_ui/agent-rules.md`: "Focus is an offset `outline`, never a `ring`... Never `focus:ring-*` — a box-shadow ring is clipped by `overflow:hidden` ancestors and vanishes in forced-colors mode (a 2.4.7 failure)" and focus-ring belongs only on focusable elements.

## Tests

- Added `test_span_badge_carries_no_focus_ring_or_invalid_ring` and `test_link_badge_carries_focus_ring` in `test/render/badge_render_test.rb`.
- Updated `test_danger_uses_tinted_surface`, which previously asserted `span.focus-ring` — that assertion is now the bug being fixed, so it was removed (the new span test covers the behavior instead).
- `test/test_components.rb`'s badge block needed no changes (no structural assertions reference the removed classes).
- Full suite green: `bundle exec rake` (test:structural 551, test:render 1022, test:system 56 — 0 failures) + rubocop clean.

## Scope

This is the first of three stacked PRs on the badge template (issue #147, part of a larger #146–149 arc); tasks 2–3 build on this BASE text.