### PR TITLE
fix(command): neutralize caller <hr> in the listbox; ArrowUp entry parity

### DIFF
--- a/lib/generators/modelrails_ui/add/templates/command/command_controller.js
+++ b/lib/generators/modelrails_ui/add/templates/command/command_controller.js
@@ -121,7 +121,13 @@ export default class extends Controller {
         next = visible[(current + 1) % visible.length]
         break
       case "ArrowUp":
-        next = visible[(current - 1 + visible.length) % visible.length]
+        // With no active option (current === -1) the modulo lands one short of
+        // the last item. combobox_controller carries the same correction — the
+        // pair is kept identical deliberately. Not keyboard-reachable here
+        // today (filter() re-seeds the active option on every open and input,
+        // and the input lives inside the panel), so this is parity, not a live
+        // bug; test_stays_closed_on_arrow_up_after_escape pins that entry path.
+        next = current === -1 ? visible[visible.length - 1] : visible[(current - 1 + visible.length) % visible.length]
         break
       case "Home":
         next = visible[0]
@@ -163,6 +169,15 @@ export default class extends Controller {
     this.options.forEach(item => {
       item.setAttribute("role", "option")
       if (!item.id) item.id = `${this._idPrefix}-option-${this._optionId++}`
+    })
+
+    // An <hr> separator's implicit role="separator" is an illegal child of
+    // role="listbox" (axe aria-required-children, critical). SEPARATOR and the
+    // docs example both hand callers exactly this markup, so the contract is
+    // applied here — where markup cannot break it — rather than asked for.
+    this.listTarget.querySelectorAll("hr").forEach(hr => {
+      hr.setAttribute("role", "presentation")
+      hr.setAttribute("aria-hidden", "true")
     })
   }
 

--- a/test/system/command_system_test.rb
+++ b/test/system/command_system_test.rb
@@ -23,6 +23,30 @@ BrowserHarness.scenario("command/fuzzy", controllers: %w[command], modules: %w[s
   end
 end
 
+# Mirrors the documented separator example (docs/components/command.md): a plain
+# <hr> between groups, inside the role="listbox". An <hr>'s implicit
+# role="separator" is an illegal listbox child (axe aria-required-children,
+# critical), so the controller must neutralize caller-supplied rules.
+BrowserHarness.scenario("command/separator", controllers: %w[command], modules: %w[search/command_score]) do
+  view = ActionController::Base.new.view_context
+  item = ->(value) do
+    view.tag.button(value, type: "button", class: UI::CommandComponent::ITEM,
+      data: {command_value: value})
+  end
+  group = ->(*items) do
+    view.tag.div(view.safe_join(items), class: UI::CommandComponent::GROUP_WRAPPER,
+      data: {command_group: true})
+  end
+  UI::CommandComponent.new.render_in(view) do |c|
+    c.with_trigger { "Open" }
+    view.safe_join([
+      group.call(item.call("Groups")),
+      view.tag.hr(class: UI::CommandComponent::SEPARATOR),
+      group.call(item.call("New document"))
+    ])
+  end
+end
+
 # Ranking only exists at runtime — the render lane sees the authored order and nothing else.
 class CommandSystemTest < BrowserTestCase
   def setup
@@ -78,5 +102,18 @@ class CommandSystemTest < BrowserTestCase
     search("nd")
 
     assert_no_stimulus_errors
+  end
+
+  # A caller-supplied <hr> — the shape the component's own SEPARATOR constant and
+  # docs example instruct — must not reach the a11y tree as a listbox child.
+  def test_a_caller_supplied_separator_is_not_an_illegal_listbox_child
+    visit_scenario("command/separator")
+    find("[data-action='click->command#open']").click
+    find("[data-command-target=input]")
+
+    rule = find("hr", visible: :all)
+
+    assert_equal "presentation", rule[:role]
+    assert_equal "true", rule["aria-hidden"]
   end
 end


### PR DESCRIPTION
Closes #167.

## Why

Diffing a consuming app's vendored menu-family controllers against these templates turned up drift running the *wrong* direction — the consumer was ahead. `menu`, `menubar`, and `combobox` differ only in comment text; `command` was behind by two real fixes that never came back upstream.

## 1. `<hr>` is an illegal child of `role="listbox"`

An `<hr>`'s implicit `role="separator"` violates `aria-required-children` — axe severity **critical**.

The sharp part: this component *invites* the markup. `SEPARATOR` is an exposed constant, its comment says "use a plain `<hr>` tag", and `docs/components/command.md:31` shows exactly that inside the list. Anyone following the docs got the violation.

So the fix goes in `_tagOptions()`, where caller markup cannot break the contract, rather than becoming a docs caveat that says "but not like that."

## 2. ArrowUp entry parity with combobox

With no active option, the modulo landed one short of the last item. `combobox_controller` already carries the correction; `command` didn't.

Honestly scoped: **not a live bug here.** `filter()` re-seeds the active option on every open and input, and the input lives inside the panel — `test_stays_closed_on_arrow_up_after_escape` pins that entry path as unreachable. This is parity, and it matters because #168 extracts this exact pair into a shared primitive. Extracting across a known divergence would bake the divergence in.

## Test

One system test, built from the documented separator example. Verified **red first** — `role` came back `nil`, confirming the `<hr>` reached the a11y tree as an implicit separator — then green.

## Verification

- `rake test`: 562 + 1031 + 67 runs, **0 failures** across all three lanes
- `rubocop`: 237 files, no offenses
- Comment-stripped diff against the consumer's vendored copy: **code identical**, so the semantic drift is closed. Comments intentionally differ — gem comments shouldn't cite a consumer's issue numbers.

## Follow-on

Unblocks #168 (shared keyboard primitive for the two duplicated pairs).