### PR TITLE
fix(generators): agent-rules template names real classes and keeps the live region on the container

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- `agent_rules` template: replace the phantom `bg-page` with `bg-surface`/`bg-surface-raised`; same phantom in the `bottom_nav` lookbook preview template.
+- `agent_rules` template: the overlay-container rule keeps the live region on the container — the per-item-only shape it prescribed silences appended toasts.
+- `agent_rules` template: point component docs at the gem's `docs/components/` path.
+- `house-rules` template: system specs bypass CSP via Cuprite, not Playwright.
+
 ## [0.14.0] - 2026-08-25
 
 ### Added

--- a/lib/generators/modelrails_ui/agent_rules/templates/agent-rules.md
+++ b/lib/generators/modelrails_ui/agent_rules/templates/agent-rules.md
@@ -5,14 +5,15 @@ Defer to it instead of inventing UI from scratch.
 
 ## Before you build any UI
 - **Check what exists first.** `bin/rails g modelrails_ui:list` shows installed primitives;
-  `docs/components/<name>.md` documents usage; `/lookbook` shows live previews.
+  the gem's `docs/components/<name>.md` (`bundle show modelrails_ui`) documents usage;
+  `/lookbook` shows live previews.
 - **Prefer a documented `UI::*` primitive** over a hand-rolled utility stack. Build bespoke
   markup only when no primitive fits — and say so explicitly.
 - `UI::*` **is** the shared component library — use it freely.
 
 ## Color, type, tokens — never raw
 - **No raw hex, arbitrary color utilities, or off-system fonts.** Use semantic tokens:
-  `bg-page`/`bg-surface`, `text-text-body`/`text-text-heading`, `bg-hue-*`, `.btn-*`.
+  `bg-surface`/`bg-surface-raised`, `text-text-body`/`text-text-heading`, `bg-hue-*`, `.btn-*`.
 - **Signals** are canonical `info · success · warning · danger`. Chips (alert/badge/toast)
   are *tinted* (`bg-*-surface` + `text-*` + `*-border`); fills (button, indicator dot) are
   *solid* with adaptive on-color. Base signal tokens are TEXT colors — never a solid fill,
@@ -38,17 +39,19 @@ Defer to it instead of inventing UI from scratch.
   box-shadow ring is clipped by `overflow:hidden` ancestors and vanishes in forced-colors mode
   (a 2.4.7 failure). The one exception is a menu item's full-surface
   `focus-visible:bg-surface-sunken` highlight (a stronger indicator where an outline is clipped).
-- **A fixed-position overlay container with `aria-label` is a live region OR a landmark — never
-  bare, never `role="group"`.** Such a container (toast stack, notification tray) must clear two
-  axe rules at once: `aria-prohibited-attr` (`aria-label` needs a role) and `region` (its content
-  must sit in a live region or landmark, since it lives outside `<main>`). Two valid shapes:
-  (a) make the container the live region — `role="status"` + `aria-live="polite"` (or
-  `role="alert"`/`assertive` for errors) — when the container announces its own children; or
-  (b) make it a landmark — `role="region"`, with the `aria-label` as its name — when the live
-  regions live on the individual items (per-item `role="status"`, so the container must *not*
-  also be a live region). `role="group"` clears `aria-prohibited-attr` but is neither, so it
-  trips `region`. (`ToasterComponent` uses shape (a); an app's own `shared/_toasts` per-toast
-  stack uses shape (b).)
+- **A fixed-position overlay container with `aria-label` is a live region — and, when it needs
+  a name, a landmark too. Never bare, never `role="group"`.** Such a container (toast stack,
+  notification tray) must clear two axe rules at once: `aria-prohibited-attr` (`aria-label`
+  needs a role) and `region` (its content must sit in a live region or landmark, since it lives
+  outside `<main>`). The live region is the **container**, present and empty from first render:
+  either `role="status"` + `aria-live="polite"` (or `role="alert"`/`assertive` for errors), or
+  `role="region"` + `aria-label` + `aria-live="…"` when it also needs a landmark name — both
+  are valid; axe's `region` rule accepts live *or* landmark, and ARIA does not forbid both.
+  What does NOT work is a live region only on the items: a toast appended already carrying
+  its text and its own `aria-live` is inserted-with-content, and assistive tech drops it.
+  Per-item `role="status"`/`"alert"` is fine — implicit and harmless — but it is not what
+  announces. `role="group"` clears `aria-prohibited-attr` only. (`ToasterComponent` and an
+  app's own `shared/_toasts` both keep the live region on the container.)
 
 ## Before you call UI work done
 - **Check both themes** — light *and* dark (class-based dark mode).

--- a/lib/generators/modelrails_ui/agent_rules/templates/house-rules.md
+++ b/lib/generators/modelrails_ui/agent_rules/templates/house-rules.md
@@ -5,5 +5,5 @@ the generator seeds it once and never overwrites it.
 
 - **All UI text uses I18n locale keys** — no hardcoded strings.
 - **No inline event handlers** (`onclick`, `onchange`, …). A strict Content Security
-  Policy (CSP) blocks them, and system specs won't catch it (Playwright bypasses CSP) —
+  Policy (CSP) blocks them, and system specs won't catch it (Cuprite's CDP driver bypasses CSP) —
   use Stimulus actions: `data-action="click->controller#method"`.

--- a/lib/generators/modelrails_ui/lookbook/templates/previews/ui/bottom_nav_component_preview/default.html.erb
+++ b/lib/generators/modelrails_ui/lookbook/templates/previews/ui/bottom_nav_component_preview/default.html.erb
@@ -1,5 +1,5 @@
 <%# The bar is `fixed bottom-0` in the app; the relative wrapper pins it inside the preview frame. %>
-<div class="relative h-40 overflow-hidden rounded-lg border border-border bg-page">
+<div class="relative h-40 overflow-hidden rounded-lg border border-border bg-surface">
   <%= ui :bottom_nav, items: [
         {
           label: "Home",


### PR DESCRIPTION
Two defects in the generated `agent-rules.md` template, found by a panel
review of the reference host's doctrine audit (2026-08-29). Both matter
more than a doc typo because the host's UI skill says these rules **win**
on conflict, and the file is regenerated with `force: true` — a host can't
fix it locally.

## `bg-page` is a phantom

The rule led with `bg-page`/`bg-surface`. There is no `--color-page` token
in the install CSS and no `.bg-page` in any host's compiled build (positive
control: `.bg-surface` → 1). An agent following the rule emits a class that
renders nothing and looks right by accident. The same class was in the
`bottom_nav` lookbook preview template, which hosts generate and track.
Both now use `bg-surface` / `bg-surface-raised`.

## The toast rule prescribed the shape that silences toasts

The rule offered shape (a) — container is the live region — and shape (b)
— landmark container, live region only on the items — and assigned an
app's own `shared/_toasts` to (b). Shape (b) is the incident behind
modelrails_base #683: a toast appended already carrying its text and
`aria-live` is inserted-with-content, and assistive tech drops it.
Success/info toasts go silent.

The rule now says the live region is the container, present and empty
from first render — as a `status`/`alert` role, or as a `role="region"`
with `aria-label` **and** `aria-live` when it needs a landmark name. Both
are valid: axe's `region` rule accepts live *or* landmark, and ARIA does
not forbid both. Per-item roles are harmless but are not what announces.
`ToasterComponent` already does this (container `role="status"
aria-live="polite"`), so the rule now describes the gem's own component.

## Also

- Component docs are the gem's `docs/components/<name>.md`, not the
  host's root `docs/` (which, in the reference host, is something else).
- `house-rules.md` template still said "Playwright bypasses CSP"; hosts
  run Cuprite. Seeded once per host, so every new fork got the stale line.

`rake test:structural` → 567 runs, 0 failures. Adjacent, not duplicated:
#175 (no version stamp — the mechanism by which these survived
unnoticed) and #140 (toaster adoption).
