### PR TITLE
fix(menu-family): keyboard entry — menu ArrowUp guard, combobox zero-filter reopen

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- Menu-family keyboard entry, two live bugs: `menu` ArrowUp with no focused item (the panel's `tabindex="-1"` catches padding/separator clicks) now enters at the LAST item instead of silently landing on `items[n-2]` — the one navigation path still missing the entry guard `command`/`combobox` already carry; `combobox` ArrowDown/ArrowUp after Escape on a zero-match filter now reopens the listbox (entering at first/last per APG) instead of locking the keyboard out until a printable keystroke. Browser-lane tests pin both, plus an invariant example pinning that `command` stays closed on ArrowUp after Escape (its parity branch is deliberately unreachable).
+
 ## [0.13.0] - 2026-08-23
 
 ### Added

--- a/lib/generators/modelrails_ui/add/templates/combobox/combobox_controller.js
+++ b/lib/generators/modelrails_ui/add/templates/combobox/combobox_controller.js
@@ -52,11 +52,27 @@ export default class extends Controller {
   // focus stays on the input (combobox pattern), so selection is driven via
   // aria-activedescendant rather than moving focus onto options.
   navigate(event) {
-    const visible = this.optionTargets.filter(o => !o.hidden)
     if (event.key === "Escape") {
       this.close()
       return
     }
+
+    // Reopen handling runs BEFORE the visible set is computed: after Escape
+    // on a zero-match filter the stale option.hidden states would leave
+    // `visible` empty, and an early return here locked the keyboard out of
+    // ever reopening (only a printable keystroke recovered). open() re-runs
+    // filter() against the restored committed label; entry then follows APG —
+    // ArrowDown activates the FIRST visible option, ArrowUp the LAST.
+    if ((event.key === "ArrowDown" || event.key === "ArrowUp") && this.panelTarget.hidden) {
+      event.preventDefault()
+      this.open()
+      const reopened = this.optionTargets.filter(o => !o.hidden)
+      if (!reopened.length) return
+      this._setActive(event.key === "ArrowUp" ? reopened[reopened.length - 1] : reopened[0])
+      return
+    }
+
+    const visible = this.optionTargets.filter(o => !o.hidden)
     if (!visible.length) return
 
     const current = visible.findIndex(el => el.id === this.activeId)
@@ -64,12 +80,12 @@ export default class extends Controller {
 
     switch (event.key) {
       case "ArrowDown":
-        if (this.panelTarget.hidden) this.open()
         next = visible[(current + 1) % visible.length]
         break
       case "ArrowUp":
-        if (this.panelTarget.hidden) this.open()
-        next = visible[(current - 1 + visible.length) % visible.length]
+        // No active option (current === -1): APG says ArrowUp enters at the
+        // LAST option — the modulo alone lands one short of it.
+        next = current === -1 ? visible[visible.length - 1] : visible[(current - 1 + visible.length) % visible.length]
         break
       case "Home":
         next = visible[0]

--- a/lib/generators/modelrails_ui/add/templates/dropdown_menu/menu_controller.js
+++ b/lib/generators/modelrails_ui/add/templates/dropdown_menu/menu_controller.js
@@ -111,7 +111,12 @@ export default class extends Controller {
         break
       case "ArrowUp":
         event.preventDefault()
-        this.focusItem(items[(current - 1 + items.length) % items.length])
+        // No item focused (current === -1): the panel itself holds focus —
+        // its tabindex="-1" catches clicks on padding or a separator. APG says
+        // ArrowUp enters at the LAST item; the modulo alone lands one short
+        // of it. Same correction as combobox/command; typeAhead already
+        // guards -1 with Math.max — this was the one unguarded path.
+        this.focusItem(current === -1 ? items[items.length - 1] : items[(current - 1 + items.length) % items.length])
         break
       case "Home":
         event.preventDefault()

--- a/test/system/combobox_system_test.rb
+++ b/test/system/combobox_system_test.rb
@@ -51,6 +51,32 @@ class ComboboxSystemTest < BrowserTestCase
     assert_selector "[data-combobox-target=empty]"
   end
 
+  # Zero-match filter → Escape → ArrowUp must reopen, entering at the LAST
+  # option. close() leaves the zero-match hidden states in place, so with the
+  # reopen branch behind the empty-visible guard no key could ever reopen the
+  # listbox (aria-expanded stuck false; only a printable keystroke recovered).
+  def test_arrow_up_reopens_after_escape_from_a_zero_match_filter
+    visit_scenario("combobox/basic")
+    input.click
+    input.send_keys("zzzz")
+    press(:Escape)
+    press(:Up)
+
+    assert_selector "[role=option]", count: 3
+    assert_equal "Mexico", find("##{input["aria-activedescendant"]}").text
+  end
+
+  def test_arrow_down_reopens_after_escape_from_a_zero_match_filter_at_the_first_option
+    visit_scenario("combobox/basic")
+    input.click
+    input.send_keys("zzzz")
+    press(:Escape)
+    press(:Down)
+
+    assert_selector "[role=option]", count: 3
+    assert_equal "United States", find("##{input["aria-activedescendant"]}").text
+  end
+
   # aria-activedescendant must name a real element — a stale or absent id silently breaks
   # the announcement while looking fine in the DOM.
   def test_arrow_down_points_activedescendant_at_a_real_option

--- a/test/system/command_system_test.rb
+++ b/test/system/command_system_test.rb
@@ -36,6 +36,21 @@ class CommandSystemTest < BrowserTestCase
   def search(query) = find("[data-command-target=input]").set(query)
   def visible_items = page.all("[data-command-value]:not([hidden])").map(&:text)
 
+  # Invariant pin for navigate's entry-parity branch: the palette's input lives
+  # INSIDE the panel, so once Escape closes it no keyboard path reaches
+  # navigate — ArrowUp must NOT reopen. If a refactor ever routes keys to the
+  # controller while closed (the combobox reopen shape), this turns that
+  # parity branch live and this example catches the contract change.
+  def test_stays_closed_on_arrow_up_after_escape
+    press(:Escape)
+
+    assert_no_selector "[data-command-target=input]"
+
+    press(:Up)
+
+    assert_no_selector "[data-command-target=input]"
+  end
+
   def test_matches_a_subsequence_that_is_not_a_substring
     search("nd")
 

--- a/test/system/dropdown_menu_system_test.rb
+++ b/test/system/dropdown_menu_system_test.rb
@@ -47,6 +47,18 @@ class DropdownMenuSystemTest < BrowserTestCase
     assert_equal "Share", page.evaluate_script("document.activeElement.textContent.trim()")
   end
 
+  # The panel carries tabindex="-1", so clicking its padding or a separator
+  # focuses the PANEL — no item is active and indexOf(activeElement) is -1.
+  # APG: ArrowUp from that state enters at the LAST item; the unguarded modulo
+  # landed on items[n-2], silently skipping the last item. (Focus set via JS —
+  # deterministic stand-in for a padding click, same activeElement state.)
+  def test_arrow_up_with_focus_on_the_panel_enters_at_the_last_item
+    page.execute_script("document.querySelector('[data-menu-target=menu]').focus()")
+    press(:Up)
+
+    assert_equal "Share", page.evaluate_script("document.activeElement.textContent.trim()")
+  end
+
   def test_submenu_opens_on_arrow_right
     press(:Down)
     press(:Right)


### PR DESCRIPTION
Fixes the two live keyboard-entry bugs the modelrails_base panel filed as base#677 — both gem-canonical:

1. **menu ArrowUp with no focused item** — the panel's `tabindex="-1"` catches clicks on padding or a separator, so `items.indexOf(document.activeElement)` is `-1` and the unguarded modulo lands on `items[n-2]`, silently skipping the last item. Now enters at the LAST item (APG), the same correction `command`/`combobox` already carry; `typeAhead` already guarded `-1` — `navigate` was the one unguarded path. Inherited by dropdown_menu/context_menu/menubar_menu.
2. **combobox zero-filter Escape lockout** — `close()` leaves zero-match `option.hidden` states in place and the reopen branch sat behind the empty-visible guard, so after Escape no key could ever reopen the listbox (only a printable keystroke recovered). Reopen handling now runs BEFORE the visible-set computation: `open()` re-runs `filter()` against the restored committed label, ArrowDown enters at the first option, ArrowUp at the last. The in-switch ArrowUp also gains the entry guard this template was missing (the vendored base copy already had it — divergence healed).

Browser-lane tests: RED-first examples for both bugs (verified failing against the pre-fix templates via stash), plus the invariant example pinning that `command` stays closed on ArrowUp after Escape — its parity branch is deliberately unreachable, and this example catches any refactor that turns it live.

Full suite: structural 562 + render 1030 + system 63 runs, 0 failures; rubocop clean.