### PR TITLE
fix(select): floor the width at 44px, not just the height

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- `select`: floor the width at 44px (`min-w-[var(--form-input-height)]`, the same spelling as the existing height floor). `w-full` pins nothing, so a select sharing a flex row with a submit button takes only the leftover space — a host app's inline role editor measured 29px at phone width and 43px in CI, failing WCAG 2.5.5 (AAA) target size on the width axis while its height was never at risk.
+
 ## [0.15.0] - 2026-09-01
 
 ### Added

--- a/lib/generators/modelrails_ui/add/templates/select/select_component.rb.tt
+++ b/lib/generators/modelrails_ui/add/templates/select/select_component.rb.tt
@@ -32,7 +32,11 @@ module UI
   #
   # No fail-loud guard — there's no enum axis to validate.
   class SelectComponent < ApplicationComponent
-    BASE = "flex min-h-[var(--form-input-height)] w-full rounded-md border border-border-strong bg-transparent px-3 py-1 text-sm shadow-sm " \
+    # min-w alongside min-h, one spelling of the 2.5.5 floor: `w-full` pins
+    # nothing, so a select in a flex row with a sibling button takes only the
+    # leftover space. A host app's inline role editor measured 29px at phone
+    # width and 43px in CI, while its height was never at risk.
+    BASE = "flex min-h-[var(--form-input-height)] min-w-[var(--form-input-height)] w-full rounded-md border border-border-strong bg-transparent px-3 py-1 text-sm shadow-sm " \
            "outline-none focus-visible:border-border-focus focus-ring " \
            "aria-invalid:border-danger-border aria-invalid:ring-2 aria-invalid:ring-danger " \
            "disabled:cursor-not-allowed disabled:opacity-50"


### PR DESCRIPTION
## Problem

`UI::Select`'s `BASE` pinned `min-h-[var(--form-input-height)]` and `w-full`.
The height floor holds. `w-full` pins nothing — it makes the select fill its
container, and says nothing about how small that container may get.

So a select sharing a flex row with a submit button takes only the leftover
space, and in a constrained container it drops under the WCAG 2.5.5 (AAA)
target-size floor on the **width** axis while its height is never at risk.

Measured in a host app whose inline role editor puts a select in a `flex-1`
(basis zero) beside a submit button inside a table cell:

| viewport | rendered box | |
| --- | --- | --- |
| phone (375px) | **29×44** | well under |
| Linux CI, members table | **43×44** | under — caught by the AAA audit |
| desktop, locally | 47×44 | three pixels of margin |

The desktop number is the telling one: `frame 126 − submit 68 − gap 12 = 46`.
Those three pixels were arithmetic on the select's neighbours, not something the
component guaranteed. Any longer submit label — a translation, say — takes it
under on every viewport.

## Fix

`min-w-[var(--form-input-height)]` in `BASE`, beside the height floor.

Deliberately **not** `min-w-11`, though it resolves to the same 44px: the
consuming app's `application.css` states that the invariant has one spelling,
and the height floor sitting next to it is already written this way. Two
spellings of one rule is how the next person misses that they are the same rule.

## Verification

Gem suites green — 572, 1047 and 101 runs across the three lanes, 0 failures.

In the host app, a proving spec measures the **rendered box** at phone width
rather than asserting the class is present: red at 29×44 before, green after,
and confirmed in the compiled stylesheet
(`.min-w-\[var\(--form-input-height\)\]{min-width:var(--form-input-height)}`).

## Note for consumers

Components ship as generator templates, so an app that already generated
`UI::SelectComponent` has its own copy and this change will not reach it. The
host app fixed both.
