### PR TITLE
release: v0.14.0 — shared keyboard module, theme-aware hue ramp, command listbox fix

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,9 +7,26 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.14.0] - 2026-08-25
+
+### Added
+
+- `keyboard/keyboard_nav.js` — a shared ES module holding the two movement algorithms the menu family had inlined four times: `TypeAhead` (buffer + APG idle reset + wrap-scan) and `nextActive` (ArrowDown/Up/Home/End over a visible set). Both are pure movement and never touch focus, aria, or the DOM; each controller keeps its own focus mechanics. Registered in `SHARED_JS` for dropdown_menu, context_menu, menubar, menubar_menu, combobox, and command — consumers need a `keyboard` importmap pin. Net −53/+27 across the four controllers. (#168)
+- Theme-aware hue-ramp tokens: `--hue-initials-l`/`--hue-initials-c` for the fill and `--color-text-on-hue-initials` for its text, redefined under `.dark` the way `interactive` already is. (#144)
+- Browser-lane coverage for menubar's bar-level keyboard contract — type-ahead match/wrap/multi-character-buffer/no-match, the menu-side `enabledItems` filter reached through the bar, and the ←/→ navigation that stays local. menubar previously had render-lane coverage only, and the render lane cannot run JS or Stimulus outlets. (#171, #168)
+- `test_hue_ramp_contrast.rb` — AAA proven across all 360 hues in both themes, reading the shipped values out of the stylesheet and resolving the declared on-color rather than restating either. (#144)
+
 ### Fixed
 
+- `command`: a caller-supplied `<hr>` is neutralized to `role="presentation"` + `aria-hidden` in `_tagOptions()`. An `<hr>`'s implicit `role="separator"` is an illegal child of `role="listbox"` (axe `aria-required-children`, critical) — and the component invited the markup, since `SEPARATOR` is an exposed constant and command.md's example places one inside the list. (#167)
+- `command`: ArrowUp with no active option enters at the LAST item, matching `combobox`. Parity rather than a live path — `filter()` re-seeds the active option on every open and input — but it keeps the duplicated pair identical, which the #168 extraction depends on. (#167)
+- `bg-hue-initials` participates in dark mode. It resolved to a fixed `oklch(0.35 0.2 var(--hue))` in both themes while `AvatarComponent` hardcoded `text-white` on it, so a hue disc stayed dark-with-white-text beside a `bg-interactive` sibling that flips to light-fill-with-dark-text. Dark is now L 0.80 / C 0.10 with `--neutral-900` text: 9.14:1 at the worst hue, and the only candidate that stays inside sRGB gamut at every hue — so that ratio is what renders rather than an estimate of the browser's gamut mapping. Light mode is unchanged (8.82:1 worst hue, verified). (#144)
 - FormBuilder tolerates object-less forms (`form_with url:` sets the builder's object to FALSE, which survives safe navigation): `error_for` and `error_summary` guard with `respond_to?(:errors)`, so enhanced helpers render on model-less forms instead of raising. (#163)
+- `dialog`: focus is restored on disconnect, and a detached opener is guarded. (#165)
+
+### Changed
+
+- `AvatarComponent#color_classes` pairs the hue fill with `text-text-on-hue-initials` instead of a hardcoded `text-white`. **Consumers with an app-side `text-white` on a `bg-hue-initials` element should remove it** — it defeats the adaptive on-color and leaves white text on a re-lit fill. (#144)
 
 ## [0.13.1] - 2026-08-23
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    modelrails_ui (0.13.1)
+    modelrails_ui (0.14.0)
       railties (>= 8.0)
       view_component (>= 4.0)
 
@@ -387,7 +387,7 @@ CHECKSUMS
   matrix (0.4.3) sha256=a0d5ab7ddcc1973ff690ab361b67f359acbb16958d1dc072b8b956a286564c5b
   mini_mime (1.1.5) sha256=8681b7e2e4215f2a159f9400b5816d85e9d8c6c6b491e96a12797e798f8bccef
   minitest (6.0.6) sha256=153ea36d1d987a62942382b61075745042a2b3123b1cd48f4c3675af9cc7d6f1
-  modelrails_ui (0.13.1)
+  modelrails_ui (0.14.0)
   net-imap (0.6.4.1) sha256=29f0360d75a7efd3539f16ac1957dea5c0a51ddeceb348db4553c3120914ea0d
   net-pop (0.1.2) sha256=848b4e982013c15b2f0382792268763b748cce91c9e91e36b0f27ed26420dff3
   net-protocol (0.2.2) sha256=aa73e0cba6a125369de9837b8d8ef82a61849360eba0521900e2c3713aa162a8

--- a/lib/modelrails_ui/version.rb
+++ b/lib/modelrails_ui/version.rb
@@ -2,5 +2,5 @@
 
 module ModelrailsUi
   # modelrails_ui's own SemVer line (forked from view_primitives 0.1.0). See MODELRAILS_STATUS.md.
-  VERSION = "0.13.1"
+  VERSION = "0.14.0"
 end


### PR DESCRIPTION
Version bump + CHANGELOG for six unreleased commits. No code changes.

## Why 0.14.0 and not 0.13.2

- **#168** adds a new shared ES module (`keyboard/keyboard_nav.js`) that consumers must pin
- **#144** changes rendered output in dark mode

Either alone is more than a patch.

## What was unreleased

Six commits sat on `main` past `v0.13.1`, and only **#163** had a CHANGELOG entry. Entries for **#165, #167, #168, #144** are written here rather than left for the next reader to reconstruct from `git log`.

| | |
|---|---|
| #144 | hue initials re-light in dark mode with an adaptive on-color |
| #168 | shared keyboard movement module (via #171, #172) |
| #167 | `command` listbox `<hr>` neutralization + ArrowUp parity |
| #165 | dialog focus restore on disconnect |
| #163 | FormBuilder tolerates object-less forms |

## Consumer notes, carried in the entries

Two things that will bite an upgrader silently, so they're in the CHANGELOG rather than only here:

1. **A `keyboard` importmap pin is required.** Without `pin_all_from "app/javascript/keyboard", under: "keyboard"`, four controllers throw on a bare module import.
2. **App-side `text-white` on a `bg-hue-initials` element must come off.** It now defeats the adaptive on-color, leaving white text on a re-lit fill — worse than the bug being fixed.

## Verification

- `rake test`: 567 + 1031 + 90, 0 failures
- `rubocop`: 240 files, no offenses
- `Gemfile.lock` regenerated; no stale `0.13.1` outside the historical CHANGELOG section

## After merge

Tag `v0.14.0` and release — yours to run. Base then bumps its pin, adds the `keyboard` namespace + importmap pin, re-vendors four controllers, hand-ports the hue tokens into its own `application.css` (base defines `.bg-hue-initials` itself, so a pin bump alone will not fix dark mode there), and clears three `text-white` pairings — one vendored, two hand-rolled in the identity picker hub.