### PR TITLE
fix(dialog): restore focus on disconnect and guard a detached opener

### DIFF
--- a/lib/generators/modelrails_ui/add/templates/dialog/modal_controller.js
+++ b/lib/generators/modelrails_ui/add/templates/dialog/modal_controller.js
@@ -38,7 +38,11 @@ export default class extends Controller {
     }
 
     if (this.dialogTarget.open) {
+      // A dialog torn out of the DOM while open (Turbo replaced the page or a
+      // stream removed the row) closes with NO native focus restore — restore
+      // explicitly or focus silently lands on <body>.
       this.dialogTarget.close()
+      this.restoreFocus()
     }
   }
 
@@ -58,9 +62,20 @@ export default class extends Controller {
       if (this.dialogTarget.open) {
         this.dialogTarget.close()
       }
-      this.previouslyFocused?.focus()
-      this.previouslyFocused = null
+      this.restoreFocus()
     })
+  }
+
+  // Focus the opener again — unless it left the DOM while the dialog was open
+  // (a detached node's focus() is a silent no-op and focus falls to <body>, a
+  // 2.4.3 loss). Fall back to the page's stable focus anchor: the skip-link
+  // <main tabindex="-1"> every host layout carries.
+  restoreFocus() {
+    const target = this.previouslyFocused?.isConnected
+      ? this.previouslyFocused
+      : document.querySelector('main[tabindex="-1"]')
+    target?.focus()
+    this.previouslyFocused = null
   }
 
   handleEscOnPage() {

--- a/test/system/dialog_system_test.rb
+++ b/test/system/dialog_system_test.rb
@@ -67,3 +67,64 @@ class DialogSystemTest < BrowserTestCase
     assert_no_stimulus_errors
   end
 end
+
+# One dialog whose opener can be detached while it is open — the list-page
+# reality (a Turbo Stream removes the row whose button opened the confirm).
+BrowserHarness.scenario("dialog/focus_restore", controllers: %w[modal]) do
+  view = ActionController::Base.new.view_context
+  before = view.tag.button("Before", id: "before-btn", type: "button")
+  dialog = view.tag.div(id: "opener-wrap") do
+    UI::DialogComponent.new(title: "Confirm", id: "focus-dialog").render_in(view) do |c|
+      c.with_trigger { "Open" }
+      view.tag.p("Body")
+    end
+  end
+  before + dialog
+end
+
+# `close()` restored focus with `previouslyFocused?.focus()` — a DETACHED node's
+# focus() is a silent no-op, so focus fell to <body> (a 2.4.3 loss). And
+# `disconnect()` closed the dialog with no restore at all. Both paths now fall
+# back to the page's stable focus anchor, `main[tabindex="-1"]` (the skip-link
+# target every host layout carries).
+class DialogFocusRestoreSystemTest < BrowserTestCase
+  def setup
+    super
+    visit_scenario("dialog/focus_restore")
+    page.execute_script(%(document.querySelector("main").setAttribute("tabindex", "-1")))
+    # Focus a real element, then open via a SCRIPT click (which moves no focus)
+    # so previouslyFocused is deterministically #before-btn.
+    page.execute_script(%(document.getElementById("before-btn").focus()))
+    page.execute_script(%(document.querySelector("[data-action='click->modal#open']").click()))
+    find("dialog[open]")
+  end
+
+  def focused = page.evaluate_script("document.activeElement.id || document.activeElement.tagName")
+
+  def test_close_restores_focus_to_the_opener_when_it_is_still_attached
+    page.driver.browser.keyboard.type(:escape)
+
+    assert_no_selector "dialog[open]"
+    assert_equal "before-btn", focused
+  end
+
+  def test_close_falls_back_to_main_when_the_previously_focused_element_left_the_dom
+    page.execute_script(%(document.getElementById("before-btn").remove()))
+    page.driver.browser.keyboard.type(:escape)
+
+    assert_no_selector "dialog[open]"
+    # The restore rides the close animation's callback — wait on :focus.
+    assert_selector "main:focus"
+  end
+
+  def test_disconnect_falls_back_to_main_instead_of_dropping_focus
+    page.execute_script(%(document.getElementById("before-btn").remove()))
+    page.execute_script(%(document.getElementById("opener-wrap").remove()))
+
+    assert_no_selector "dialog[open]", visible: :all
+    # activeElement, not :focus — this path is script-driven end to end, so the
+    # page never receives real input and document.hasFocus() (which :focus
+    # requires) stays false under CDP.
+    assert_equal "MAIN", focused
+  end
+end


### PR DESCRIPTION
close() restored focus with `previouslyFocused?.focus()` — a **detached** node's `focus()` is a silent no-op, so focus fell to `<body>` (WCAG 2.4.3) whenever the opener left the DOM while the dialog was open (e.g. a Turbo Stream removing the row whose button opened the confirm). `disconnect()` closed the dialog with no restore at all.

Both paths now share `restoreFocus()`: the opener when still connected, else the page's stable focus anchor — the skip-link `main[tabindex="-1"]` every host layout carries (a missing anchor degrades to today's behavior).

Browser-lane tests cover all three paths: attached restore, detached fallback on close, and the disconnect restore. Written RED-first against main.

Found by modelrails_base #685 (panel review 2026-08-18); base syncs the vendored copy in its W2-G PR.