### PR TITLE
feat(badge): emit data-variant/data-tone contract hooks (#149)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- Badge emits stable `data-variant`/`data-tone` contract hooks so host specs can assert the two-axis contract instead of private class lists. (#149)
+
 ### Changed
 
 - Docs: _modal docblock reflects the fail-loud id contract; ModalChrome documents its includer interface (panel, dialog_attrs); dialog.md documents id/body_id/wrapper.

--- a/lib/generators/modelrails_ui/add/templates/badge/badge_component.rb.tt
+++ b/lib/generators/modelrails_ui/add/templates/badge/badge_component.rb.tt
@@ -98,6 +98,7 @@ module UI
     def call
       content_tag(@tag || :span, content.presence || @label,
         class: cn(BASE, COMBOS.fetch([@variant, @tone], COMBOS[[:solid, :primary]]), @extra_class),
+        "data-variant": @variant, "data-tone": @tone,
         **@html_attrs)
     end
 

--- a/test/render/badge_render_test.rb
+++ b/test/render/badge_render_test.rb
@@ -135,4 +135,19 @@ class BadgeRenderTest < ViewComponent::TestCase
 
     assert_selector "a.focus-ring.min-h-11"
   end
+
+  # Contract hooks (#149): every badge emits data-variant/data-tone reflecting the
+  # POST-shim axes, so host specs can assert on the two-axis contract instead of
+  # reaching into private class internals.
+  def test_badge_emits_variant_and_tone_hooks
+    render_inline(UI::BadgeComponent.new("Active", variant: :soft, tone: :success))
+
+    assert_selector "span[data-variant='soft'][data-tone='success']"
+  end
+
+  def test_link_badge_emits_hooks_too
+    render_inline(UI::BadgeComponent.new("Docs", variant: :soft, tone: :success, href: "/docs"))
+
+    assert_selector "a[data-variant='soft'][data-tone='success']"
+  end
 end


### PR DESCRIPTION
## Summary

Closes #149.

Every badge cell now emits `data-variant` and `data-tone` attributes reflecting the resolved, **post-shim** axes — the same two axes `COMBOS` is keyed on. Host specs can assert `span[data-variant='soft'][data-tone='success']` directly instead of asserting on Tailwind class internals (which are private/implementation detail and change across the AAA-proven cells).

### Hook contract

- Attributes always reflect `@variant`/`@tone` **after** `coerce_axes` resolves them — a legacy flat `variant:` value (e.g. `variant: :danger`) is translated through `SHIM` first, so the emitted hooks are `data-variant="soft" data-tone="danger"`, matching the two-axis API a caller would use going forward. This keeps the contract stable regardless of which calling convention (flat or two-axis) a host used.
- Applies uniformly to both render paths: the default `<span>` and the `<a>` rendered when `href:` is given.

### Splat-order override semantics

In `call`, the `"data-variant":`/`"data-tone":` pairs are placed **before** `**@html_attrs` in the `content_tag` call. Ruby keyword-argument splatting means a later key wins on collision, so if a caller explicitly passes `"data-variant":`/`"data-tone":` in their own `html_attrs`, that explicit value overrides the computed hook rather than being silently clobbered by it.

## Stack

Second of three stacked PRs on the badge template. Was based on `fix/badge-base-hygiene` (#150, Task 1: BASE hygiene) while that PR was open; #150 has since merged (squashed into `main` as d9e24f0), so this branch was rebased onto `main` and retargeted here — the diff now contains only this task's changes.

## Test plan

- [x] TDD: added `test_badge_emits_variant_and_tone_hooks` and `test_link_badge_emits_hooks_too` to `test/render/badge_render_test.rb`; both failed (RED) before the `call` change, pass (GREEN) after.
- [x] `bundle exec rake test:render` — green.
- [x] Full `bundle exec rake` (render tests + component tests + RuboCop) — all green, 0 RuboCop offenses.
- [x] CHANGELOG updated under `## [Unreleased]` / `### Added` (heading created; only `### Fixed` existed before).