### PR TITLE
fix(badge): restore AAA wording fix + add neutral preview scenario

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- Badge Lookbook preview gains a `neutral` scenario (`variant: :soft, tone: :neutral`), reachable at `.../badge_component/neutral`, so a consuming app's per-scenario 0b axe row can exercise the `[:soft, :neutral]` cell. (#146)
+
+### Fixed
+
+- Badge docs (docblock, badge.md, preview comment, test comment) no longer claim AAA proof for the `[:soft, :neutral]` cell — restores the review fix (25aa4b0) that missed the v0.12.0 merge: PR #152 landed at 4b78b30 before its follow-up commit was pushed, so the wording correction never shipped. Reworded to "9 AAA-proven, plus `soft`/`neutral` pending the consuming app's 0b axe row" throughout. (#146)
+
 ## [0.12.0] - 2026-08-23
 
 ### Added

--- a/docs/components/badge.md
+++ b/docs/components/badge.md
@@ -27,8 +27,10 @@ Creates `app/components/ui/badge_component.rb`.
 ## Cells (variant × tone)
 
 Badge is a **two-axis** component: `variant:` (shape) × `tone:` (signal). Only
-the 10 AAA-proven `(variant, tone)` cells below ship — pairings outside this
-table are unproven and not guaranteed legible.
+the 10 `(variant, tone)` cells below ship — pairings outside this table are
+unproven and not guaranteed legible. 9 of the 10 are AAA-proven; `soft`/`neutral`
+is marked below — its AAA proof lands with the consuming app's 0b axe row (this
+gem's CI disables `color-contrast`; see [Testing](../testing.md)).
 
 | Variant | Tone | Class recipe |
 |---------|------|--------------|
@@ -38,10 +40,12 @@ table are unproven and not guaranteed legible.
 | `soft` | `success` | `bg-success-surface text-success border-success-border [a&]:hover:bg-success-hover` |
 | `soft` | `warning` | `bg-warning-surface text-warning border-warning-border [a&]:hover:bg-warning-hover` |
 | `soft` | `danger` | `bg-danger-surface text-danger border-danger-border [a&]:hover:bg-danger-hover` |
-| `soft` | `neutral` | `bg-surface text-text-muted border-border [a&]:hover:bg-surface-sunken [a&]:hover:text-text-heading` |
+| `soft` | `neutral` † | `bg-surface text-text-muted border-border [a&]:hover:bg-surface-sunken [a&]:hover:text-text-heading` |
 | `outline` | `neutral` | `border-border text-text-heading [a&]:hover:bg-surface-sunken [a&]:hover:text-text-heading` |
 | `ghost` | `neutral` | `[a&]:hover:bg-surface-sunken [a&]:hover:text-text-heading` |
 | `link` | `primary` | `text-interactive underline-offset-4 [a&]:hover:underline` |
+
+† `soft`/`neutral` AAA proof is downstream, not yet CI-verified in this gem — see above.
 
 ```erb
 <%= ui :badge, "Active",  variant: :solid, tone: :primary %>

--- a/lib/generators/modelrails_ui/add/templates/badge/badge_component.rb.tt
+++ b/lib/generators/modelrails_ui/add/templates/badge/badge_component.rb.tt
@@ -29,11 +29,12 @@ module UI
   # - `variant: :solid | :soft | :outline | :ghost | :link` (default `:solid`)
   # - `tone: :primary | :neutral | :info | :success | :warning | :danger` (default `:primary`)
   #
-  # Only the 10 AAA-proven cells ship (see `COMBOS`). Every signal lives on the SOFT
-  # variant as a TINTED chip — note `[:soft, :danger]` is the badge "danger" (there is
-  # NO solid-danger badge fill; `variant: :solid, tone: :danger` is unproven and raises).
-  # `[:soft, :neutral]` is the one soft cell with no signal color — a muted chip for
-  # draft-style pills (no colored border/text, just surface + muted text).
+  # Only the 10 cells in `COMBOS` ship — 9 are AAA-proven; the 10th, `[:soft, :neutral]`
+  # (a muted chip for draft-style pills, no colored border/text), has its AAA proof land
+  # with the consuming app's 0b axe row (gem CI disables `color-contrast`; see
+  # `docs/testing.md`). Every signal lives on the SOFT variant as a TINTED chip — note
+  # `[:soft, :danger]` is the badge "danger" (there is NO solid-danger badge fill;
+  # `variant: :solid, tone: :danger` is unproven and raises).
   #
   # ## Legacy shim (deprecated flat `variant:` → `[variant, tone]`)
   # The historical flat values still work, byte-identically, via `SHIM`:
@@ -48,7 +49,8 @@ module UI
            "aria-invalid:border-danger-border " \
            "[&>svg]:pointer-events-none [&>svg]:size-3"
 
-    # The 10 AAA-proven cells, keyed `[variant, tone]`. Signal tones use the TINTED
+    # The 10 shipped cells, keyed `[variant, tone]` — 9 AAA-proven, plus `[:soft, :neutral]`
+    # pending the consuming app's 0b axe row (see the class docblock). Signal tones use the TINTED
     # treatment (soft `*-surface` background + saturated `text-<level>` + `*-border`),
     # matching the alert + toast cards. The `--color-<level>` base tokens are TEXT
     # colors (dark in light mode for AAA-on-light readability), so using them as solid

--- a/lib/generators/modelrails_ui/add/templates/badge/badge_component.rb.tt
+++ b/lib/generators/modelrails_ui/add/templates/badge/badge_component.rb.tt
@@ -16,7 +16,8 @@ module UI
   #   A badge is presentational; `href:` is for navigation/filtering, not actions.
   #
   # ## Accessibility contract
-  # - **Guarantees:** AAA-contrast text on every shipped cell's surface, including the
+  # - **Guarantees:** AAA-contrast text on 9 of the 10 shipped cells' surfaces
+  #   (`soft`/`neutral` pending the consuming app's 0b axe row), including the
   #   adaptive signal treatments (`danger`/`success`/`info`/`warning`) which stay
   #   legible in dark mode.
   # - **You supply:** if the badge conveys status that isn't already in the
@@ -30,7 +31,7 @@ module UI
   # - `tone: :primary | :neutral | :info | :success | :warning | :danger` (default `:primary`)
   #
   # Only the 10 cells in `COMBOS` ship — 9 are AAA-proven; the 10th, `[:soft, :neutral]`
-  # (a muted chip for draft-style pills, no colored border/text), has its AAA proof land
+  # (a muted chip for draft-style pills, no colored border/text), whose AAA proof lands
   # with the consuming app's 0b axe row (gem CI disables `color-contrast`; see
   # `docs/testing.md`). Every signal lives on the SOFT variant as a TINTED chip — note
   # `[:soft, :danger]` is the badge "danger" (there is NO solid-danger badge fill;

--- a/lib/generators/modelrails_ui/lookbook/templates/previews/ui/badge_component_preview.rb
+++ b/lib/generators/modelrails_ui/lookbook/templates/previews/ui/badge_component_preview.rb
@@ -86,9 +86,10 @@ module UI
 
     # @!group Reference
 
-    # Edit `label` and the two-axis `variant`/`tone` cell live. Only the 10 AAA-proven
-    # cells are offered (signals live on the SOFT variant as tinted chips; an unproven
-    # pairing raises in dev).
+    # Edit `label` and the two-axis `variant`/`tone` cell live. Only the 10 shipped
+    # cells are offered — 9 AAA-proven, plus `soft/neutral` pending the consuming app's
+    # 0b axe row (signals live on the SOFT variant as tinted chips; an unproven pairing
+    # raises in dev).
     # @param label text
     # @param cell select [solid/primary, soft/primary, soft/info, soft/success, soft/warning, soft/danger, soft/neutral, outline/neutral, ghost/neutral, link/primary]
     def playground(label: "Badge", cell: "soft/primary")

--- a/lib/generators/modelrails_ui/lookbook/templates/previews/ui/badge_component_preview.rb
+++ b/lib/generators/modelrails_ui/lookbook/templates/previews/ui/badge_component_preview.rb
@@ -14,8 +14,9 @@ module UI
   # - It's a real action — use `UI::ButtonComponent` (or `button_to` for non-GET).
   #
   # ## Accessibility contract
-  # - **Guarantees:** AAA-contrast text on every variant, including the adaptive
-  #   signal treatments (`danger`/`success`/`info`/`warning`) that stay legible in dark mode.
+  # - **Guarantees:** AAA-contrast text on 9 of the 10 shipped cells (`soft`/`neutral`
+  #   pending the consuming app's 0b axe row), including the adaptive signal treatments
+  #   (`danger`/`success`/`info`/`warning`) that stay legible in dark mode.
   # - **You supply:** an accessible name when the badge conveys status not already in
   #   the surrounding text, and a valid `variant` (an unknown one raises in development).
   #
@@ -30,7 +31,7 @@ module UI
 
     # @!group Overview
 
-    # Every AAA-proven variant × tone cell on one screen.
+    # Every shipped variant × tone cell on one screen — 9 AAA-proven, soft/neutral pending.
     def showcase
     end
 

--- a/lib/generators/modelrails_ui/lookbook/templates/previews/ui/badge_component_preview.rb
+++ b/lib/generators/modelrails_ui/lookbook/templates/previews/ui/badge_component_preview.rb
@@ -46,6 +46,11 @@ module UI
     def secondary
     end
 
+    # Muted chip for draft-style pills — the two-axis `[:soft, :neutral]` cell, pending
+    # the consuming app's 0b axe row (see the class docblock).
+    def neutral
+    end
+
     # Informational signal — tinted info chip.
     def info
     end

--- a/lib/generators/modelrails_ui/lookbook/templates/previews/ui/badge_component_preview/neutral.html.erb
+++ b/lib/generators/modelrails_ui/lookbook/templates/previews/ui/badge_component_preview/neutral.html.erb
@@ -1,0 +1,1 @@
+<%= ui :badge, "Draft", variant: :soft, tone: :neutral %>

--- a/test/test_components.rb
+++ b/test/test_components.rb
@@ -381,7 +381,7 @@ class TestBadgeComponent < Minitest::Test
     assert_equal :primary, c.instance_variable_get(:@tone)
   end
 
-  # Every shipped (variant, tone) cell is an AAA-proven treatment in COMBOS.
+  # Every one of the 10 shipped cells is present in COMBOS.
   def test_all_combos_exist
     [%i[solid primary], %i[soft primary], %i[soft info], %i[soft success],
       %i[soft warning], %i[soft danger], %i[soft neutral], %i[outline neutral],


### PR DESCRIPTION
## Summary

Two final-review findings from the v0.12.0 arc (#146), fixed together:

1. **Orphaned review fix.** PR #152 merged at 4b78b30 before its review-fix commit 25aa4b0 was pushed to the branch, so 25aa4b0 (docs-only: reword four "10 AAA-proven" overclaims to "9 proven, plus `[:soft, :neutral]` pending the consuming app's 0b axe row") never made it into main or the v0.12.0 release. This PR cherry-picks 25aa4b0 and additionally qualifies two more lines the review flagged that make the same blanket claim: the `.tt` docblock's "Guarantees" line and `test/test_components.rb`'s `test_all_combos_exist` comment. Also fixes a grammar wobble in the cherry-picked wording ("has its AAA proof land with" → "whose AAA proof lands with").

2. **Missing `neutral` Lookbook scenario.** The badge preview had no dedicated scenario for the `[:soft, :neutral]` cell — only the "Reference" playground offered it as a dropdown option. The downstream app's planned per-scenario 0b axe row needs a stable scenario path to visit (`.../badge_component/neutral`), like every other Examples entry. Added a `neutral` scenario that calls the two-axis API directly (this cell has no legacy flat alias).

CHANGELOG gets a fresh `## [Unreleased]` section for both.

## Why a v0.12.1 will follow

The `.tt` docblock is a generator template — it vendors byte-for-byte into every host app pinned to the v0.12.0 tag. The wording fix only reaches those hosts once a v0.12.1 patch release ships. That release is a separate follow-up step after this PR merges, not part of this PR.

## Test plan

- [x] `bundle exec rake` — full suite (structural 551, render 1028, system 56) + RuboCop, all green
- [x] Cherry-pick applied cleanly, no conflicts
- [x] Verified no other lines in the touched files still claim unproven AAA for `[:soft, :neutral]`