### PR TITLE
fix(form_draft): cancel pending announce on disconnect; re-import key on scope rotation

### DIFF
--- a/lib/generators/modelrails_ui/add/templates/form_draft/form_draft_controller.js
+++ b/lib/generators/modelrails_ui/add/templates/form_draft/form_draft_controller.js
@@ -57,15 +57,24 @@ export function expired(draft, expiresInHours) {
 // snapshot / session-replay leak surface).
 
 let keyPromise = null
+let keyDigest = null
 
-function resolveKey() {
+function resolveKey(scopeDigest) {
   const meta = document.querySelector('meta[name="form-draft-key"]')
   if (meta) {
     const b64 = meta.content
     meta.remove()
-    if (!keyPromise) keyPromise = importKey(b64)
+    // Re-import on a scope-digest change (key rotation): the cached key
+    // belongs to the OLD digest, and encrypting new-digest drafts with it
+    // would strand them — no fresh page load could ever decrypt them.
+    if (!keyPromise || keyDigest !== scopeDigest) {
+      keyPromise = importKey(b64)
+      keyDigest = scopeDigest
+    }
   }
-  return keyPromise
+  // Digest changed but no fresh key meta: fail closed (feature off) rather
+  // than encrypt under a key the next page load won't have.
+  return keyDigest === scopeDigest ? keyPromise : null
 }
 
 async function importKey(b64) {
@@ -107,7 +116,7 @@ export default class extends Controller {
     this.disarmed = false
     this.pendingSave = null
     this.scopeDigest = document.querySelector('meta[name="form-draft-scope"]')?.content
-    resolveKey() // scrub + warm the key cache even if this instance no-ops
+    resolveKey(this.scopeDigest) // scrub + warm the key cache even if this instance no-ops
 
     this.boundStorage = this.onStorage.bind(this)
     this.boundFlush = this.flush.bind(this)
@@ -127,6 +136,7 @@ export default class extends Controller {
 
   disconnect() {
     this.cancelPendingSave()
+    this.cancelPendingAnnounce()
     window.removeEventListener("storage", this.boundStorage)
     document.removeEventListener("turbo:before-visit", this.boundFlush)
     document.removeEventListener("visibilitychange", this.boundVisibility)
@@ -247,7 +257,7 @@ export default class extends Controller {
 
   async persist() {
     this.pendingSave = null
-    const key = await resolveKey()
+    const key = await resolveKey(this.scopeDigest)
     if (!key || this.disarmed) return
     const payload = JSON.stringify({ savedAt: Date.now(), data: serializeForm(this.element) })
     const blob = await this.encrypt(key, payload)
@@ -271,7 +281,7 @@ export default class extends Controller {
   }
 
   async readDraft() {
-    const key = await resolveKey()
+    const key = await resolveKey(this.scopeDigest)
     if (!key) return null
     const blob = this.safely(() => localStorage.getItem(this.storageKey))
     if (!blob) return null
@@ -374,11 +384,26 @@ export default class extends Controller {
   }
 
   // Small delay so the polite message isn't swallowed by page-load speech.
+  // The rAF/timer ids are kept so disconnect() can cancel the chain — a write
+  // landing after disconnect hits a detached node, or worse, announces stale
+  // text into a Turbo-cache-restored copy of this element.
   announce(message) {
     if (!this.hasStatusTarget || !message) return
-    requestAnimationFrame(() => {
-      setTimeout(() => { this.statusTarget.textContent = message }, 100)
+    this.cancelPendingAnnounce()
+    this.announceFrame = requestAnimationFrame(() => {
+      this.announceFrame = null
+      this.announceTimer = setTimeout(() => {
+        this.announceTimer = null
+        this.statusTarget.textContent = message
+      }, 100)
     })
+  }
+
+  cancelPendingAnnounce() {
+    if (this.announceFrame) cancelAnimationFrame(this.announceFrame)
+    if (this.announceTimer) clearTimeout(this.announceTimer)
+    this.announceFrame = null
+    this.announceTimer = null
   }
 
   focusFirstField() {

--- a/test/system/form_draft_system_test.rb
+++ b/test/system/form_draft_system_test.rb
@@ -1,0 +1,121 @@
+# frozen_string_literal: true
+
+require "system_test_helper"
+require "base64"
+
+# Two AES-256 keys a host would deliver via <meta name="form-draft-key">; the
+# second plays the rotated key after a deploy changes the scope digest.
+module FormDraftTestKeys
+  KEY_ONE = Base64.strict_encode64("\x00" * 32)
+  KEY_TWO = Base64.strict_encode64("\x01" * 32)
+end
+
+BrowserHarness.scenario("form_draft/lifecycle", controllers: %w[form-draft]) do
+  <<~HTML
+    <meta name="form-draft-scope" content="digest-one">
+    <meta name="form-draft-key" content="#{FormDraftTestKeys::KEY_ONE}">
+    <form id="draft-form" action="/articles" method="post"
+          data-controller="form-draft"
+          data-form-draft-key-value="rotation-test"
+          data-action="input->form-draft#save">
+      <div data-form-draft-target="notice" hidden>
+        <button type="button" data-action="form-draft#recover">Recover draft</button>
+        <button type="button" data-action="form-draft#discard">Discard draft</button>
+      </div>
+      <div data-form-draft-target="status" role="status" aria-live="polite" aria-atomic="true"
+           data-found-text="Recoverable draft found."
+           data-restored-text="Draft restored. %{count} fields updated."
+           data-discarded-text="Draft discarded."></div>
+      <label>Title <input type="text" name="title" value="hello"></label>
+    </form>
+  HTML
+end
+
+# The render lane proves the markup contract; only this lane can see the two
+# lifecycle bugs from the 2026-07 review: an announcement timer outliving its
+# controller (#74) and the module-level key cache surviving a scope-digest
+# rotation (#73).
+class FormDraftSystemTest < BrowserTestCase
+  def setup
+    super
+    visit_scenario("form_draft/lifecycle")
+  end
+
+  # Control: proves announce() actually fires while connected, so the
+  # disconnect test below cannot pass vacuously.
+  def test_discard_announces_into_the_status_region
+    page.execute_script(%{document.querySelector('[data-action="form-draft#discard"]').click()})
+
+    assert page.has_css?('[data-form-draft-target="status"]', text: "Draft discarded.")
+    assert_no_stimulus_errors
+  end
+
+  # #74: announce() schedules rAF -> setTimeout(100ms); disconnect() must
+  # cancel the chain or the write lands on a detached node — and on a Turbo
+  # cache restore of the same element, a stale announcement.
+  def test_disconnect_cancels_a_pending_announcement
+    page.execute_script(<<~JS)
+      const form = document.getElementById("draft-form")
+      window.__status = form.querySelector('[data-form-draft-target="status"]')
+      form.querySelector('[data-action="form-draft#discard"]').click()
+      form.remove()
+    JS
+    sleep 0.4 # well past the rAF + 100ms announcement delay
+
+    assert_equal "", page.evaluate_script("window.__status.textContent"),
+      "a pending announcement fired after disconnect()"
+  end
+
+  # #73: rotate scope digest + key meta (a deploy), reconnect the form, save.
+  # The new draft must decrypt with the ROTATED key; the stale cached key
+  # would strand every draft written after the rotation.
+  def test_scope_rotation_reimports_the_key_before_the_next_save
+    page.execute_script(<<~JS)
+      document.querySelector('meta[name="form-draft-scope"]').content = "digest-two"
+      const rotated = document.createElement("meta")
+      rotated.name = "form-draft-key"
+      rotated.content = "#{FormDraftTestKeys::KEY_TWO}"
+      document.head.append(rotated)
+      const form = document.getElementById("draft-form")
+      const parent = form.parentElement
+      form.remove()
+      parent.append(form)
+    JS
+    page.execute_script(<<~JS)
+      const field = document.querySelector('input[name="title"]')
+      field.value = "rotated draft"
+      field.dispatchEvent(new Event("input", { bubbles: true }))
+    JS
+
+    result = page.evaluate_async_script(<<~JS)
+      const done = arguments[0]
+      setTimeout(async () => {
+        try {
+          const key = Object.keys(localStorage).find((k) => k.startsWith("draft:v1:digest-two:"))
+          if (!key) return done({ ok: false, reason: "no draft stored under the rotated digest" })
+          const bytes = Uint8Array.from(atob(localStorage.getItem(key)), (c) => c.charCodeAt(0))
+          const rotated = await crypto.subtle.importKey(
+            "raw",
+            Uint8Array.from(atob("#{FormDraftTestKeys::KEY_TWO}"), (c) => c.charCodeAt(0)),
+            "AES-GCM", false, ["decrypt"]
+          )
+          try {
+            await crypto.subtle.decrypt(
+              { name: "AES-GCM", iv: bytes.subarray(0, 12),
+                additionalData: new TextEncoder().encode(key), tagLength: 128 },
+              rotated, bytes.subarray(12)
+            )
+            done({ ok: true })
+          } catch {
+            done({ ok: false, reason: "draft was not encrypted with the rotated key" })
+          }
+        } catch (e) {
+          done({ ok: false, reason: e.message })
+        }
+      }, 600) // past the 300ms save debounce + encryption
+    JS
+
+    assert result["ok"], "after rotation: #{result["reason"]}"
+    assert_no_stimulus_errors
+  end
+end


### PR DESCRIPTION
Closes #74. Closes #73.

Two lifecycle bugs from the 2026-07 review, both proven in the browser lane (new `test/system/form_draft_system_test.rb`, three tests — each watched fail on the bug before the fix):

**#74 — announce() outliving its controller.** `announce()` schedules a rAF → 100ms setTimeout chain with neither id stored; `disconnect()` only cleared `pendingSave`. The write landed on a detached node — and on a Turbo cache restore of the same element, a stale announcement. The rAF/timer ids are now tracked and `disconnect()` cancels the chain (`cancelPendingAnnounce()`, mirroring the existing `cancelPendingSave` shape). A control test pins that discard still announces while connected, so the disconnect test can't pass vacuously.

**#73 — module-level key cache surviving a scope-digest rotation.** `resolveKey()` cached the first imported key forever, so a draft saved after a deploy rotated the digest+key was encrypted with the *old* key — no fresh page load could ever decrypt it. The cache is now keyed on the scope digest: a digest change with a fresh key meta re-imports; a digest change with **no** fresh meta fails closed (feature off) rather than encrypting under a key the next page load won't have. The system test performs the rotation in-page and decrypts the stored blob with the rotated key to prove which key encrypted it.