### PR TITLE
fix(switch): off-state presence — bordered unchecked track, shadowed thumb

### DIFF
--- a/lib/generators/modelrails_ui/add/templates/switch/switch_component.rb.tt
+++ b/lib/generators/modelrails_ui/add/templates/switch/switch_component.rb.tt
@@ -43,13 +43,18 @@ module UI
     # `focus-ring` bakes `:focus-visible` into its own selector and can't be peer-projected,
     # so we emit the same `outline: 2px solid var(--color-interactive-focus)` via an arbitrary
     # property under `peer-focus-visible:` (a utility class here would be a phantom — no CSS).
-    TRACK   = "pointer-events-none absolute inset-0 rounded-full border border-transparent shadow-xs " \
-              "transition-all bg-surface-sunken peer-checked:bg-interactive " \
+    # Off-state presence: bg-surface-sunken barely separates from a raised
+    # card in either theme, so the unchecked track carries a real border
+    # (transparent again once checked — the interactive fill needs no edge).
+    TRACK   = "pointer-events-none absolute inset-0 rounded-full border border-border-strong shadow-xs " \
+              "transition-all bg-surface-sunken peer-checked:bg-interactive peer-checked:border-transparent " \
               "peer-focus-visible:[outline:2px_solid_var(--color-interactive-focus)] peer-focus-visible:[outline-offset:2px] " \
               "peer-aria-invalid:ring-2 peer-aria-invalid:ring-danger " \
               "peer-disabled:opacity-50"
+    # shadow-sm: the thumb is the card's own surface color, so without an
+    # edge it vanishes against the unchecked track in both themes.
     THUMB   = "pointer-events-none absolute inset-y-0 left-px my-auto z-10 block size-4 rounded-full " \
-              "bg-surface-raised ring-0 transition-transform " \
+              "bg-surface-raised shadow-sm ring-0 transition-transform " \
               "translate-x-0 peer-checked:translate-x-[calc(100%-2px)]"
 
     def initialize(label: nil, checked: false, invalid: false, describedby: nil, **html_attrs)


### PR DESCRIPTION
Host-app browser review (modelrails_base #788) caught unchecked switches rendering as barely-visible ovals in BOTH themes: the track's `bg-surface-sunken` barely separates from a raised card, its border was transparent, and the thumb — `bg-surface-raised`, the card's own color — had no edge at all.

Fix: the unchecked track carries `border-border-strong` (returning to transparent when checked — the interactive fill needs no edge), and the thumb gains `shadow-sm`. Before/after screenshots in the host PR.

Full suite: structural 562 + render 1030 + system 63, 0 failures; rubocop clean.