### PR TITLE
fix(form_builder): required: in html_options converts to aria-only (select + collection groups)

### DIFF
--- a/lib/generators/modelrails_ui/add/templates/form_builder/form_builder.rb.tt
+++ b/lib/generators/modelrails_ui/add/templates/form_builder/form_builder.rb.tt
@@ -101,6 +101,11 @@ module UI
       field_opts = {}
       field_opts[:label] = options.delete(:label) if options.key?(:label)
       field_opts[:help] = options.delete(:help) if options.key?(:help)
+      # required in EITHER hash converts to aria-only — html_options is the
+      # documented Rails signature, and passing it through to super would emit
+      # native required, defeating the class-header contract. options wins
+      # when both are given.
+      field_opts[:required] = html_options.delete(:required) if html_options.key?(:required)
       field_opts[:required] = options.delete(:required) if options.key?(:required)
       field_opts[:id] = html_options.delete(:id) if html_options.key?(:id)
 
@@ -214,7 +219,10 @@ module UI
       html_options = html_options.dup
       legend_text = options.key?(:label) ? options.delete(:label) : default_label(method)
       hint = options.delete(:help)
-      required = !!options.delete(:required)
+      # Strip required from BOTH hashes: left in html_options it would emit
+      # native required on every input in the group (same contract hole as
+      # select's html_options path).
+      required = !!options.delete(:required) | !!html_options.delete(:required)
       error = error_for(method)
       base_id = field_id(method)
 

--- a/test/render/form_builder_render_test.rb
+++ b/test/render/form_builder_render_test.rb
@@ -216,6 +216,15 @@ class FormBuilderRenderTest < ViewComponent::TestCase
     refute page.has_css?("select[required]")
   end
 
+  def test_select_required_in_html_options_is_converted_to_aria_only
+    # The Rails signature a fork author will actually use: required in the
+    # fourth (html_options) hash must not bypass the no-native-required contract.
+    page = page_for(builder.select(:title, %w[a b], {}, {required: true}))
+
+    assert page.has_css?("select[aria-required='true']")
+    refute page.has_css?("select[required]")
+  end
+
   def test_select_honours_caller_html_options
     page = page_for(builder.select(:title, %w[a b], {}, {"data-controller" => "auto-submit"}))
 
@@ -363,6 +372,17 @@ class FormBuilderRenderTest < ViewComponent::TestCase
     # Caller class is additive, not a replacement — dropping CHECKBOX_CLASSES here
     # would leave radio rows unstyled and out of the accent color system.
     assert_equal 2, page.all("input[type='radio'].auto-submit.text-interactive").size
+  end
+
+  def test_collection_group_required_in_html_options_never_reaches_the_inputs
+    # Same contract hole as select: required in the html_options hash would
+    # otherwise emit native required on EVERY input in the group.
+    page = page_for(builder.collection_radio_buttons(:title, ROLES, :first, :last, {},
+      {required: true}))
+
+    refute page.has_css?("input[required]")
+    # It still means "this group is required": the legend gets the mark.
+    assert page.has_css?("legend span[aria-hidden='true']", text: "*")
   end
 
   # -- submit -------------------------------------------------------------


### PR DESCRIPTION
Closes #145.

`required: true` in the `html_options` hash — the documented Rails signature — passed straight through to `super` and emitted native `required`, silently defeating the class-header "no native required — ever" contract. The same hole existed in `collection_group`, where it would have landed native `required` on **every input** in a checkbox/radio group.

- `select`: `required` is now stripped from both hashes and converted to aria-only (`options` wins when both are given).
- `collection_group` (collection_checkboxes / collection_radio_buttons): `required` in either hash resolves to the group-level legend mark, never a native attribute.

Render tests written first and watched fail on the exact leak: `form.select :status, choices, {}, { required: true }` now emits `aria-required="true"` and no native `required`; a group with `required` in html_options emits no `input[required]` and keeps the legend mark.