### PR TITLE
fix(avatar): hue initials re-light in dark mode with an adaptive on-color

### DIFF
--- a/lib/generators/modelrails_ui/add/templates/avatar/avatar_component.rb.tt
+++ b/lib/generators/modelrails_ui/add/templates/avatar/avatar_component.rb.tt
@@ -113,7 +113,7 @@ module UI
     end
 
     def color_classes
-      @hue ? "bg-hue-initials text-white" : "bg-interactive text-text-on-interactive"
+      @hue ? "bg-hue-initials text-text-on-hue-initials" : "bg-interactive text-text-on-interactive"
     end
 
     def aria_attrs

--- a/lib/generators/modelrails_ui/install/templates/modelrails_ui.css
+++ b/lib/generators/modelrails_ui/install/templates/modelrails_ui.css
@@ -94,6 +94,15 @@
   --color-text-muted:          var(--neutral-700); /* AAA 7:1 on white surface — same darkness as body; visual hierarchy is now via font-size/weight, not lightness */
   --color-text-on-interactive: oklch(100% 0 0);  /* white */
 
+  /* --- Hue ramp (workspace/org initials; caller supplies --hue) ---
+   * A fill, so it follows the fills rule: solid background + adaptive on-color.
+   * Light mode is a dark disc with white text; .dark re-lights it and flips the
+   * on-color, the same way interactive does. AAA is proven for ALL 360 hues by
+   * test/test_hue_ramp_contrast.rb, which reads these values, not copies of them. */
+  --hue-initials-l: 0.35;
+  --hue-initials-c: 0.20;
+  --color-text-on-hue-initials: oklch(100% 0 0);  /* white */
+
   /* --- Interactive (buttons, links, focus rings) ---
    *
    * NOTE on choosing between `interactive` and `interactive-hover`:
@@ -165,6 +174,15 @@
   --color-text-body:           var(--neutral-300);
   --color-text-muted:          var(--neutral-300); /* AAA 7:1 on dark surface — same as body; visual hierarchy via font-size/weight, not lightness (matches light-mode policy) */
   --color-text-on-interactive: var(--neutral-900);  /* dark text on light interactive bg */
+
+  /* --- Hue ramp ---
+   * L/C mirror the palette's own dark interactive shade (primary-300 is L .828 C .111),
+   * so a hue disc reads as the same family as its neighbours. Chosen at 0.80/0.10
+   * because that is IN sRGB gamut at every hue: the computed 9.14:1 worst case is then
+   * what actually renders, rather than an estimate of the browser's gamut mapping. */
+  --hue-initials-l: 0.80;
+  --hue-initials-c: 0.10;
+  --color-text-on-hue-initials: var(--neutral-900);  /* dark text on the re-lit fill */
 
   /* --- Interactive --- */
   --color-interactive:       var(--primary-300); /* was primary-400 (6.7:1 on slate-800) — primary-300 reaches AAA 7:1 */
@@ -319,6 +337,7 @@
   --color-text-body: var(--color-text-body);
   --color-text-muted: var(--color-text-muted);
   --color-text-on-interactive: var(--color-text-on-interactive);
+  --color-text-on-hue-initials: var(--color-text-on-hue-initials);
 
   /* Interactive */
   --color-interactive: var(--color-interactive);
@@ -622,12 +641,13 @@
    OKLCH Hue-based Background Utilities
    Used with style="--hue: <value>" to apply dynamic colors without full
    inline background-color declarations (CSP-safer).
-   bg-hue-initials: L=0.35, C=0.20 — AAA contrast with white text
+   bg-hue-initials: theme-aware via --hue-initials-l/-c; pair with
+     text-text-on-hue-initials, never a hardcoded text color
    bg-hue-interactive: L=0.40, C=0.15 — accent/dot color for workspace branding
    ========================================================================== */
 
 .bg-hue-initials {
-  background-color: oklch(0.35 0.2 var(--hue, 210));
+  background-color: oklch(var(--hue-initials-l) var(--hue-initials-c) var(--hue, 210));
 }
 
 .bg-hue-interactive {

--- a/test/render/avatar_render_test.rb
+++ b/test/render/avatar_render_test.rb
@@ -49,12 +49,15 @@ class AvatarRenderTest < ViewComponent::TestCase
     assert_selector "span.text-text-on-interactive"
   end
 
-  # The hue fill is the project's own semantic utility (fixed L=0.35, theme-independent),
-  # engineered for AAA white text — that pairing is the documented correct one here.
-  def test_hue_initials_use_the_semantic_hue_fill
+  # The hue fill is the project's own semantic utility, theme-aware since #144: the
+  # lightness comes from --hue-initials-l, which .dark re-lights, and the on-color rides
+  # along in its own token. The pairing is asserted because the bug was a hardcoded
+  # text-white that could not follow the fill.
+  def test_hue_initials_use_the_semantic_hue_fill_with_its_adaptive_on_color
     render_inline(UI::AvatarComponent.new(fallback: "AL", hue: 280))
 
-    assert_selector "span.bg-hue-initials[style*='--hue: 280']"
+    assert_selector "span.bg-hue-initials.text-text-on-hue-initials[style*='--hue: 280']"
+    refute_selector "span.bg-hue-initials.text-white"
   end
 
   def test_applies_the_requested_size

--- a/test/test_hue_ramp_contrast.rb
+++ b/test/test_hue_ramp_contrast.rb
@@ -1,0 +1,144 @@
+# frozen_string_literal: true
+
+require "test_helper"
+
+# AAA for the hue ramp, across every hue.
+#
+# The other contrast test pins fixed palette pairs. This one cannot: `bg-hue-initials`
+# takes `--hue` from the caller, so the guarantee has to hold for all 360 hues, and the
+# binding constraint is the WORST hue, not a representative one.
+#
+# Values are read out of the shipped stylesheet rather than restated here. A hardcoded
+# copy would keep passing after someone edited the CSS, which is the failure this exists
+# to prevent.
+class TestHueRampContrast < Minitest::Test
+  AAA = 7.0
+  CSS = File.expand_path("../lib/generators/modelrails_ui/install/templates/modelrails_ui.css", __dir__)
+
+  WHITE = [1.0, 0.0, 0.0].freeze
+  SLATE_900 = [0.208, 0.042, 265.755].freeze # --neutral-900, the dark-mode on-color
+
+  def css = @css ||= File.read(CSS)
+
+  # Last definition wins for :root, first .dark block for dark — mirrors the cascade.
+  def token(name, dark: false)
+    scope = dark ? css[/^\.dark \{.*?^\}/m] : css[/^:root \{.*?#{Regexp.escape(name)}:.*?^\}/m]
+
+    refute_nil scope, "no #{dark ? ".dark" : ":root"} block defining #{name}"
+    m = scope[/#{Regexp.escape(name)}:\s*([0-9.]+)/, 1]
+
+    refute_nil m, "#{name} not defined in #{dark ? ".dark" : ":root"}"
+    Float(m)
+  end
+
+  # Resolve the DECLARED on-color rather than assuming it. Asserting AAA against a
+  # hardcoded dark color would keep passing if the token reverted to white — the exact
+  # regression this guards, and one a first draft of this test missed.
+  ON_COLORS = {
+    "oklch(100% 0 0)" => WHITE,
+    "var(--neutral-900)" => SLATE_900
+  }.freeze
+
+  def on_color(dark: false)
+    scope = dark ? css[/^\.dark \{.*?^\}/m] : css[/^:root \{.*?--color-text-on-hue-initials:.*?^\}/m]
+    raw = scope[/--color-text-on-hue-initials:\s*([^;]+);/, 1].strip
+
+    ON_COLORS.fetch(raw) do
+      flunk "unrecognised on-color #{raw.inspect}; add it to ON_COLORS with its OKLCH triple " \
+            "so the ratio below is computed against what actually ships"
+    end
+  end
+
+  def oklch_luminance(l, c, h)
+    hr = h * Math::PI / 180.0
+    a = c * Math.cos(hr)
+    b = c * Math.sin(hr)
+    l_ = (l + 0.3963377774 * a + 0.2158037573 * b)**3
+    m_ = (l - 0.1055613458 * a - 0.0638541728 * b)**3
+    s_ = (l - 0.0894841775 * a - 1.2914855480 * b)**3
+    r = 4.0767416621 * l_ - 3.3077115913 * m_ + 0.2309699292 * s_
+    g = -1.2684380046 * l_ + 2.6097574011 * m_ - 0.3413193965 * s_
+    bl = -0.0041960863 * l_ - 0.7034186147 * m_ + 1.7076147010 * s_
+    rr, gg, bb = [r, g, bl].map { |x| x.clamp(0.0, 1.0) }
+    0.2126 * rr + 0.7152 * gg + 0.0722 * bb
+  end
+
+  def contrast(c1, c2)
+    y1 = oklch_luminance(*c1)
+    y2 = oklch_luminance(*c2)
+    ([y1, y2].max + 0.05) / ([y1, y2].min + 0.05)
+  end
+
+  # True when the OKLCH triple falls outside sRGB. Matters because the contrast model
+  # above clamps, while a browser gamut-MAPS — for an out-of-gamut color the two disagree,
+  # so a ratio computed here is an approximation of what actually renders.
+  def out_of_gamut?(l, c, h)
+    hr = h * Math::PI / 180.0
+    a = c * Math.cos(hr)
+    b = c * Math.sin(hr)
+    l_ = (l + 0.3963377774 * a + 0.2158037573 * b)**3
+    m_ = (l - 0.1055613458 * a - 0.0638541728 * b)**3
+    s_ = (l - 0.0894841775 * a - 1.2914855480 * b)**3
+    r = 4.0767416621 * l_ - 3.3077115913 * m_ + 0.2309699292 * s_
+    g = -1.2684380046 * l_ + 2.6097574011 * m_ - 0.3413193965 * s_
+    bl = -0.0041960863 * l_ - 0.7034186147 * m_ + 1.7076147010 * s_
+    [r, g, bl].any? { |x| x < -0.001 || x > 1.001 }
+  end
+
+  def worst_hue(l, c, on_color)
+    (0..359).map { |h| [contrast([l, c, h], on_color), h] }.min
+  end
+
+  def test_light_mode_hue_initials_meet_aaa_at_every_hue
+    l = token("--hue-initials-l")
+    c = token("--hue-initials-c")
+    ratio, hue = worst_hue(l, c, on_color)
+
+    assert_operator ratio, :>=, AAA,
+      "light hue-initials worst hue #{hue}: #{ratio.round(2)}:1 below AAA"
+  end
+
+  def test_dark_mode_hue_initials_meet_aaa_at_every_hue
+    l = token("--hue-initials-l", dark: true)
+    c = token("--hue-initials-c", dark: true)
+    ratio, hue = worst_hue(l, c, on_color(dark: true))
+
+    assert_operator ratio, :>=, AAA,
+      "dark hue-initials worst hue #{hue}: #{ratio.round(2)}:1 below AAA"
+  end
+
+  # The point of the issue: the fill must actually change between themes. A dark-mode
+  # value equal to the light one would pass the two tests above while leaving a fixed
+  # dark disc beside a light-flipping sibling chip.
+  def test_the_hue_fill_re_lights_in_dark_mode
+    assert_operator token("--hue-initials-l", dark: true), :>, token("--hue-initials-l") + 0.2,
+      "dark hue fill must be substantially lighter than light mode, not the same disc"
+  end
+
+  # White on the re-lit fill is the mistake this replaces. Both halves are checked: the
+  # declared token must not be white, AND white must actually fail there — so neither a
+  # token revert nor a fill that drifted dark again can pass unnoticed.
+  def test_the_dark_on_color_is_dark_and_white_would_fail_there
+    refute_equal WHITE, on_color(dark: true),
+      "dark on-color reverted to white; the re-lit fill needs dark text"
+
+    l = token("--hue-initials-l", dark: true)
+    c = token("--hue-initials-c", dark: true)
+    ratio, = worst_hue(l, c, WHITE)
+
+    assert_operator ratio, :<, AAA,
+      "dark fill is dark enough for white text — it did not re-light"
+  end
+
+  # The dark value is chosen to sit inside sRGB at every hue, so the ratio above is what
+  # renders rather than an approximation of the browser's gamut mapping. The light value
+  # predates this test and is NOT in gamut — recorded, not asserted, so this stays a
+  # regression guard on the new value rather than a failing complaint about the old one.
+  def test_the_dark_mode_hue_fill_is_in_gamut_at_every_hue
+    l = token("--hue-initials-l", dark: true)
+    c = token("--hue-initials-c", dark: true)
+    outside = (0..359).count { |h| out_of_gamut?(l, c, h) }
+
+    assert_equal 0, outside, "#{outside} hues fall outside sRGB; the AAA ratio is then only an estimate"
+  end
+end


### PR DESCRIPTION
Closes #144.

## The bug

`bg-hue-initials` resolved to a fixed `oklch(0.35 0.2 var(--hue))` in **both** themes, and `AvatarComponent#color_classes` hardcoded `text-white` on it. In dark mode a hue disc stayed dark-with-white-text next to a `bg-interactive` sibling that flips to light-fill-with-dark-text. Same component, same page, opposite treatments — and the hardcoded color was *why* it couldn't adapt.

## The fix

A token pair, following the fills rule the rest of the system already uses:

| | light | dark |
|---|---|---|
| `--hue-initials-l` / `-c` | 0.35 / 0.20 | **0.80 / 0.10** |
| `--color-text-on-hue-initials` | white | `--neutral-900` |

Redefined under `.dark` exactly the way `interactive` is.

## The dark values were computed, not picked

Two constraints, both across all 360 hues since the caller supplies `--hue`:

**AAA at the worst hue.** 0.80/0.10 gives **9.14:1** worst case (hue 353) — 2.14 above the 7:1 floor.

**In sRGB gamut.** This is the part worth flagging. The existing values are already out of gamut at most hues — `bg-hue-initials` at 333/360, `bg-hue-interactive` at 224/360 — so browsers gamut-map them, and any contrast figure computed by clamping is an *approximation* of what renders. 0.80/0.10 is the only candidate I found that is **0/360 out of gamut**, so its 9.14:1 is what actually paints.

They also sit right beside the palette's own dark interactive shade (`primary-300` is L .828 C .111), so a hue disc reads as the same family as its neighbours rather than an unrelated pastel.

**Light mode is unchanged** — I verified its claim rather than assuming it: worst hue 186 at 8.82:1, all 360 pass.

## Test

`test_hue_ramp_contrast.rb` **reads the shipped values out of the stylesheet** instead of restating them — a hardcoded copy would keep passing after someone edited the CSS, which is the failure it exists to prevent. It sweeps all 360 hues and resolves the **declared** on-color.

That last part came from a mutation catching my own first draft: asserting AAA against a hardcoded dark color meant flipping `--color-text-on-hue-initials` back to white went **completely undetected**. Fixed, and now:

| Mutation | Before | After |
|---|---|---|
| dark fill reverts to light values | 4 ✅ | 4 ✅ |
| dark on-color reverts to white | **0 ⚠️** | 2 ✅ |

Also recorded, deliberately not asserted: the light value's out-of-gamut status. Making that a failure would turn a new regression guard into a complaint about pre-existing behavior — worth its own decision, not a drive-by.

## Verification

- `rake test`: 567 + 1031 + 90, 0 failures
- `rubocop`: 240 files, no offenses
- `text-white` gone from `color_classes`; render test asserts the pairing and `refute_selector`s the old one

## Downstream

Consumers re-vendoring get the theme-aware fill automatically. Any app-side `text-white` sitting on a `bg-hue-initials` element should come off in the same pass.