### PR TITLE
fix(form_builder): render the reader, not the stored bytes, for a loaded record

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- `form_builder`: a field for an attribute loaded from the database renders the reader's value, not `*_before_type_cast` — for an Active Record encrypted attribute that was the ciphertext. The raw pre-cast value is used only when the attribute came from the user this request (the guard ActionView's own field helpers apply), so a failed cast still re-renders what was typed.
+
 ## [0.14.1] - 2026-08-29
 
 ### Fixed

--- a/lib/generators/modelrails_ui/add/templates/form_builder/form_builder.rb.tt
+++ b/lib/generators/modelrails_ui/add/templates/form_builder/form_builder.rb.tt
@@ -311,11 +311,20 @@ module UI
       return nil unless object
 
       before_type_cast = :"#{method}_before_type_cast"
-      if object.respond_to?(before_type_cast)
+      if object.respond_to?(before_type_cast) && value_came_from_user?(method)
         object.public_send(before_type_cast)
       elsif object.respond_to?(method)
         object.public_send(method)
       end
+    end
+
+    # The same guard ActionView's field helpers use: the pre-cast value is the
+    # user's only when they assigned it this request. For a record loaded from
+    # the database it is the stored bytes — for an encrypted attribute, the
+    # ciphertext.
+    def value_came_from_user?(method)
+      came_from_user = :"#{method}_came_from_user?"
+      !object.respond_to?(came_from_user) || object.public_send(came_from_user)
     end
 
     def error_for(method)

--- a/test/render/form_builder_render_test.rb
+++ b/test/render/form_builder_render_test.rb
@@ -37,6 +37,19 @@ class B1Article
   end
 end
 
+# A record loaded from the database reports its attributes as NOT from the
+# user, and its *_before_type_cast is the stored bytes — for an Active Record
+# encrypted attribute, the ciphertext. The shim mirrors that pair of readers.
+class B1LoadedArticle < B1Article
+  def title_before_type_cast
+    '{"p":"ciphertext"}'
+  end
+
+  def title_came_from_user?
+    false
+  end
+end
+
 class FormBuilderRenderTest < ViewComponent::TestCase
   def builder(object = B1Article.new, object_name: :b1_article)
     UI::FormBuilder.new(object_name, object, vc_test_controller.view_context, {})
@@ -99,6 +112,14 @@ class FormBuilderRenderTest < ViewComponent::TestCase
   end
 
   # -- value resolution -------------------------------------------------------
+
+  def test_value_renders_the_reader_when_the_attribute_did_not_come_from_the_user
+    article = B1LoadedArticle.new(title: "Hello")
+    page = page_for(builder(article, object_name: :b1_article).text_field(:title))
+
+    assert page.has_css?("input[value='Hello']"), "a loaded record's field must show the reader's value"
+    refute page.has_css?("input[value='{\"p\":\"ciphertext\"}']"), "never the stored bytes"
+  end
 
   def test_value_uses_before_type_cast_so_failed_numeric_input_survives_rerender
     article = B1Article.new


### PR DESCRIPTION
## Summary

`UI::FormBuilder#field_value` read `*_before_type_cast` whenever the object responded to it, so a failed cast could re-render what the user typed ("abc" in a number field). For a record **loaded from the database** that value is the stored bytes — and for an Active Record encrypted attribute, the ciphertext. The reference app's profile form rendered `{"p":"…","h":{…}}` into the email and last-name fields the moment `encrypts` landed (modelrails_base #902).

The fix is the guard ActionView's own field helpers use (`ActionView::Helpers::Tags::Base#value_before_type_cast`): the pre-cast value is the user's only when `*_came_from_user?` says so; otherwise the reader.

## Tests

- New: `test_value_renders_the_reader_when_the_attribute_did_not_come_from_the_user` — a shim (`B1LoadedArticle`) mirrors the two ActiveRecord readers: `title_before_type_cast` returns stored bytes, `title_came_from_user?` returns false. Red before the change (the input carried the bytes), green after.
- Kept: `test_value_uses_before_type_cast_so_failed_numeric_input_survives_rerender` — the shim has no `_came_from_user?`, so it is treated as user input, exactly as a plain object is in Rails.

`bundle exec rake test` → three lanes green (567 / 1032 / 90 runs, 0 failures).

## Downstream

modelrails_base carries the same change in its vendored copy (`app/form_builders/ui/form_builder.rb`) in its encryption PR, red-first against a real encrypted `User`; this PR keeps `modelrails_ui:update` from reintroducing the bug.
