### PR TITLE
chore: catalog + tooling hygiene — list fix, ledger guard, SHARED_RB tests, rubocop directives, min-h-input token

### DIFF
--- a/COMPONENT_STATUS.md
+++ b/COMPONENT_STATUS.md
@@ -97,8 +97,10 @@ ledger is human judgment (Tier + Notes) only.
 | wysiwyg | hardened | Final band — **gem-0a-only, SUPERSEDED in this app by Lexxy** (no app adoption). Template still hardened: editor `role=textbox`+label; named toolbar buttons + `aria-pressed`; `focus-ring`; fail-loud `adapter`. 0a (14) |
 | toaster | hardened | Final band — **gem-0a-only, SUPERSEDED in this app by `shared/_toasts`** (no app adoption). Template still hardened: 6 raw-palette → tinted signal tokens (alert/banner model); per-severity live region; 44px dismiss + `focus-ring`; fail-loud `severity` (documents the flash-key collision). 0a (21) |
 | form_draft | gem-0a-proven / app-0b-pending | encrypted localStorage form-draft recovery (notice partial + form-mounted controller). 0a render test; app 0b pending. |
+| form_builder | gem-0a-proven / app-0b-pending | UI::FormBuilder (v0.10.0, B1): wrapped inputs wired to ActiveModel::Errors, aria-only required contract. Not a ViewComponent (render tests via the NOT_A_VIEWCOMPONENT carve-out). App still routes through its TailwindFormBuilder adapter (adoption handoff D1) — no app 0b yet. |
+| error_summary | gem-0a-proven / app-0b-pending | focusable autofocused error summary (v0.10.0, B1 sibling); unlinked: opt-out + anchor contract (#121/#126). 0a render test; app 0b pending. |
 
-**Hardening program COMPLETE** — all 81 components are `proven` (0a + app 0b/AAA), `hardened` (gem 0a; `wysiwyg`/`toaster` are superseded in this host and adopt no app 0b), or `gem-0a-proven / app-0b-pending` (form_draft). No `experimental` components remain.
+**Hardening program COMPLETE** — all 84 components are `proven` (0a + app 0b/AAA), `hardened` (gem 0a; `wysiwyg`/`toaster` are superseded in this host and adopt no app 0b), or `gem-0a-proven / app-0b-pending` (form_draft, form_builder, error_summary). No `experimental` components remain. (84 counts the `menubar_menu` sub-component row; the generator catalog itself is 83.)
 
 **Sibling templates to copy:** `alert` is the canonical Wave 1 reference. Copy its render test
 (`test/render/alert_render_test.rb`), template-backed preview, and — for 0b — its preview-host

--- a/docs/customization.md
+++ b/docs/customization.md
@@ -44,6 +44,18 @@ The `:root` block sets the default light theme. Override any variable there to c
 | `--ring` | Focus ring on interactive elements |
 | `--radius` | Base border radius (sm/md/lg/xl are derived from this) |
 
+### Sizing tokens
+
+| Token | Utility | Used by |
+|-------|---------|---------|
+| `--form-input-height` | `min-h-input` | The 44px form-control floor (WCAG 2.2 AAA target size): inputs, selects, buttons via `.btn-touch-target` |
+
+Write `min-h-input` in app code — it is registered in `@theme inline` and resolves to
+`var(--form-input-height)`. The two legacy spellings, `min-h-11` and
+`min-h-[var(--form-input-height)]`, resolve to the same 2.75rem today but are
+deprecated: with a single named token, changing the input height (or auditing the
+AAA invariant) has exactly one place to look.
+
 ### Colors use OKLCH
 
 OKLCH gives perceptually uniform brightness. The format is `oklch(L C H)`:

--- a/lib/generators/modelrails_ui/add/templates/command/command_component.rb.tt
+++ b/lib/generators/modelrails_ui/add/templates/command/command_component.rb.tt
@@ -155,7 +155,7 @@ module UI
     end
 
     def search_icon
-      raw('<svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" class="shrink-0 text-text-muted" aria-hidden="true"><circle cx="11" cy="11" r="8"/><path d="m21 21-4.3-4.3"/></svg>') # rubocop:disable Layout/LineLength
+      raw('<svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" class="shrink-0 text-text-muted" aria-hidden="true"><circle cx="11" cy="11" r="8"/><path d="m21 21-4.3-4.3"/></svg>')
     end
 
     # Fail loud on an unknown size in development/test so misuse is caught

--- a/lib/generators/modelrails_ui/add/templates/dropdown_menu/dropdown_menu_component.rb.tt
+++ b/lib/generators/modelrails_ui/add/templates/dropdown_menu/dropdown_menu_component.rb.tt
@@ -208,14 +208,12 @@ module UI
     # `position-area` cell + `position-try-fallbacks: flip-block` to stay on-screen) and
     # the pre-Baseline `absolute` fallback offsets. `span-right`/`span-left` edge-align the
     # menu to the trigger (unlike a tooltip, which centres). One line per placement.
-    # rubocop:disable Layout/LineLength
     PLACEMENTS = {
       bottom_start: "mt-1 supports-[position-area:bottom]:fixed supports-[position-area:bottom]:[position-area:bottom_span-right] supports-[position-area:bottom]:[position-try-fallbacks:flip-block] not-supports-[position-area:bottom]:absolute not-supports-[position-area:bottom]:top-full not-supports-[position-area:bottom]:left-0",
       bottom_end: "mt-1 supports-[position-area:bottom]:fixed supports-[position-area:bottom]:[position-area:bottom_span-left] supports-[position-area:bottom]:[position-try-fallbacks:flip-block] not-supports-[position-area:bottom]:absolute not-supports-[position-area:bottom]:top-full not-supports-[position-area:bottom]:right-0",
       top_start: "mb-1 supports-[position-area:bottom]:fixed supports-[position-area:bottom]:[position-area:top_span-right] supports-[position-area:bottom]:[position-try-fallbacks:flip-block] not-supports-[position-area:bottom]:absolute not-supports-[position-area:bottom]:bottom-full not-supports-[position-area:bottom]:left-0",
       top_end: "mb-1 supports-[position-area:bottom]:fixed supports-[position-area:bottom]:[position-area:top_span-left] supports-[position-area:bottom]:[position-try-fallbacks:flip-block] not-supports-[position-area:bottom]:absolute not-supports-[position-area:bottom]:bottom-full not-supports-[position-area:bottom]:right-0"
     }.freeze
-    # rubocop:enable Layout/LineLength
 
     # side:          :bottom | :top
     # align:         :start | :end (edge-aligned to the trigger)

--- a/lib/generators/modelrails_ui/add/templates/hover_card/hover_card_component.rb.tt
+++ b/lib/generators/modelrails_ui/add/templates/hover_card/hover_card_component.rb.tt
@@ -34,7 +34,6 @@ module UI
     # `position-area` value + `position-try-fallbacks` to keep it on-screen), and the
     # pre-Baseline `absolute` fallback offsets (`not-supports-`). A Tailwind class table —
     # one line per placement keeps it scannable.
-    # rubocop:disable Layout/LineLength
     POSITIONS = {
       bottom:       "mt-2 supports-[position-area:bottom]:fixed supports-[position-area:bottom]:[position-area:bottom_center] supports-[position-area:bottom]:[position-try-fallbacks:flip-block] not-supports-[position-area:bottom]:absolute not-supports-[position-area:bottom]:top-full not-supports-[position-area:bottom]:left-1/2 not-supports-[position-area:bottom]:-translate-x-1/2",
       top:          "mb-2 supports-[position-area:bottom]:fixed supports-[position-area:bottom]:[position-area:top_center] supports-[position-area:bottom]:[position-try-fallbacks:flip-block] not-supports-[position-area:bottom]:absolute not-supports-[position-area:bottom]:bottom-full not-supports-[position-area:bottom]:left-1/2 not-supports-[position-area:bottom]:-translate-x-1/2",
@@ -45,7 +44,6 @@ module UI
       bottom_left:  "mt-2 supports-[position-area:bottom]:fixed supports-[position-area:bottom]:[position-area:bottom_left] supports-[position-area:bottom]:[position-try-fallbacks:flip-block] not-supports-[position-area:bottom]:absolute not-supports-[position-area:bottom]:top-full not-supports-[position-area:bottom]:left-0",
       bottom_right: "mt-2 supports-[position-area:bottom]:fixed supports-[position-area:bottom]:[position-area:bottom_right] supports-[position-area:bottom]:[position-try-fallbacks:flip-block] not-supports-[position-area:bottom]:absolute not-supports-[position-area:bottom]:top-full not-supports-[position-area:bottom]:right-0"
     }.freeze
-    # rubocop:enable Layout/LineLength
 
     # id: card id; label: optional accessible name (→ role=group + aria-label);
     # side: edge :bottom | :top | :left | :right, or corner :top_left | :top_right | :bottom_left | :bottom_right

--- a/lib/generators/modelrails_ui/add/templates/menubar/menubar_menu_component.rb.tt
+++ b/lib/generators/modelrails_ui/add/templates/menubar/menubar_menu_component.rb.tt
@@ -41,9 +41,7 @@ module UI
 
     # Submenu panel — CSS anchor positioning (bottom_start, below the bar item, start-aligned,
     # flip-to-stay-on-screen), the same shape as dropdown_menu's bottom_start placement.
-    # rubocop:disable Layout/LineLength
     PANEL = "z-50 min-w-[12rem] overflow-hidden rounded-md border border-border bg-surface-overlay p-1 text-text-body shadow-md outline-none mt-1 supports-[position-area:bottom]:fixed supports-[position-area:bottom]:[position-area:bottom_span-right] supports-[position-area:bottom]:[position-try-fallbacks:flip-block] not-supports-[position-area:bottom]:absolute not-supports-[position-area:bottom]:top-full not-supports-[position-area:bottom]:left-0"
-    # rubocop:enable Layout/LineLength
 
     # Submenu item — identical to dropdown_menu's ITEM (focus-visible highlight + aria-disabled
     # treatment + SVG normalisation).

--- a/lib/generators/modelrails_ui/add/templates/navbar/navbar_component.rb.tt
+++ b/lib/generators/modelrails_ui/add/templates/navbar/navbar_component.rb.tt
@@ -34,9 +34,7 @@ module UI
       @html_attrs = html_attrs
     end
 
-    # rubocop:disable Layout/LineLength
     NAV = "sticky top-0 z-50 w-full border-b bg-surface-raised/95 backdrop-blur supports-[backdrop-filter]:bg-surface-raised/60"
-    # rubocop:enable Layout/LineLength
 
     def call
       caller_data = @html_attrs.delete(:data) || {}

--- a/lib/generators/modelrails_ui/add/templates/tabs/tabs_component.rb.tt
+++ b/lib/generators/modelrails_ui/add/templates/tabs/tabs_component.rb.tt
@@ -23,9 +23,7 @@ module UI
     renders_many :tabs, "UI::TabsItemComponent"
 
     TABLIST = "inline-flex h-9 items-center justify-center rounded-lg bg-surface-sunken p-1 text-text-muted"
-    # rubocop:disable Layout/LineLength
     TRIGGER = "inline-flex min-h-11 items-center justify-center whitespace-nowrap rounded-md px-3 py-1 text-sm font-medium transition-all focus-ring aria-disabled:pointer-events-none aria-disabled:opacity-50 data-[state=active]:bg-surface-raised data-[state=active]:text-text-heading data-[state=active]:shadow"
-    # rubocop:enable Layout/LineLength
     PANEL = "mt-2 focus-ring"
 
     ORIENTATIONS = %i[horizontal vertical].freeze

--- a/lib/generators/modelrails_ui/add/templates/tooltip/tooltip_component.rb.tt
+++ b/lib/generators/modelrails_ui/add/templates/tooltip/tooltip_component.rb.tt
@@ -40,7 +40,6 @@ module UI
     # pre-Baseline `absolute` fallback offsets (`not-supports-`). Corners fall back to a
     # corner-aligned edge on browsers without anchor positioning. A Tailwind class table —
     # one line per placement keeps it scannable.
-    # rubocop:disable Layout/LineLength
     POSITIONS = {
       top:          "mb-2 supports-[position-area:bottom]:fixed supports-[position-area:bottom]:[position-area:top_center] supports-[position-area:bottom]:[position-try-fallbacks:flip-block] not-supports-[position-area:bottom]:absolute not-supports-[position-area:bottom]:bottom-full not-supports-[position-area:bottom]:left-1/2 not-supports-[position-area:bottom]:-translate-x-1/2",
       bottom:       "mt-2 supports-[position-area:bottom]:fixed supports-[position-area:bottom]:[position-area:bottom_center] supports-[position-area:bottom]:[position-try-fallbacks:flip-block] not-supports-[position-area:bottom]:absolute not-supports-[position-area:bottom]:top-full not-supports-[position-area:bottom]:left-1/2 not-supports-[position-area:bottom]:-translate-x-1/2",
@@ -51,7 +50,6 @@ module UI
       bottom_left:  "mt-2 supports-[position-area:bottom]:fixed supports-[position-area:bottom]:[position-area:bottom_left] supports-[position-area:bottom]:[position-try-fallbacks:flip-block] not-supports-[position-area:bottom]:absolute not-supports-[position-area:bottom]:top-full not-supports-[position-area:bottom]:left-0",
       bottom_right: "mt-2 supports-[position-area:bottom]:fixed supports-[position-area:bottom]:[position-area:bottom_right] supports-[position-area:bottom]:[position-try-fallbacks:flip-block] not-supports-[position-area:bottom]:absolute not-supports-[position-area:bottom]:top-full not-supports-[position-area:bottom]:right-0"
     }.freeze
-    # rubocop:enable Layout/LineLength
 
     # Public API for the documented "describe an existing interactive control"
     # pattern (see "Don't use when"): callers build their own group/tooltip

--- a/lib/generators/modelrails_ui/components.rb
+++ b/lib/generators/modelrails_ui/components.rb
@@ -120,7 +120,8 @@ module ModelrailsUi
       # Install-status markers for components whose primary file is not
       # app/components/ui/<name>_component.rb (see primary_path below).
       PRIMARY_PATHS = {
-        "form_builder" => "app/form_builders/ui/form_builder.rb"
+        "form_builder" => "app/form_builders/ui/form_builder.rb",
+        "form_draft" => "app/views/shared/_form_draft_notice.html.erb"
       }.freeze
 
       # Components that hard-require sibling components at render time. The add

--- a/lib/generators/modelrails_ui/install/templates/modelrails_ui.css
+++ b/lib/generators/modelrails_ui/install/templates/modelrails_ui.css
@@ -379,6 +379,11 @@
   /* Modal */
   --modal-backdrop: var(--modal-backdrop);
   --modal-animation-duration: var(--modal-animation-duration);
+
+  /* Sizing — registers `min-h-input`: the named 44px form-control floor
+     (WCAG 2.2 AAA target size). Prefer it over `min-h-11` or
+     `min-h-[var(--form-input-height)]` so the invariant has ONE spelling. */
+  --min-height-input: var(--form-input-height);
 }
 
 /* ==========================================================================

--- a/test/test_component_status_ledger.rb
+++ b/test/test_component_status_ledger.rb
@@ -1,0 +1,51 @@
+# frozen_string_literal: true
+
+require "test_helper"
+require "generators/modelrails_ui/components"
+
+# COMPONENT_STATUS.md is human judgment (tier + notes), but its ROW SET is a
+# fact: one row per supported component. Drift accumulated because nothing
+# tied the two together (#133) — same spirit as the misfile invariants.
+class TestComponentStatusLedger < Minitest::Test
+  LEDGER = File.expand_path("../COMPONENT_STATUS.md", __dir__)
+
+  # Ledger rows that are deliberately NOT template directories: sub-components
+  # documented in their own row because they carry their own DoD evidence.
+  SUBCOMPONENT_ROWS = %w[menubar_menu].freeze
+
+  def rows
+    @rows ||= File.readlines(LEDGER)
+      .filter_map { |line| line[/\A\| ([a-z0-9_]+) \|/, 1] }
+  end
+
+  def supported
+    ModelrailsUi::Generators::Components.supported
+  end
+
+  def test_every_supported_component_has_a_ledger_row
+    missing = supported - rows
+
+    assert_empty missing, "Components.supported entries with no COMPONENT_STATUS.md row: #{missing.inspect}"
+  end
+
+  def test_every_ledger_row_is_a_supported_component_or_a_declared_subcomponent
+    unknown = rows - supported - SUBCOMPONENT_ROWS
+
+    assert_empty unknown, "COMPONENT_STATUS.md rows that are not supported components: #{unknown.inspect}"
+  end
+
+  def test_rows_are_unique
+    dupes = rows.tally.select { |_, n| n > 1 }.keys
+
+    assert_empty dupes, "duplicate COMPONENT_STATUS.md rows: #{dupes.inspect}"
+  end
+
+  def test_the_prose_component_count_matches_the_row_count
+    claims = File.read(LEDGER).scan(/all (\d+) components/).flatten.map(&:to_i)
+
+    claims.each do |claim|
+      assert_equal rows.size, claim,
+        "ledger prose claims 'all #{claim} components' but the table has #{rows.size} rows"
+    end
+  end
+end

--- a/test/test_generators_components_registry.rb
+++ b/test/test_generators_components_registry.rb
@@ -26,4 +26,34 @@ class TestGeneratorsComponentsRegistry < Minitest::Test
   ensure
     FileUtils.remove_entry(root)
   end
+
+  # form_draft ships no component class — its primary file is the view partial.
+  # Without a PRIMARY_PATHS entry, installed? falls back to a
+  # form_draft_component.rb that never exists and `modelrails_ui:list`
+  # misreports the component as not installed (#75).
+  def test_installed_detects_a_partial_only_component_by_its_partial
+    root = Dir.mktmpdir
+    full = File.join(root, "app/views/shared/_form_draft_notice.html.erb")
+    FileUtils.mkdir_p(File.dirname(full))
+    File.write(full, "<%# stub %>")
+
+    assert ModelrailsUi::Generators::Components.installed?("form_draft", root)
+  ensure
+    FileUtils.remove_entry(root)
+  end
+
+  # The inverse guard: every supported component's primary path must be a file
+  # the add generator actually creates — a component whose primary file can
+  # never exist is permanently "not installed" to `modelrails_ui:list`.
+  def test_every_primary_path_is_producible_from_a_shipped_template
+    templates = ModelrailsUi::Generators::Components::TEMPLATE_ROOT
+    ModelrailsUi::Generators::Components.supported.each do |component|
+      primary = File.basename(ModelrailsUi::Generators::Components.primary_path(component))
+      sources = Dir.children(File.join(templates, component))
+        .map { |f| f.delete_suffix(".tt") }
+
+      assert_includes sources, primary,
+        "#{component}: primary_path names #{primary}, but the template dir ships #{sources.inspect}"
+    end
+  end
 end

--- a/test/test_shared_rb_modules.rb
+++ b/test/test_shared_rb_modules.rb
@@ -45,4 +45,69 @@ class TestSharedRbModules < Minitest::Test
     assert_equal on_disk.sort, (on_disk & shared_sources).sort,
       "unclaimed non-component .rb.tt would be misfiled: #{(on_disk - shared_sources).inspect}"
   end
+
+  # Disjointness gate (#132): a source registered in BOTH registries would let
+  # SHARED_RB silently win in copy_template_file's .rb.tt arm, turning the
+  # NON_COMPONENT_RB entry into dead code while both misfile invariants stay
+  # green.
+  def test_shared_rb_and_non_component_rb_sources_are_disjoint
+    shared_sources = Components::SHARED_RB.values.flatten.map { |m| m.fetch(:source) }
+    overlap = shared_sources & Components::NON_COMPONENT_RB.keys
+
+    assert_empty overlap, "sources registered in both SHARED_RB and NON_COMPONENT_RB: #{overlap.inspect}"
+  end
+
+  # Multi-declarer idempotency rests on every declarer agreeing where a shared
+  # source lands; two dests for one source would make the second `add` write a
+  # second copy, and two sources sharing a dest would make it overwrite.
+  def test_shared_rb_source_to_dest_mapping_is_one_to_one
+    pairs = Components::SHARED_RB.values.flatten.map { |m| [m.fetch(:source), m.fetch(:dest)] }.uniq
+
+    pairs.group_by(&:first).each do |source, group|
+      assert_equal 1, group.size, "#{source} is declared with multiple dests: #{group.map(&:last).inspect}"
+    end
+    pairs.group_by(&:last).each do |dest, group|
+      assert_equal 1, group.size, "#{dest} is claimed by multiple sources: #{group.map(&:first).inspect}"
+    end
+  end
+end
+
+# The two-declarer sequence a real app hits: `add dialog` then `add sheet`.
+# Thor no-ops the shared chrome only when the second render is byte-identical —
+# an ERB drift between declarers would surface here as a conflict (#132). This
+# pins the assumption for SHARED_RB and, by the same mechanism, SHARED_JS.
+class TestSharedRbGeneratorIdempotency < Minitest::Test
+  Components = ModelrailsUi::Generators::Components
+  CHROME_DEST = Components::SHARED_RB.fetch("dialog")
+    .find { |m| m.fetch(:source) == "dialog/modal_chrome.rb.tt" }.fetch(:dest)
+
+  def run_add(component, root)
+    out = StringIO.new
+    # Empty stdin: a Thor conflict prompt must EOF-fail the test, never hang it.
+    $stdin = StringIO.new
+    orig_stdout, $stdout = $stdout, out
+    ModelrailsUi::Generators::AddGenerator.start([component], destination_root: root)
+    out.string
+  ensure
+    $stdout = orig_stdout
+    $stdin = STDIN
+  end
+
+  def test_add_dialog_then_add_sheet_no_ops_on_the_shared_chrome
+    root = Dir.mktmpdir
+    run_add("dialog", root)
+    chrome = File.join(root, CHROME_DEST)
+
+    assert_path_exists chrome
+    first = File.read(chrome)
+
+    second_output = run_add("sheet", root)
+
+    assert_equal first, File.read(chrome),
+      "second declarer rewrote the shared chrome — declarers render different content"
+    assert_match(/identical.*#{Regexp.escape(CHROME_DEST)}/o, second_output)
+    refute_match(/conflict/, second_output)
+  ensure
+    FileUtils.remove_entry(root)
+  end
 end

--- a/test/test_shipped_stylesheet_completeness.rb
+++ b/test/test_shipped_stylesheet_completeness.rb
@@ -63,4 +63,16 @@ class TestShippedStylesheetCompleteness < Minitest::Test
       forced-colors mode — both WCAG 2.4.7 failures. Use `@apply focus-ring`.
     MSG
   end
+
+  # The 44px form-control floor is a named token (#142): registering it in
+  # @theme inline gives consumers `min-h-input`, replacing the two legacy
+  # spellings (`min-h-11` and `min-h-[var(--form-input-height)]`) that let the
+  # AAA invariant drift apart. The token must reference --form-input-height,
+  # never restate the value.
+  def test_the_input_height_token_is_registered_as_a_theme_utility
+    theme_block = File.read(STYLESHEET)[/@theme inline \{.*?\n\}/m]
+
+    refute_nil theme_block, "no @theme inline block in the shipped stylesheet"
+    assert_includes theme_block, "--min-height-input: var(--form-input-height);"
+  end
 end

--- a/test/test_template_rubocop_directives.rb
+++ b/test/test_template_rubocop_directives.rb
@@ -1,0 +1,20 @@
+# frozen_string_literal: true
+
+require "test_helper"
+
+# `rubocop:enable Layout/LineLength` is a trap in shipped templates: the cop is
+# OFF under rubocop-rails-omakase, and an `enable` directive turns it back ON
+# for the rest of the HOST's file — surfacing unrelated long lines in every app
+# that generates the component (#111). Long Tailwind class strings need no
+# disable here; templates must ship none of these directives.
+class TestTemplateRubocopDirectives < Minitest::Test
+  TEMPLATES = File.expand_path("../lib/generators/modelrails_ui", __dir__)
+
+  def test_no_shipped_template_carries_a_line_length_directive
+    offenders = Dir.glob("#{TEMPLATES}/**/*.tt").select do |path|
+      File.read(path).include?("rubocop:disable Layout/LineLength")
+    end.map { |p| p.delete_prefix("#{TEMPLATES}/") }
+
+    assert_empty offenders, "templates shipping Layout/LineLength directives: #{offenders.inspect}"
+  end
+end


### PR DESCRIPTION
Five small independent fixes, one commit each.

Closes #75. Closes #133. Closes #132. Closes #111. Refs #142 (token + docs land here; the consumer migration sweep stays tracked on the issue).

- **#75 — `modelrails_ui:list` misreported form_draft.** `PRIMARY_PATHS` gains the `app/views/shared/_form_draft_notice.html.erb` entry so the partial-only component reports as installed. Plus an inverse guard test: every supported component's primary path must be producible from a shipped template (this is the test that would have caught the bug at introduction).
- **#133 — COMPONENT_STATUS.md reconciled + guard test.** Adds the missing `form_builder` and `error_summary` rows as `gem-0a-proven / app-0b-pending` (neither has app 0b proof — the Wave-2 forms promotion predates them, and base still routes through its TailwindFormBuilder adapter per handoff D1). Fixes the prose count and pins row-set == `Components.supported`, with `menubar_menu` declared as the one sub-component row.
- **#132 — SHARED_RB hardening.** Disjointness gate (SHARED_RB sources vs `NON_COMPONENT_RB` keys), one-to-one source↔dest mapping assertion, and a real two-declarer generator run: `add dialog` then `add sheet` must report `identical` on the shared chrome. Empty stdin makes a Thor conflict EOF-fail the test rather than hang; the drift path was exercised manually to confirm.
- **#111 — Layout/LineLength directives removed from all 7 templates.** The `enable` half re-activates a cop omakase turns off, surfacing unrelated long lines in every host file that generates these components. A guard test keeps them from returning.
- **#142 — `min-h-input` registered in `@theme inline`.** The named 44px form-control floor, resolving to `var(--form-input-height)`; docs/customization.md gains a Sizing tokens section deprecating the two legacy spellings. Migration off `min-h-11` / `min-h-[var(--form-input-height)]` is a separate sweep per the issue.