### PR TITLE
docs(changelog): restore the calendar entry dropped by the #177 merge

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- `calendar`: arrow keys cross the month boundary — a target past the grid's edge pages to the adjacent month and lands on that date instead of dead-ending (APG date-grid). Paging renders synchronously so PageUp/PageDown focus the NEW grid, and a re-render keeps the roving stop on the focused day. (#177)
 - `agent_rules` template: replace the phantom `bg-page` with `bg-surface`/`bg-surface-raised`; same phantom in the `bottom_nav` lookbook preview template.
 - `agent_rules` template: the overlay-container rule keeps the live region on the container — the per-item-only shape it prescribed silences appended toasts.
 - `agent_rules` template: point component docs at the gem's `docs/components/` path.


### PR DESCRIPTION
PR #177 added an Unreleased Fixed entry for the calendar month-boundary fix; #176 had added its own Fixed block in the same spot minutes earlier, and the merge of #177 kept only #176's lines. This restores the calendar line. Changelog only.