### PR TITLE
refactor(keyboard): one shared movement module for the menu family

### DIFF
--- a/lib/generators/modelrails_ui/add/templates/combobox/combobox_controller.js
+++ b/lib/generators/modelrails_ui/add/templates/combobox/combobox_controller.js
@@ -1,4 +1,5 @@
 import { Controller } from "@hotwired/stimulus"
+import { nextActive } from "keyboard/keyboard_nav"
 import * as topLayer from "overlays/top_layer"
 
 // Autocomplete-select behavior. Owns the WAI-ARIA APG combobox + listbox
@@ -80,18 +81,10 @@ export default class extends Controller {
 
     switch (event.key) {
       case "ArrowDown":
-        next = visible[(current + 1) % visible.length]
-        break
       case "ArrowUp":
-        // No active option (current === -1): APG says ArrowUp enters at the
-        // LAST option — the modulo alone lands one short of it.
-        next = current === -1 ? visible[visible.length - 1] : visible[(current - 1 + visible.length) % visible.length]
-        break
       case "Home":
-        next = visible[0]
-        break
       case "End":
-        next = visible[visible.length - 1]
+        next = nextActive(visible, current, event.key)
         break
       case "Enter": {
         const active = visible[current]

--- a/lib/generators/modelrails_ui/add/templates/command/command_controller.js
+++ b/lib/generators/modelrails_ui/add/templates/command/command_controller.js
@@ -1,4 +1,5 @@
 import { Controller } from "@hotwired/stimulus"
+import { nextActive } from "keyboard/keyboard_nav"
 import { commandScore } from "search/command_score"
 
 // Command palette behavior. Owns the WAI-ARIA APG combobox + listbox contract:
@@ -118,22 +119,14 @@ export default class extends Controller {
 
     switch (event.key) {
       case "ArrowDown":
-        next = visible[(current + 1) % visible.length]
-        break
       case "ArrowUp":
-        // With no active option (current === -1) the modulo lands one short of
-        // the last item. combobox_controller carries the same correction — the
-        // pair is kept identical deliberately. Not keyboard-reachable here
-        // today (filter() re-seeds the active option on every open and input,
-        // and the input lives inside the panel), so this is parity, not a live
-        // bug; test_stays_closed_on_arrow_up_after_escape pins that entry path.
-        next = current === -1 ? visible[visible.length - 1] : visible[(current - 1 + visible.length) % visible.length]
-        break
       case "Home":
-        next = visible[0]
-        break
       case "End":
-        next = visible[visible.length - 1]
+        // ArrowUp's no-active-option entry is parity with combobox, not a live path
+        // here: filter() re-seeds the active option on every open and input, and the
+        // input lives inside the panel. test_stays_closed_on_arrow_up_after_escape
+        // pins that. Sharing the movement keeps the pair from drifting again.
+        next = nextActive(visible, current, event.key)
         break
       case "Enter": {
         const active = visible[current]

--- a/lib/generators/modelrails_ui/add/templates/dropdown_menu/keyboard_nav.js
+++ b/lib/generators/modelrails_ui/add/templates/dropdown_menu/keyboard_nav.js
@@ -1,0 +1,75 @@
+// Keyboard movement shared by the menu family.
+//
+// Two algorithms were duplicated across four controllers, and one bug had to be
+// fixed in three of the copies before it was — the ArrowUp entry correction
+// reached menu and combobox but not command. Both are pure movement: they answer
+// "which item is next", and never touch focus, aria, or DOM. Each controller keeps
+// its own focus mechanics, which is where the four genuinely differ.
+//
+// Deliberately NOT here: menubar's ←/→ bar navigation. It coordinates co-indexed
+// itemTargets and menuOutlets, so it cannot be engine configuration.
+
+// Type-ahead buffer with the APG idle reset. Holds only the buffer; the caller
+// owns the item collection and how a match gets focused.
+export class TypeAhead {
+  constructor(resetAfter = 1000) {
+    this.buffer = ""
+    this.resetAfter = resetAfter
+    this._timer = null
+  }
+
+  push(char) {
+    this.buffer += char.toLowerCase()
+    if (this._timer) clearTimeout(this._timer)
+    this._timer = setTimeout(() => { this.buffer = "" }, this.resetAfter)
+    return this.buffer
+  }
+
+  // Controllers clear the idle timer on disconnect; a live timeout would fire into
+  // a torn-down controller.
+  cancel() {
+    if (this._timer) clearTimeout(this._timer)
+    this._timer = null
+    this.buffer = ""
+  }
+
+  // Index of the next item whose text starts with the buffer, scanning forward
+  // from `from` and wrapping; -1 when nothing matches.
+  //
+  // `skip` exists because the two callers filter differently and both shapes must
+  // survive: menu pre-filters into enabledItems and passes no skip, while menubar
+  // scans itemTargets unfiltered — its indices are co-indexed with menuOutlets, so
+  // it cannot filter first — and skips inline.
+  match(items, from, {skip = null} = {}) {
+    for (let n = 1; n <= items.length; n++) {
+      const i = (from + n) % items.length
+      const item = items[i]
+      if (skip && skip(item)) continue
+      if (item.textContent.trim().toLowerCase().startsWith(this.buffer)) return i
+    }
+    return -1
+  }
+}
+
+// Next active option for an aria-activedescendant listbox, given the visible set
+// and the index of the current one (-1 when none is active). Returns null for keys
+// that do not move.
+//
+// The ArrowUp branch is the one that shipped wrong: with nothing active, the
+// modulo alone lands one short of the last option. APG says enter at the END.
+export function nextActive(items, current, key) {
+  if (!items.length) return null
+
+  switch (key) {
+    case "ArrowDown":
+      return items[(current + 1) % items.length]
+    case "ArrowUp":
+      return current === -1 ? items[items.length - 1] : items[(current - 1 + items.length) % items.length]
+    case "Home":
+      return items[0]
+    case "End":
+      return items[items.length - 1]
+    default:
+      return null
+  }
+}

--- a/lib/generators/modelrails_ui/add/templates/dropdown_menu/menu_controller.js
+++ b/lib/generators/modelrails_ui/add/templates/dropdown_menu/menu_controller.js
@@ -1,4 +1,5 @@
 import { Controller } from "@hotwired/stimulus"
+import { TypeAhead } from "keyboard/keyboard_nav"
 import * as topLayer from "overlays/top_layer"
 
 // Behavior for the menu-pattern band. dropdown_menu is the exemplar/home; context_menu
@@ -13,12 +14,11 @@ export default class extends Controller {
   static values = { open: { type: Boolean, default: false } }
 
   connect() {
-    this.typeBuffer = ""
-    this.typeTimer = null
+    this._typeAhead = new TypeAhead()
   }
 
   disconnect() {
-    if (this.typeTimer) clearTimeout(this.typeTimer)
+    this._typeAhead.cancel()
   }
 
   // --- open / close -------------------------------------------------------
@@ -144,19 +144,12 @@ export default class extends Controller {
   }
 
   typeAhead(char) {
-    this.typeBuffer += char.toLowerCase()
-    if (this.typeTimer) clearTimeout(this.typeTimer)
-    this.typeTimer = setTimeout(() => { this.typeBuffer = "" }, 1000)
+    this._typeAhead.push(char)
 
+    // Pre-filtered: menu focuses by element, so disabled items can leave the set.
     const items = this.enabledItems
-    const start = Math.max(0, items.indexOf(document.activeElement))
-    for (let n = 1; n <= items.length; n++) {
-      const item = items[(start + n) % items.length]
-      if (item.textContent.trim().toLowerCase().startsWith(this.typeBuffer)) {
-        this.focusItem(item)
-        return
-      }
-    }
+    const i = this._typeAhead.match(items, Math.max(0, items.indexOf(document.activeElement)))
+    if (i !== -1) this.focusItem(items[i])
   }
 
   // --- activation ---------------------------------------------------------

--- a/lib/generators/modelrails_ui/add/templates/menubar/menubar_controller.js
+++ b/lib/generators/modelrails_ui/add/templates/menubar/menubar_controller.js
@@ -1,4 +1,5 @@
 import { Controller } from "@hotwired/stimulus"
+import { TypeAhead } from "keyboard/keyboard_nav"
 
 // Coordinator for the WAI-ARIA APG menubar. Each menubar item's submenu is its OWN `menu`
 // controller (reused via EXTRA_STIMULUS, like dropdown_menu/context_menu); THIS controller
@@ -15,13 +16,12 @@ export default class extends Controller {
   static outlets = ["menu"]   // the per-item submenu `menu` controllers (one per item)
 
   connect() {
-    this.typeBuffer = ""
-    this.typeTimer = null
+    this._typeAhead = new TypeAhead()
     this.resetRovingTabindex()
   }
 
   disconnect() {
-    if (this.typeTimer) clearTimeout(this.typeTimer)
+    this._typeAhead.cancel()
   }
 
   // --- roving tabindex across bar items -----------------------------------
@@ -114,19 +114,14 @@ export default class extends Controller {
   }
 
   typeAhead(char) {
-    this.typeBuffer += char.toLowerCase()
-    if (this.typeTimer) clearTimeout(this.typeTimer)
-    this.typeTimer = setTimeout(() => { this.typeBuffer = "" }, 1000)
-    const n = this.itemTargets.length
-    const start = Math.max(0, this.itemTargets.indexOf(document.activeElement))
-    for (let k = 1; k <= n; k++) {
-      const i = (start + k) % n
-      const el = this.itemTargets[i]
-      if (el.getAttribute("aria-disabled") === "true") continue
-      if (el.textContent.trim().toLowerCase().startsWith(this.typeBuffer)) {
-        this.focusItem(i)
-        return
-      }
-    }
+    this._typeAhead.push(char)
+
+    // Unfiltered + inline skip: focusItem takes an INDEX into itemTargets, which is
+    // co-indexed with menuOutlets. Filtering first would shift those indices apart.
+    const items = this.itemTargets
+    const i = this._typeAhead.match(items, Math.max(0, items.indexOf(document.activeElement)), {
+      skip: (el) => el.getAttribute("aria-disabled") === "true"
+    })
+    if (i !== -1) this.focusItem(i)
   }
 }

--- a/lib/generators/modelrails_ui/components.rb
+++ b/lib/generators/modelrails_ui/components.rb
@@ -31,18 +31,23 @@ module ModelrailsUi
       # and a host reading its importmap should be able to tell what it is.
       COMMAND_SCORE = {source: "command/command_score.js", dir: "search"}.freeze
 
+      # Type-ahead + activedescendant movement, shared by the menu family. Lives in
+      # dropdown_menu/ because the menu engine is its origin; namespaced `keyboard`
+      # because it is movement logic, not a dropdown concern.
+      KEYBOARD_NAV = {source: "dropdown_menu/keyboard_nav.js", dir: "keyboard"}.freeze
+
       SHARED_JS = {
-        "dropdown_menu" => [TOP_LAYER],
-        "context_menu" => [TOP_LAYER],
-        "menubar" => [TOP_LAYER],
-        "menubar_menu" => [TOP_LAYER],
+        "dropdown_menu" => [TOP_LAYER, KEYBOARD_NAV],
+        "context_menu" => [TOP_LAYER, KEYBOARD_NAV],
+        "menubar" => [TOP_LAYER, KEYBOARD_NAV],
+        "menubar_menu" => [TOP_LAYER, KEYBOARD_NAV],
         "popover" => [TOP_LAYER],
-        "combobox" => [TOP_LAYER],
+        "combobox" => [TOP_LAYER, KEYBOARD_NAV],
         "date_picker" => [TOP_LAYER],
         "timepicker" => [TOP_LAYER],
         "navigation_menu" => [TOP_LAYER],
         "mega_menu" => [TOP_LAYER],
-        "command" => [COMMAND_SCORE]
+        "command" => [COMMAND_SCORE, KEYBOARD_NAV]
       }.freeze
 
       # Shared Ruby modules — SHARED_JS, one asset kind over. A plain .rb.tt

--- a/test/system/combobox_system_test.rb
+++ b/test/system/combobox_system_test.rb
@@ -10,12 +10,12 @@ OPTIONS = [
   {value: "mx", label: "Mexico"}
 ].freeze
 
-BrowserHarness.scenario("combobox/basic", controllers: %w[combobox], modules: %w[overlays/top_layer]) do
+BrowserHarness.scenario("combobox/basic", controllers: %w[combobox], modules: %w[overlays/top_layer keyboard/keyboard_nav]) do
   view = ActionController::Base.new.view_context
   UI::ComboboxComponent.new(name: "country", label: "Country", options: OPTIONS).render_in(view)
 end
 
-BrowserHarness.scenario("combobox/two", controllers: %w[combobox], modules: %w[overlays/top_layer]) do
+BrowserHarness.scenario("combobox/two", controllers: %w[combobox], modules: %w[overlays/top_layer keyboard/keyboard_nav]) do
   view = ActionController::Base.new.view_context
   UI::ComboboxComponent.new(name: "origin", label: "Origin", options: OPTIONS).render_in(view) +
     UI::ComboboxComponent.new(name: "destination", label: "Destination", options: OPTIONS).render_in(view)

--- a/test/system/command_system_test.rb
+++ b/test/system/command_system_test.rb
@@ -6,7 +6,7 @@ load_component "command", "command_component.rb.tt"
 # Also an end-to-end check of the `search` shared-module namespace: the controller imports
 # `search/command_score` by bare specifier, so if SHARED_JS did not register it the import
 # would fail here exactly as it would in a fork.
-BrowserHarness.scenario("command/fuzzy", controllers: %w[command], modules: %w[search/command_score]) do
+BrowserHarness.scenario("command/fuzzy", controllers: %w[command], modules: %w[search/command_score keyboard/keyboard_nav]) do
   view = ActionController::Base.new.view_context
   item = ->(value, keywords = nil) do
     attrs = {type: "button", class: UI::CommandComponent::ITEM, data: {command_value: value}}
@@ -27,7 +27,7 @@ end
 # <hr> between groups, inside the role="listbox". An <hr>'s implicit
 # role="separator" is an illegal listbox child (axe aria-required-children,
 # critical), so the controller must neutralize caller-supplied rules.
-BrowserHarness.scenario("command/separator", controllers: %w[command], modules: %w[search/command_score]) do
+BrowserHarness.scenario("command/separator", controllers: %w[command], modules: %w[search/command_score keyboard/keyboard_nav]) do
   view = ActionController::Base.new.view_context
   item = ->(value) do
     view.tag.button(value, type: "button", class: UI::CommandComponent::ITEM,

--- a/test/system/dropdown_menu_system_test.rb
+++ b/test/system/dropdown_menu_system_test.rb
@@ -7,7 +7,7 @@ load_component "dropdown_menu", "dropdown_menu_component.rb.tt"
 # Rendering a slotted component needs a view context, so build the HTML the same way the
 # render lane does rather than going through a controller.
 BrowserHarness.scenario("dropdown_menu/submenu",
-  controllers: %w[menu submenu], modules: %w[overlays/top_layer]) do
+  controllers: %w[menu submenu], modules: %w[overlays/top_layer keyboard/keyboard_nav]) do
   view = ActionController::Base.new.view_context
   UI::DropdownMenuComponent.new.render_in(view) do |c|
     c.with_trigger { "Actions" }

--- a/test/system/keyboard_nav_system_test.rb
+++ b/test/system/keyboard_nav_system_test.rb
@@ -1,0 +1,151 @@
+# frozen_string_literal: true
+
+require "system_test_helper"
+
+# The shared module extracted from the menu family, exercised directly.
+#
+# Worth its own file because the component-level nets do not reach all of it: the
+# ArrowUp no-active-option branch is unreachable through both of its callers —
+# combobox's filter() re-seeds the active option to visible[0] on every open and
+# input, and command does the same — so a mutation removing that guard passes every
+# component test. It is still correct APG behavior and still the exact branch that
+# shipped broken once, so it is pinned here rather than left to a future caller to
+# rediscover.
+#
+# This is the payoff of extraction: movement logic that was four inlined switches is
+# now a pure function that can be asserted without driving a component.
+BrowserHarness.scenario("keyboard_nav/module", modules: %w[keyboard/keyboard_nav]) do
+  <<~HTML.html_safe
+    <script type="module">
+      import { nextActive, TypeAhead } from "keyboard/keyboard_nav"
+      window.__kbd = { nextActive, TypeAhead }
+    </script>
+    <ul id="items">
+      <li>Alpha</li><li>Beta</li><li>Gamma</li>
+    </ul>
+  HTML
+end
+
+class KeyboardNavSystemTest < BrowserTestCase
+  def setup
+    super
+    visit_scenario("keyboard_nav/module")
+    Timeout.timeout(5) { sleep 0.02 until page.evaluate_script("!!window.__kbd") }
+  end
+
+  # Returns the text of nextActive(items, current, key) over the three <li>s.
+  def move(current, key)
+    page.evaluate_script(<<~JS)
+      (() => {
+        const items = Array.from(document.querySelectorAll("#items li"))
+        const el = window.__kbd.nextActive(items, #{current}, "#{key}")
+        return el ? el.textContent : null
+      })()
+    JS
+  end
+
+  # --- nextActive ----------------------------------------------------------
+
+  def test_arrow_down_advances
+    assert_equal "Gamma", move(1, "ArrowDown")
+  end
+
+  def test_arrow_down_wraps
+    assert_equal "Alpha", move(2, "ArrowDown")
+  end
+
+  def test_arrow_up_retreats
+    assert_equal "Alpha", move(1, "ArrowUp")
+  end
+
+  def test_arrow_up_wraps
+    assert_equal "Gamma", move(0, "ArrowUp")
+  end
+
+  # The branch no component test can reach. APG: with nothing active, ArrowUp enters
+  # at the END. The modulo alone lands one short — the #661 class of bug.
+  def test_arrow_up_with_nothing_active_enters_at_the_last_item
+    assert_equal "Gamma", move(-1, "ArrowUp")
+  end
+
+  # Its ArrowDown counterpart needs no guard: (-1 + 1) % n is already 0.
+  def test_arrow_down_with_nothing_active_enters_at_the_first_item
+    assert_equal "Alpha", move(-1, "ArrowDown")
+  end
+
+  def test_home_and_end_are_absolute
+    assert_equal "Alpha", move(2, "Home")
+    assert_equal "Gamma", move(0, "End")
+  end
+
+  def test_a_key_that_does_not_move_returns_nothing
+    assert_nil move(1, "Enter")
+  end
+
+  def test_an_empty_set_returns_nothing
+    result = page.evaluate_script('window.__kbd.nextActive([], -1, "ArrowDown")')
+
+    assert_nil result
+  end
+
+  # --- TypeAhead -----------------------------------------------------------
+
+  def match_for(keys, from)
+    page.evaluate_script(<<~JS)
+      (() => {
+        const items = Array.from(document.querySelectorAll("#items li"))
+        const ta = new window.__kbd.TypeAhead()
+        #{keys.chars.map { |c| "ta.push(#{c.inspect});" }.join(" ")}
+        return ta.match(items, #{from})
+      })()
+    JS
+  end
+
+  def test_match_finds_the_next_item_by_prefix
+    assert_equal 2, match_for("g", 0)
+  end
+
+  def test_match_wraps_to_find_an_earlier_item
+    assert_equal 0, match_for("a", 2)
+  end
+
+  def test_match_accumulates_the_buffer_across_keystrokes
+    assert_equal 1, match_for("be", 0)
+  end
+
+  def test_match_returns_minus_one_when_nothing_matches
+    assert_equal(-1, match_for("z", 0))
+  end
+
+  # The skip predicate is menubar's shape: it cannot pre-filter, because its indices
+  # are co-indexed with menuOutlets, so the returned index must be into the ORIGINAL
+  # array with skipped entries passed over.
+  def test_skip_passes_over_an_item_without_shifting_the_returned_index
+    result = page.evaluate_script(<<~JS)
+      (() => {
+        const items = Array.from(document.querySelectorAll("#items li"))
+        items[1].setAttribute("aria-disabled", "true")
+        const ta = new window.__kbd.TypeAhead()
+        ta.push("b")
+        return ta.match(items, 0, { skip: (el) => el.getAttribute("aria-disabled") === "true" })
+      })()
+    JS
+
+    assert_equal(-1, result)
+  end
+
+  def test_cancel_clears_the_buffer
+    result = page.evaluate_script(<<~JS)
+      (() => {
+        const items = Array.from(document.querySelectorAll("#items li"))
+        const ta = new window.__kbd.TypeAhead()
+        ta.push("g")
+        ta.cancel()
+        ta.push("a")
+        return ta.match(items, 0)
+      })()
+    JS
+
+    assert_equal 0, result
+  end
+end

--- a/test/system/menubar_system_test.rb
+++ b/test/system/menubar_system_test.rb
@@ -12,7 +12,7 @@ load_component "menubar", "menubar_component.rb.tt"
 #
 # Written as characterization coverage ahead of the shared keyboard primitive: type-ahead
 # is duplicated between `menu` and `menubar`, and extracting it needs a net on both sides.
-BrowserHarness.scenario("menubar/bar", controllers: %w[menubar menu], modules: %w[overlays/top_layer]) do
+BrowserHarness.scenario("menubar/bar", controllers: %w[menubar menu], modules: %w[overlays/top_layer keyboard/keyboard_nav]) do
   view = ActionController::Base.new.view_context
   UI::MenubarComponent.new(label: "Main").render_in(view) do |bar|
     bar.with_menu(label: "File") do |m|


### PR DESCRIPTION
Closes #168. Builds on #167 (pair 2 made identical) and #171 (pair 1 given a net).

## What moved

Two algorithms were inlined four times. `keyboard/keyboard_nav.js` now holds both as **pure movement** — they answer "which item is next" and never touch focus, aria, or the DOM. Each controller keeps its own focus mechanics, which is where the four genuinely differ.

| Export | Replaces | In |
|---|---|---|
| `TypeAhead` | buffer + idle reset + wrap-scan | `menu`, `menubar` |
| `nextActive` | ArrowDown/Up/Home/End over the visible set | `combobox`, `command` |

**Net −53/+27** across the four controllers.

## The accessor split is preserved, not smoothed over

This is the part that made the extraction look harder than it was. `menu` pre-filters into `enabledItems` and focuses **by element**; `menubar` scans `itemTargets` unfiltered — its indices are co-indexed with `menuOutlets`, so it *cannot* filter first — and focuses **by index**.

So `match()` returns an index into the array it was given and takes an optional `skip` predicate. Both shapes survive unchanged, and both are pinned by tests.

`menubar`'s ←/→ bar navigation stays local, as #168 scoped it.

## Extraction paid for itself immediately

Making the logic standalone made it testable standalone — which surfaced a gap **no component test ever covered**:

`nextActive`'s no-active-option ArrowUp branch is unreachable through *both* callers. `combobox.filter()` re-seeds the active option to `visible[0]` on every open and input, and `command` does the same; empty sets return early. A mutation deleting that guard passed the entire component suite.

That is the exact branch that shipped broken as the `#661` class of bug. `keyboard_nav_system_test.rb` now drives the module directly — 15 examples — and the same mutation fails.

## Mutation-checked

| Mutation | Before this PR | After |
|---|---|---|
| `nextActive` ArrowUp `-1` guard removed | 0 failures ⚠️ | 1 ✅ |
| `TypeAhead.match` ignores `skip` | n/a | 1 ✅ |
| `menu` ArrowUp `-1` guard removed | 1 ✅ | 1 ✅ |
| `menubar` typeAhead match broken | 3 ✅ | 3 ✅ |

## On "specs pass unedited"

The **assertions** are unchanged — that was the contract and it held. Four scenario files did change, but only their `modules:` declarations, because the import graph now includes `keyboard/keyboard_nav`. Harness plumbing, not behavior.

## Verification

- `rake test`: 562 + 1031 + 90 runs, 0 failures (system lane 75 → 90)
- `rubocop`: 239 files, no offenses
- `SHARED_JS` registered for all six consuming components; the repo's own invariant tests (every plain `.js` claimed, every importer declares) pass

## Downstream

Consumers' vendored copies are now behind by this refactor. No urgency — behavior is identical — so it rides the next routine re-vendor rather than needing its own sync.