### PR TITLE
fix(form_builder): tolerate object-less forms — error surfaces guard with respond_to?

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- FormBuilder tolerates object-less forms (`form_with url:` sets the builder's object to FALSE, which survives safe navigation): `error_for` and `error_summary` guard with `respond_to?(:errors)`, so enhanced helpers render on model-less forms instead of raising. (#163)
+
 ## [0.13.1] - 2026-08-23
 
 ### Fixed

--- a/lib/generators/modelrails_ui/add/templates/form_builder/form_builder.rb.tt
+++ b/lib/generators/modelrails_ui/add/templates/form_builder/form_builder.rb.tt
@@ -190,7 +190,9 @@ module UI
     # surface (and the announcement mechanism; see its header). The shim adds
     # what only the builder knows: each error's field anchor via field_id.
     def error_summary(options = {})
-      return if object.nil? || object.errors.empty?
+      # respond_to? guard: an object-less builder (form_with url: sets object
+      # to FALSE) has no errors surface — the summary is simply absent.
+      return unless object.respond_to?(:errors) && object.errors.any?
 
       options = options.dup
       # Anchors are DERIVED default ids (Rails' field_id) — the summary renders
@@ -317,7 +319,11 @@ module UI
     end
 
     def error_for(method)
-      object&.errors&.[](method)&.first
+      # respond_to?, not `&.`: form_with without a model sets object to FALSE
+      # (not nil), which survives safe navigation and then raises on .errors.
+      return nil unless object.respond_to?(:errors)
+
+      object.errors[method]&.first
     end
 
     # Matches the wording ErrorSummary's full_messages use, so the name a user

--- a/test/render/form_builder_render_test.rb
+++ b/test/render/form_builder_render_test.rb
@@ -48,6 +48,20 @@ class FormBuilderRenderTest < ViewComponent::TestCase
 
   # -- wrapped field wiring ---------------------------------------------------
 
+  # An object-less builder (form_with url: — Rails sets object to FALSE, not
+  # nil, so `object&.` does not short-circuit) must render every enhanced
+  # helper without raising: error state is simply absent.
+  def test_objectless_builder_renders_enhanced_helpers_without_raising
+    b = builder(false, object_name: :prefs)
+    html = b.select(:retention, [["30 days", 30]], {label: "Retention"})
+    doc = Nokogiri::HTML4.fragment(html.to_s)
+    assert doc.at_css("select.ui-select"), "select should render for an object-less builder"
+    assert doc.at_css("label"), "label should render for an object-less builder"
+
+    summary = b.error_summary
+    assert_nil summary, "error_summary must be a no-op with no errors object"
+  end
+
   def test_text_field_binds_label_control_and_id_together
     page = page_for(builder.text_field(:title))
 

--- a/test/render/form_builder_render_test.rb
+++ b/test/render/form_builder_render_test.rb
@@ -55,10 +55,12 @@ class FormBuilderRenderTest < ViewComponent::TestCase
     b = builder(false, object_name: :prefs)
     html = b.select(:retention, [["30 days", 30]], {label: "Retention"})
     doc = Nokogiri::HTML4.fragment(html.to_s)
+
     assert doc.at_css("select.ui-select"), "select should render for an object-less builder"
     assert doc.at_css("label"), "label should render for an object-less builder"
 
     summary = b.error_summary
+
     assert_nil summary, "error_summary must be a no-op with no errors object"
   end
 


### PR DESCRIPTION
Found during base #732's W2-C adoption: converting a raw `<select>` inside `form_with url:` (no model) to the enhanced `f.select` raised `NoMethodError: undefined method 'errors' for false` — Rails sets an object-less builder's object to **false**, not nil, so `object&.errors` does not short-circuit.

`error_for` and `error_summary` now guard with `respond_to?(:errors)`; enhanced helpers render on model-less forms with the error surface simply absent. RED-first render test (object-less `select` + `error_summary` no-op).

Full suite: 49-test builder lane green; structural + render + system 0 failures; rubocop clean.