### PR TITLE
release: v0.14.1 — calendar arrows cross months, agent-rules template names real classes and the right toast shape

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.14.1] - 2026-08-29
+
 ### Fixed
 
 - `calendar`: arrow keys cross the month boundary — a target past the grid's edge pages to the adjacent month and lands on that date instead of dead-ending (APG date-grid). Paging renders synchronously so PageUp/PageDown focus the NEW grid, and a re-render keeps the roving stop on the focused day. (#177)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- `calendar`: arrow keys cross the month boundary — a target past the grid's edge pages to the adjacent month and lands on that date instead of dead-ending (APG date-grid). Paging renders synchronously so PageUp/PageDown focus the NEW grid, and a re-render keeps the roving stop on the focused day. (#177)
 - `agent_rules` template: replace the phantom `bg-page` with `bg-surface`/`bg-surface-raised`; same phantom in the `bottom_nav` lookbook preview template.
 - `agent_rules` template: the overlay-container rule keeps the live region on the container — the per-item-only shape it prescribed silences appended toasts.
 - `agent_rules` template: point component docs at the gem's `docs/components/` path.

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    modelrails_ui (0.14.0)
+    modelrails_ui (0.14.1)
       railties (>= 8.0)
       view_component (>= 4.0)
 
@@ -387,7 +387,7 @@ CHECKSUMS
   matrix (0.4.3) sha256=a0d5ab7ddcc1973ff690ab361b67f359acbb16958d1dc072b8b956a286564c5b
   mini_mime (1.1.5) sha256=8681b7e2e4215f2a159f9400b5816d85e9d8c6c6b491e96a12797e798f8bccef
   minitest (6.0.6) sha256=153ea36d1d987a62942382b61075745042a2b3123b1cd48f4c3675af9cc7d6f1
-  modelrails_ui (0.14.0)
+  modelrails_ui (0.14.1)
   net-imap (0.6.4.1) sha256=29f0360d75a7efd3539f16ac1957dea5c0a51ddeceb348db4553c3120914ea0d
   net-pop (0.1.2) sha256=848b4e982013c15b2f0382792268763b748cce91c9e91e36b0f27ed26420dff3
   net-protocol (0.2.2) sha256=aa73e0cba6a125369de9837b8d8ef82a61849360eba0521900e2c3713aa162a8

--- a/lib/modelrails_ui/version.rb
+++ b/lib/modelrails_ui/version.rb
@@ -2,5 +2,5 @@
 
 module ModelrailsUi
   # modelrails_ui's own SemVer line (forked from view_primitives 0.1.0). See MODELRAILS_STATUS.md.
-  VERSION = "0.14.0"
+  VERSION = "0.14.1"
 end


### PR DESCRIPTION
Version bump + CHANGELOG date for the two fixes merged today (#176, #177) plus the restored changelog line (#178, which this branch stacks on — merge that first or this one carries its commit). After merge: tag `v0.14.1` on main, then the reference host bumps its Gemfile pin and regenerates `agent-rules.md` and the `bottom_nav` preview. Same shape as #174: CHANGELOG, Gemfile.lock, version.rb.