### PR TITLE
fix(breadcrumb): class: targets the nav root; add list_class: for the ol

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Changed
 
 - Docs: _modal docblock reflects the fail-loud id contract; ModalChrome documents its includer interface (panel, dialog_attrs); dialog.md documents id/body_id/wrapper.
+- BREAKING for hosts styling the list via `class:` — breadcrumb's `class:` now lands on the `<nav>` root like every other passthrough attribute; use the new `list_class:` to style the `<ol>`. (#148)
 
 ### Fixed
 

--- a/docs/components/breadcrumb.md
+++ b/docs/components/breadcrumb.md
@@ -28,6 +28,15 @@ A **non-last** item without an `href` renders as plain text (never a dead `<a>`)
 "linked for some viewers, plain for others" crumbs — e.g. a parent page whose link is
 policy-gated — stay expressible with the same `items:` array.
 
+## Attributes
+
+`class:` targets the `<nav>` root, like every other passthrough attribute on a `UI::*`
+component. Use `list_class:` to style the `<ol>` (precedent: tabs' `tablist_class:`):
+
+```erb
+<%= render(UI::BreadcrumbComponent.new(items: trail, class: "mb-6", list_class: "gap-4")) %>
+```
+
 ## Collapsing a long trail
 
 `max_items:` keeps the root and the tail and stands one ellipsis in for the rest.

--- a/lib/generators/modelrails_ui/add/templates/breadcrumb/breadcrumb_component.rb.tt
+++ b/lib/generators/modelrails_ui/add/templates/breadcrumb/breadcrumb_component.rb.tt
@@ -22,7 +22,9 @@ module UI
     # items: [{ label:, href: }, ..., { label: }] — last item is the current page (no href).
     # separator: the visual divider between crumbs (decorative). label: the <nav> accessible
     # name (i18n; default t("ui.breadcrumb.label", default: "Breadcrumb")).
-    def initialize(items: [], separator: "/", label: nil, max_items: nil, **html_attrs)
+    # list_class: extra classes merged onto the <ol> (class: targets the <nav> root like every
+    # other passthrough attribute — precedent: tabs' tablist_class:).
+    def initialize(items: [], separator: "/", label: nil, max_items: nil, list_class: nil, **html_attrs)
       if max_items && max_items < 2
         raise ArgumentError, "UI::Breadcrumb max_items must be at least 2 (got #{max_items.inspect})"
       end
@@ -31,12 +33,13 @@ module UI
       @items = items
       @separator = separator
       @label = label
+      @list_class = list_class
       @extra_class = html_attrs.delete(:class)
       @html_attrs = html_attrs
     end
 
     def call
-      content_tag(:nav, ordered_list, "aria-label": nav_label, **@html_attrs)
+      content_tag(:nav, ordered_list, "aria-label": nav_label, class: @extra_class, **@html_attrs)
     end
 
     private
@@ -62,7 +65,7 @@ module UI
         safe_join(shown.each_with_index.map { |item, i|
           item == :ellipsis ? ellipsis : crumb(item, i == shown.size - 1)
         }),
-        class: cn("flex flex-wrap items-center gap-1.5 break-words text-sm text-text-muted sm:gap-2.5", @extra_class))
+        class: cn("flex flex-wrap items-center gap-1.5 break-words text-sm text-text-muted sm:gap-2.5", @list_class))
     end
 
     def ellipsis

--- a/test/render/breadcrumb_render_test.rb
+++ b/test/render/breadcrumb_render_test.rb
@@ -94,4 +94,20 @@ class BreadcrumbRenderTest < ViewComponent::TestCase
 
     assert_match(/max_items/, error.message)
   end
+
+  # `class:` is a passthrough attr like every other UI::* component — it targets the <nav>
+  # root, not the <ol>. (#148)
+  def test_class_lands_on_the_nav_root
+    render_inline(UI::BreadcrumbComponent.new(items: [{label: "Docs", href: "/docs"}, {label: "Here"}], class: "mb-6"))
+
+    assert_selector "nav.mb-6[aria-label]", visible: :all
+    assert_no_selector "ol.mb-6", visible: :all
+  end
+
+  # list_class: is the named sub-element hook for the <ol> (precedent: tabs' tablist_class:).
+  def test_list_class_lands_on_the_ol
+    render_inline(UI::BreadcrumbComponent.new(items: [{label: "Docs", href: "/docs"}, {label: "Here"}], list_class: "gap-4"))
+
+    assert_selector "nav > ol.gap-4", visible: :all
+  end
 end


### PR DESCRIPTION
## Summary

Closes #148.

`UI::BreadcrumbComponent`'s `class:` kwarg was the one passthrough attribute that skipped the `<nav>` and landed on the `<ol>` instead — every other `UI::*` component treats `class:` as targeting its root element. This PR brings breadcrumb in line and adds `list_class:` (precedent: tabs' `tablist_class:`) for hosts that want to style the `<ol>` specifically.

**BREAKING** for hosts styling the crumb list via `class:` — that class now lands on the `<nav>` root, not the `<ol>`. Migration: pass `list_class:` instead to keep styling the `<ol>`. Host callers that wrapped the component in an extra `<div class="...">` just to target the nav can now pass `class:` directly instead.

## Changes
- `initialize` gains `list_class: nil`; `@extra_class` (from `class:`) now flows to the `<nav>` in `call`, and `@list_class` flows to the `<ol>` in `ordered_list`.
- `test/render/breadcrumb_render_test.rb`: two new render tests (`class:` → nav root, `list_class:` → ol).
- `docs/components/breadcrumb.md`: new Attributes section documenting both kwargs.
- `CHANGELOG.md`: `### Changed` entry under `[Unreleased]` framing the break.

## Test plan
- [x] TDD: both new render tests failed pre-fix (`bundle exec rake test:render`), pass post-fix
- [x] `bundle exec rake test:render` — 1028 runs, 0 failures
- [x] `bundle exec rake` (full suite incl. RuboCop) — green