### PR TITLE
docs(previews): badge two-axis Examples, alert+indicator playgrounds, html_attrs + variants doc sync

### DIFF
--- a/docs/components/alert.md
+++ b/docs/components/alert.md
@@ -134,6 +134,7 @@ end
 | `role` | Symbol/String | `nil` | Override the tone's role (e.g. `:note` for persistent context); any override drops `aria-live` |
 | `title` | String | `nil` | Plain-text title, alternative to `with_alert_title` slot |
 | `description` | String | `nil` | Plain-text description, alternative to `with_alert_description` slot |
+| `**html_attrs` | Hash | — | Forwarded to the outer `<div>` (e.g. `data:` for Stimulus wiring, `id:`); `class:` merges via `cn` |
 
 | Slot | Required | Description |
 |------|----------|-------------|

--- a/docs/components/indicator.md
+++ b/docs/components/indicator.md
@@ -28,10 +28,11 @@ Creates `app/components/ui/indicator_component.rb`.
 
 | Variant | Colour |
 |---------|--------|
-| `default` | Primary |
-| `destructive` | Red |
+| `default` | Primary (interactive fill) |
+| `info` | Info blue |
 | `success` | Green |
-| `warning` | Yellow |
+| `warning` | Amber |
+| `danger` | Red (`destructive` is a non-breaking alias) |
 
 ## Positions
 
@@ -43,7 +44,7 @@ Creates `app/components/ui/indicator_component.rb`.
 | `bottom_left` | Bottom-left corner |
 
 ```erb
-<%= ui :indicator, variant: :destructive, position: :bottom_right do %>
+<%= ui :indicator, variant: :danger, position: :bottom_right do %>
   <%= ui :avatar, fallback: "Bob" %>
 <% end %>
 ```
@@ -53,6 +54,6 @@ Creates `app/components/ui/indicator_component.rb`.
 | Option | Type | Default | Description |
 |--------|------|---------|-------------|
 | `count` | Integer / nil | `nil` | When set, renders a numbered badge; otherwise renders a small dot |
-| `variant` | Symbol | `:default` | Colour — `:default`, `:destructive`, `:success`, `:warning` |
+| `variant` | Symbol | `:default` | Colour — `:default`, `:info`, `:success`, `:warning`, `:danger` (`:destructive` is a non-breaking alias for `:danger`) |
 | `position` | Symbol | `:top_right` | Corner — `:top_right`, `:top_left`, `:bottom_right`, `:bottom_left` |
 | `**html_attrs` | Hash | — | Forwarded to the outer wrapper `<span>` |

--- a/lib/generators/modelrails_ui/lookbook/templates/previews/ui/alert_component_preview.rb
+++ b/lib/generators/modelrails_ui/lookbook/templates/previews/ui/alert_component_preview.rb
@@ -66,6 +66,17 @@ module UI
 
     # @!group Reference
 
+    # Edit the tone and message live. `danger` announces assertively (role=alert);
+    # every other tone politely (role=status). `icon: false` suppresses the
+    # severity glyph.
+    # @param tone select [neutral, info, success, warning, danger]
+    # @param title text
+    # @param description text
+    # @param icon toggle
+    def playground(tone: :neutral, title: "Heads up", description: "Your trial ends in 3 days.", icon: true)
+      render_with_template(locals: {tone: tone.to_sym, title: title, description: description, icon: icon})
+    end
+
     # ## Don't — an empty alert
     #
     # An alert with no title and no description renders an empty live region —

--- a/lib/generators/modelrails_ui/lookbook/templates/previews/ui/alert_component_preview/playground.html.erb
+++ b/lib/generators/modelrails_ui/lookbook/templates/previews/ui/alert_component_preview/playground.html.erb
@@ -1,0 +1,2 @@
+<%# locals: (tone:, title:, description:, icon:) -%>
+<%= ui :alert, tone: tone, title: title.presence, description: description.presence, icon: icon %>

--- a/lib/generators/modelrails_ui/lookbook/templates/previews/ui/badge_component_preview.rb
+++ b/lib/generators/modelrails_ui/lookbook/templates/previews/ui/badge_component_preview.rb
@@ -20,11 +20,13 @@ module UI
   # - **You supply:** an accessible name when the badge conveys status not already in
   #   the surrounding text, and a valid `variant` (an unknown one raises in development).
   #
-  # ## Variants
-  # Signal levels: `info` · `success` · `warning` · `danger` (tinted chips —
-  # soft `*-surface` + saturated `text-<level>`, matching the alert + toast cards).
-  # Style levels: `default` · `secondary` · `outline` · `ghost` · `link`.
-  # (`destructive` is a non-breaking alias for `danger`.)
+  # ## Cells (variant × tone)
+  # Two-axis API: `variant:` (shape — `solid` · `soft` · `outline` · `ghost` · `link`)
+  # × `tone:` (signal — `primary` · `neutral` · `info` · `success` · `warning` ·
+  # `danger`). Only the 10 shipped cells render; signal tones live on the SOFT
+  # variant as tinted chips (soft `*-surface` + saturated `text-<level>`, matching
+  # the alert + toast cards). Legacy flat `variant:` values still render via a
+  # deprecation shim — write the two axes in new code.
   # @logical_path Feedback & Status
   class BadgeComponentPreview < ViewComponent::Preview
     include UIHelper
@@ -39,11 +41,11 @@ module UI
 
     # @!group Examples
 
-    # The default, high-emphasis label.
+    # The default, high-emphasis label — the `solid`/`primary` cell (a bare call).
     def default
     end
 
-    # Neutral / lower-emphasis label.
+    # Lower-emphasis label — the `soft`/`primary` cell (the legacy `secondary`).
     def secondary
     end
 
@@ -52,35 +54,37 @@ module UI
     def neutral
     end
 
-    # Informational signal — tinted info chip.
+    # Informational signal — the `soft`/`info` tinted chip.
     def info
     end
 
-    # Success / completed status — tinted success chip.
+    # Success / completed status — the `soft`/`success` tinted chip.
     def success
     end
 
-    # Warning status — tinted warning chip (soft amber surface + dark amber text).
+    # Warning status — the `soft`/`warning` tinted chip (soft amber surface + dark amber text).
     def warning
     end
 
-    # Error / removed / failed status — tinted danger chip; keeps a danger focus ring.
+    # Error / removed / failed status — the `soft`/`danger` tinted chip; keeps a danger focus ring.
     def danger
     end
 
-    # `variant: :destructive` is a non-breaking alias for `:danger`.
+    # The legacy-shim demo: historical flat values (here `variant: :destructive`)
+    # still resolve to their cell (`soft`/`danger`) byte-identically. New code
+    # writes the two axes.
     def destructive
     end
 
-    # Outlined label — a border with no fill.
+    # Outlined label — the `outline`/`neutral` cell, a border with no fill.
     def outline
     end
 
-    # Minimal label — no fill, no border; reveals a surface tint on hover when linked.
+    # Minimal label — the `ghost`/`neutral` cell; no fill, no border, surface tint on hover when linked.
     def ghost
     end
 
-    # Link-styled label — pair with `href:` for a clickable tag/filter.
+    # Link-styled label — the `link`/`primary` cell; pair with `href:` for a clickable tag/filter.
     def link
     end
 

--- a/lib/generators/modelrails_ui/lookbook/templates/previews/ui/badge_component_preview/danger.html.erb
+++ b/lib/generators/modelrails_ui/lookbook/templates/previews/ui/badge_component_preview/danger.html.erb
@@ -1,1 +1,1 @@
-<%= ui :badge, "Failed", variant: :danger %>
+<%= ui :badge, "Failed", variant: :soft, tone: :danger %>

--- a/lib/generators/modelrails_ui/lookbook/templates/previews/ui/badge_component_preview/dont_action.html.erb
+++ b/lib/generators/modelrails_ui/lookbook/templates/previews/ui/badge_component_preview/dont_action.html.erb
@@ -1,2 +1,2 @@
 <%# ✗ a bare badge is not interactive — use ui :button (or href: for navigation) %>
-<%= ui :badge, "Delete", variant: :destructive %>
+<%= ui :badge, "Delete", variant: :soft, tone: :danger %>

--- a/lib/generators/modelrails_ui/lookbook/templates/previews/ui/badge_component_preview/ghost.html.erb
+++ b/lib/generators/modelrails_ui/lookbook/templates/previews/ui/badge_component_preview/ghost.html.erb
@@ -1,1 +1,1 @@
-<%= ui :badge, "Archived", variant: :ghost %>
+<%= ui :badge, "Archived", variant: :ghost, tone: :neutral %>

--- a/lib/generators/modelrails_ui/lookbook/templates/previews/ui/badge_component_preview/info.html.erb
+++ b/lib/generators/modelrails_ui/lookbook/templates/previews/ui/badge_component_preview/info.html.erb
@@ -1,1 +1,1 @@
-<%= ui :badge, "Info", variant: :info %>
+<%= ui :badge, "Info", variant: :soft, tone: :info %>

--- a/lib/generators/modelrails_ui/lookbook/templates/previews/ui/badge_component_preview/link.html.erb
+++ b/lib/generators/modelrails_ui/lookbook/templates/previews/ui/badge_component_preview/link.html.erb
@@ -1,1 +1,1 @@
-<%= ui :badge, "Learn more", variant: :link %>
+<%= ui :badge, "Learn more", variant: :link, tone: :primary %>

--- a/lib/generators/modelrails_ui/lookbook/templates/previews/ui/badge_component_preview/link_href.html.erb
+++ b/lib/generators/modelrails_ui/lookbook/templates/previews/ui/badge_component_preview/link_href.html.erb
@@ -1,1 +1,1 @@
-<%= ui :badge, "Rails", href: "/tags/rails", variant: :secondary %>
+<%= ui :badge, "Rails", href: "/tags/rails", variant: :soft, tone: :primary %>

--- a/lib/generators/modelrails_ui/lookbook/templates/previews/ui/badge_component_preview/outline.html.erb
+++ b/lib/generators/modelrails_ui/lookbook/templates/previews/ui/badge_component_preview/outline.html.erb
@@ -1,1 +1,1 @@
-<%= ui :badge, "Beta", variant: :outline %>
+<%= ui :badge, "Beta", variant: :outline, tone: :neutral %>

--- a/lib/generators/modelrails_ui/lookbook/templates/previews/ui/badge_component_preview/secondary.html.erb
+++ b/lib/generators/modelrails_ui/lookbook/templates/previews/ui/badge_component_preview/secondary.html.erb
@@ -1,1 +1,1 @@
-<%= ui :badge, "Draft", variant: :secondary %>
+<%= ui :badge, "Draft", variant: :soft, tone: :primary %>

--- a/lib/generators/modelrails_ui/lookbook/templates/previews/ui/badge_component_preview/success.html.erb
+++ b/lib/generators/modelrails_ui/lookbook/templates/previews/ui/badge_component_preview/success.html.erb
@@ -1,1 +1,1 @@
-<%= ui :badge, "Active", variant: :success %>
+<%= ui :badge, "Active", variant: :soft, tone: :success %>

--- a/lib/generators/modelrails_ui/lookbook/templates/previews/ui/badge_component_preview/warning.html.erb
+++ b/lib/generators/modelrails_ui/lookbook/templates/previews/ui/badge_component_preview/warning.html.erb
@@ -1,1 +1,1 @@
-<%= ui :badge, "Pending", variant: :warning %>
+<%= ui :badge, "Pending", variant: :soft, tone: :warning %>

--- a/lib/generators/modelrails_ui/lookbook/templates/previews/ui/indicator_component_preview.rb
+++ b/lib/generators/modelrails_ui/lookbook/templates/previews/ui/indicator_component_preview.rb
@@ -43,6 +43,15 @@ module UI
 
     # @!group Reference
 
+    # Edit the variant, count, and corner live. A blank count renders the bare
+    # presence dot. (`destructive` is a non-breaking alias for `danger`.)
+    # @param variant select [default, info, success, warning, danger]
+    # @param count number
+    # @param position select [top_right, top_left, bottom_right, bottom_left]
+    def playground(variant: :default, count: 3, position: :top_right)
+      render_with_template(locals: {variant: variant.to_sym, count: count, position: position.to_sym})
+    end
+
     # ## Don't — color-only signal
     #
     # This destructive dot is the only thing conveying "error" — there's no text or

--- a/lib/generators/modelrails_ui/lookbook/templates/previews/ui/indicator_component_preview/playground.html.erb
+++ b/lib/generators/modelrails_ui/lookbook/templates/previews/ui/indicator_component_preview/playground.html.erb
@@ -1,0 +1,4 @@
+<%# locals: (variant:, count:, position:) -%>
+<%= ui :indicator, variant: variant, count: count.presence&.to_i, position: position do %>
+  <span class="inline-flex size-9 items-center justify-center rounded-md bg-surface-sunken text-text-body">A</span>
+<% end %>


### PR DESCRIPTION
Closes #154. Closes #19. Closes #138.

- **#154 — badge Examples demo the two-axis API.** All flat `variant:` scenarios rewritten to explicit `variant:`/`tone:` cells (mapping per the component's `SHIM`); the rewritten set covers all 10 shipped cells. `destructive` is kept as the single, labeled legacy-shim demo, and the preview docstrings now speak two-axis.
- **#19 — `@param` playgrounds for alert + indicator** (DoD item 10, the oldest open issue). Both follow the tooltip `render_with_template` pattern: alert exposes tone/title/description/icon, indicator exposes variant/count/position (blank count → bare presence dot, and the select includes the new `info` tone from #136).
- **#138 — alert's `**html_attrs` documented.** The passthrough already existed in the template; alert.md's API table now says so (same shape as the dropdown_menu row).
- **#136 follow-up — indicator.md synced** to the shipped 5-tone set (`default/info/success/warning/danger`, `destructive` as alias) in the Variants table, example, and API row.

Lookbook rendering itself isn't provable in this repo — after merge these previews deserve an eyeball in modelrails_base's Lookbook once regenerated there.